### PR TITLE
feat: row-streaming push_decoder for lossy VP8

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -3117,4 +3117,267 @@ mod tests {
             assert_eq!(total_rows, 32);
         }
     }
+
+    // ── push_decoder tests ─────────────────────────────────────────────
+
+    /// A minimal sink that collects every strip into a single flat buffer,
+    /// then lets tests compare it byte-for-byte against a reference.
+    struct CollectSink {
+        buf: alloc::vec::Vec<u8>,
+        width: u32,
+        height: u32,
+        descriptor: Option<PixelDescriptor>,
+        began: bool,
+        finished: bool,
+        strips_received: u32,
+    }
+
+    impl CollectSink {
+        fn new() -> Self {
+            Self {
+                buf: alloc::vec::Vec::new(),
+                width: 0,
+                height: 0,
+                descriptor: None,
+                began: false,
+                finished: false,
+                strips_received: 0,
+            }
+        }
+    }
+
+    impl zencodec::decode::DecodeRowSink for CollectSink {
+        fn begin(
+            &mut self,
+            width: u32,
+            height: u32,
+            descriptor: PixelDescriptor,
+        ) -> Result<(), SinkError> {
+            self.width = width;
+            self.height = height;
+            self.descriptor = Some(descriptor);
+            let bpp = descriptor.bytes_per_pixel();
+            let total = (width as usize) * (height as usize) * bpp;
+            self.buf.clear();
+            self.buf.resize(total, 0);
+            self.began = true;
+            Ok(())
+        }
+
+        fn provide_next_buffer(
+            &mut self,
+            y: u32,
+            height: u32,
+            width: u32,
+            descriptor: PixelDescriptor,
+        ) -> Result<zenpixels::PixelSliceMut<'_>, SinkError> {
+            assert!(self.began, "provide_next_buffer before begin");
+            assert!(!self.finished, "provide_next_buffer after finish");
+            assert_eq!(width, self.width);
+            assert_eq!(Some(descriptor), self.descriptor);
+            let bpp = descriptor.bytes_per_pixel();
+            let row_bytes = (width as usize) * bpp;
+            let start = (y as usize) * row_bytes;
+            let end = start + (height as usize) * row_bytes;
+            assert!(end <= self.buf.len(), "strip exceeds buffer");
+            self.strips_received += 1;
+            let slice = zenpixels::PixelSliceMut::new(
+                &mut self.buf[start..end],
+                width,
+                height,
+                row_bytes,
+                descriptor,
+            )
+            .expect("valid slice");
+            Ok(slice)
+        }
+
+        fn finish(&mut self) -> Result<(), SinkError> {
+            self.finished = true;
+            Ok(())
+        }
+    }
+
+    fn push_decode(
+        data: &[u8],
+        preferred: &[PixelDescriptor],
+    ) -> (CollectSink, OutputInfo) {
+        use zencodec::decode::DecodeJob;
+        let mut sink = CollectSink::new();
+        let dec = WebpDecoderConfig::new();
+        let info = dec
+            .job()
+            .push_decoder(Cow::Borrowed(data), &mut sink, preferred)
+            .expect("push_decoder");
+        (sink, info)
+    }
+
+    fn full_decode(data: &[u8], preferred: &[PixelDescriptor]) -> (alloc::vec::Vec<u8>, u32, u32, PixelDescriptor) {
+        use zencodec::decode::DecodeJob;
+        let dec = WebpDecoderConfig::new();
+        let out = dec
+            .job()
+            .decoder(Cow::Borrowed(data), preferred)
+            .unwrap()
+            .decode()
+            .unwrap();
+        let buf = out.into_buffer();
+        let width = buf.width();
+        let height = buf.height();
+        let desc = buf.descriptor();
+        (buf.into_vec(), width, height, desc)
+    }
+
+    /// Exact byte-for-byte parity between `push_decoder` and the full-decode
+    /// path on a lossy-no-alpha VP8 stream (hits the native streaming path).
+    #[test]
+    fn push_decoder_parity_lossy_rgb() {
+        let rgb = make_rgb8_pixels(128, 96);
+        let enc = WebpEncoderConfig::lossy().with_quality(85.0);
+        let output = enc.job().encoder().unwrap().encode(rgb.as_slice()).unwrap();
+        let data = output.data();
+
+        let (sink, info) = push_decode(data, &[]);
+        let (reference, rw, rh, rdesc) = full_decode(data, &[]);
+
+        assert_eq!(sink.width, rw);
+        assert_eq!(sink.height, rh);
+        assert_eq!(sink.descriptor, Some(rdesc));
+        assert_eq!(info.native_format, rdesc);
+        assert!(sink.began && sink.finished);
+        assert!(sink.strips_received >= 1);
+        assert_eq!(sink.buf, reference, "streaming bytes must match oneshot");
+    }
+
+    /// Parity on a lossy VP8 + VP8X container with ALPH chunk. This uses
+    /// the same streaming path but `alpha_plane` is applied per-strip.
+    #[test]
+    fn push_decoder_parity_lossy_with_alpha() {
+        let rgba = make_rgba8_pixels(48, 48);
+        let enc = WebpEncoderConfig::lossy().with_quality(90.0);
+        let output = enc.job().encoder().unwrap().encode(rgba.as_slice()).unwrap();
+        let data = output.data();
+
+        // Only run the parity assertion if the encoder actually produced alpha.
+        let native_info = crate::ImageInfo::from_webp(data).unwrap();
+        if !native_info.has_alpha {
+            return;
+        }
+
+        let (sink, _info) = push_decode(data, &[PixelDescriptor::RGBA8_SRGB]);
+        let (reference, _, _, rdesc) = full_decode(data, &[PixelDescriptor::RGBA8_SRGB]);
+        assert_eq!(rdesc, PixelDescriptor::RGBA8_SRGB);
+        assert_eq!(sink.descriptor, Some(PixelDescriptor::RGBA8_SRGB));
+        assert_eq!(sink.buf, reference, "alpha strip must match full decode");
+    }
+
+    /// Lossless VP8L is **not** eligible for the native streaming path —
+    /// push_decoder must fall back to the helper and still produce a
+    /// correct image that matches the full-decode output byte-for-byte.
+    #[test]
+    fn push_decoder_fallback_lossless() {
+        let rgba = make_rgba8_pixels(32, 32);
+        let enc = WebpEncoderConfig::lossless();
+        let output = enc.job().encoder().unwrap().encode(rgba.as_slice()).unwrap();
+        let data = output.data();
+
+        // Sanity: the container must actually be VP8L or VP8X+VP8L for the
+        // fallback path to be exercised. If the encoder produced plain VP8
+        // (unlikely for lossless), this test degenerates into a lossy parity
+        // check, which is still valid.
+        let (sink, _info) = push_decode(data, &[]);
+        let (reference, _, _, _) = full_decode(data, &[]);
+        assert_eq!(sink.buf, reference, "lossless fallback must be exact");
+    }
+
+    /// `Cow::Owned` must work as well as `Cow::Borrowed` (the function
+    /// body owns `data` throughout, so both lifetimes are equivalent).
+    #[test]
+    fn push_decoder_cow_owned_works() {
+        use zencodec::decode::DecodeJob;
+        let rgb = make_rgb8_pixels(32, 32);
+        let enc = WebpEncoderConfig::lossy().with_quality(80.0);
+        let output = enc.job().encoder().unwrap().encode(rgb.as_slice()).unwrap();
+
+        let borrowed = {
+            let mut sink = CollectSink::new();
+            WebpDecoderConfig::new()
+                .job()
+                .push_decoder(Cow::Borrowed(output.data()), &mut sink, &[])
+                .unwrap();
+            sink.buf
+        };
+        let owned_bytes = output.data().to_vec();
+        let owned = {
+            let mut sink = CollectSink::new();
+            WebpDecoderConfig::new()
+                .job()
+                .push_decoder(Cow::Owned(owned_bytes), &mut sink, &[])
+                .unwrap();
+            sink.buf
+        };
+
+        assert_eq!(owned, borrowed, "Cow::Owned must match Cow::Borrowed");
+    }
+
+    /// BGRA negotiation: when the sink asks for BGRA, the streaming path
+    /// must swizzle and deliver BGRA, and the result must still match the
+    /// full-decode BGRA output.
+    #[test]
+    fn push_decoder_bgra_negotiation() {
+        let rgba = make_rgba8_pixels(16, 16);
+        let enc = WebpEncoderConfig::lossy().with_quality(90.0);
+        let output = enc.job().encoder().unwrap().encode(rgba.as_slice()).unwrap();
+        let data = output.data();
+
+        let native_info = crate::ImageInfo::from_webp(data).unwrap();
+        if !native_info.has_alpha {
+            return;
+        }
+
+        let (sink, _info) = push_decode(data, &[PixelDescriptor::BGRA8_SRGB]);
+        assert_eq!(sink.descriptor, Some(PixelDescriptor::BGRA8_SRGB));
+        let (reference, _, _, rdesc) = full_decode(data, &[PixelDescriptor::BGRA8_SRGB]);
+        assert_eq!(rdesc, PixelDescriptor::BGRA8_SRGB);
+        assert_eq!(sink.buf, reference);
+    }
+
+    /// Real corpus image: gallery1/1.webp is a plain lossy VP8 at 550x368.
+    /// This exercises a larger input than the synthetic gradients and
+    /// verifies parity on a real-world encoder's output.
+    #[test]
+    fn push_decoder_parity_corpus_gallery1() {
+        let data = include_bytes!("../tests/images/gallery1/1.webp");
+        let (sink, info) = push_decode(data, &[]);
+        let (reference, rw, rh, _) = full_decode(data, &[]);
+        assert_eq!(sink.width, rw);
+        assert_eq!(sink.height, rh);
+        assert_eq!(info.native_format, sink.descriptor.unwrap());
+        assert_eq!(sink.buf, reference, "gallery1/1.webp parity");
+    }
+
+    /// Real corpus image with alpha (VP8X + VP8 + ALPH).
+    #[test]
+    fn push_decoder_parity_corpus_alpha() {
+        let data = include_bytes!("../tests/images/gallery2/1_webp_a.webp");
+        let native = crate::ImageInfo::from_webp(data).unwrap();
+        if !native.has_alpha {
+            // Corpus layout guarantees _a files have alpha; assert for safety.
+            panic!("expected 1_webp_a.webp to have alpha");
+        }
+        let (sink, _info) = push_decode(data, &[PixelDescriptor::RGBA8_SRGB]);
+        let (reference, _, _, rdesc) = full_decode(data, &[PixelDescriptor::RGBA8_SRGB]);
+        assert_eq!(rdesc, PixelDescriptor::RGBA8_SRGB);
+        assert_eq!(sink.descriptor, Some(PixelDescriptor::RGBA8_SRGB));
+        assert_eq!(sink.buf, reference, "gallery2/1_webp_a.webp parity");
+    }
+
+    /// Real corpus lossless image — must go through the fallback path.
+    #[test]
+    fn push_decoder_parity_corpus_lossless() {
+        let data = include_bytes!("../tests/images/gallery2/1_webp_ll.webp");
+        let (sink, _info) = push_decode(data, &[]);
+        let (reference, _, _, _) = full_decode(data, &[]);
+        assert_eq!(sink.buf, reference, "lossless fallback parity");
+    }
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1788,47 +1788,10 @@ impl zencodec::decode::Decode for WebpDecoder<'_> {
 /// * Anything else (VP8L as the first chunk, truncated, unknown) is not
 ///   eligible.
 fn is_lossy_streaming_candidate(data: &[u8]) -> bool {
-    if data.len() < 30 {
+    let Ok(info) = crate::detect::probe(data) else {
         return false;
-    }
-    if &data[..4] != b"RIFF" || &data[8..12] != b"WEBP" {
-        return false;
-    }
-    match &data[12..16] {
-        b"VP8 " => true,
-        b"VP8X" => {
-            // VP8X flags byte at offset 20 (after 4-byte chunk-size at 16..20).
-            // Bit 0x02 = animation, 0x20 = ICC, 0x10 = EXIF, etc.
-            let flags = data[20];
-            let is_animation = (flags & 0x02) != 0;
-            if is_animation {
-                return false;
-            }
-            // Walk chunks to find the image payload. Streaming is only
-            // eligible when the frame is a VP8 (lossy) chunk — not VP8L.
-            let mut off = 30usize; // VP8X chunk header (8) + VP8X payload (10) + RIFF header (12) = 30
-            while off + 8 <= data.len() {
-                let fourcc = &data[off..off + 4];
-                let size = u32::from_le_bytes([
-                    data[off + 4],
-                    data[off + 5],
-                    data[off + 6],
-                    data[off + 7],
-                ]) as usize;
-                match fourcc {
-                    b"VP8 " => return true,
-                    b"VP8L" => return false,
-                    _ => {
-                        // Advance past this chunk (size + pad to even).
-                        let advance = 8 + size + (size & 1);
-                        off = off.saturating_add(advance);
-                    }
-                }
-            }
-            false
-        }
-        _ => false,
-    }
+    };
+    !info.has_animation && matches!(info.bitstream, crate::detect::BitstreamType::Lossy { .. })
 }
 
 /// Native row-streaming `push_decoder` for lossy VP8.

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1179,6 +1179,7 @@ impl zencodec::decode::DecoderConfig for WebpDecoderConfig {
 // ── Decode Job ──────────────────────────────────────────────────────────────
 
 /// Per-operation WebP decode job.
+#[derive(Clone)]
 pub struct WebpDecodeJob {
     config: WebpDecoderConfig,
     stop: Option<zencodec::StopToken>,
@@ -1473,9 +1474,7 @@ impl<'a> zencodec::decode::DecodeJob<'a> for WebpDecodeJob {
         sink: &mut dyn zencodec::decode::DecodeRowSink,
         preferred: &[PixelDescriptor],
     ) -> Result<OutputInfo, Self::Error> {
-        zencodec::helpers::copy_decode_to_sink(self, data, sink, preferred, |e| {
-            at!(DecodeError::InvalidParameter(alloc::format!("{e}")))
-        })
+        push_decoder_impl(self, data, sink, preferred)
     }
 
     fn animation_frame_decoder(
@@ -1772,6 +1771,161 @@ impl zencodec::decode::Decode for WebpDecoder<'_> {
         let pixels = negotiate_format(output.into_buffer(), &self.preferred);
         Ok(DecodeOutput::new(pixels, info))
     }
+}
+
+// ── push_decoder dispatch ─────────────────────────────────────────────────
+
+/// Return `true` iff the input is a lossy VP8 single image eligible for
+/// zero-copy streaming decode.
+///
+/// The check is intentionally quick — just enough to decide between the
+/// native streaming path and the full-decode fallback:
+///
+/// * `VP8 ` chunk after the RIFF/WEBP magic → lossy bitstream, eligible.
+/// * `VP8X` chunk → inspect VP8X flags. Animations, VP8L bitstreams, and
+///   truly unknown encodings disqualify; plain lossy (optionally with ALPH)
+///   qualifies.
+/// * Anything else (VP8L as the first chunk, truncated, unknown) is not
+///   eligible.
+fn is_lossy_streaming_candidate(data: &[u8]) -> bool {
+    if data.len() < 30 {
+        return false;
+    }
+    if &data[..4] != b"RIFF" || &data[8..12] != b"WEBP" {
+        return false;
+    }
+    match &data[12..16] {
+        b"VP8 " => true,
+        b"VP8X" => {
+            // VP8X flags byte at offset 20 (after 4-byte chunk-size at 16..20).
+            // Bit 0x02 = animation, 0x20 = ICC, 0x10 = EXIF, etc.
+            let flags = data[20];
+            let is_animation = (flags & 0x02) != 0;
+            if is_animation {
+                return false;
+            }
+            // Walk chunks to find the image payload. Streaming is only
+            // eligible when the frame is a VP8 (lossy) chunk — not VP8L.
+            let mut off = 30usize; // VP8X chunk header (8) + VP8X payload (10) + RIFF header (12) = 30
+            while off + 8 <= data.len() {
+                let fourcc = &data[off..off + 4];
+                let size = u32::from_le_bytes([
+                    data[off + 4],
+                    data[off + 5],
+                    data[off + 6],
+                    data[off + 7],
+                ]) as usize;
+                match fourcc {
+                    b"VP8 " => return true,
+                    b"VP8L" => return false,
+                    _ => {
+                        // Advance past this chunk (size + pad to even).
+                        let advance = 8 + size + (size & 1);
+                        off = off.saturating_add(advance);
+                    }
+                }
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+/// Native row-streaming `push_decoder` for lossy VP8.
+///
+/// Feeds each macroblock-row strip directly to the sink, skipping the
+/// full-frame RGB/RGBA allocation that [`zencodec::helpers::copy_decode_to_sink`]
+/// requires. For lossless (VP8L), animations, or lossy streams where the
+/// internal streaming decoder cannot be constructed, transparently falls
+/// back to the full-decode helper so the caller still gets a correct image.
+fn push_decoder_impl<'a>(
+    job: WebpDecodeJob,
+    data: Cow<'a, [u8]>,
+    sink: &mut dyn zencodec::decode::DecodeRowSink,
+    preferred: &[PixelDescriptor],
+) -> Result<OutputInfo, At<DecodeError>> {
+    let wrap_sink = |e: SinkError| at!(DecodeError::InvalidParameter(alloc::format!("{e}")));
+
+    // Fast path only applies to lossy single-image VP8. For VP8L, animation,
+    // or anything the container scanner can't classify, fall back to the
+    // helper-driven full decode — it handles all the same cases `decode()` does.
+    if !is_lossy_streaming_candidate(&data) {
+        return zencodec::helpers::copy_decode_to_sink(job, data, sink, preferred, |e| {
+            at!(DecodeError::InvalidParameter(alloc::format!("{e}")))
+        });
+    }
+
+    // Dimension limit enforcement (matches `WebpDecoder::do_decode`).
+    if let Ok(info) = crate::ImageInfo::from_webp(&data) {
+        job.limits
+            .check_dimensions(info.width, info.height)
+            .map_err(|e| at!(DecodeError::InvalidParameter(alloc::format!("{e}"))))?;
+    }
+
+    use zencodec::decode::{DecodeJob, StreamingDecode};
+
+    // Clone stop out of the job so we can still check cancellation after
+    // `streaming_decoder` consumes `job` below.
+    let stop = job.stop.clone();
+    let fallback_job = job.clone();
+
+    // Build the streaming decoder. If this rejects the input (e.g.
+    // extra_y_rows < 2 — filter disabled — or any other edge case we
+    // haven't pre-filtered), retry with the full-decode helper using a
+    // cloned job so `self` is not consumed.
+    let mut stream = match job.streaming_decoder(Cow::Borrowed(&data), preferred) {
+        Ok(s) => s,
+        Err(_) => {
+            return zencodec::helpers::copy_decode_to_sink(
+                fallback_job,
+                data,
+                sink,
+                preferred,
+                |e| at!(DecodeError::InvalidParameter(alloc::format!("{e}"))),
+            );
+        }
+    };
+
+    let width = stream.width;
+    let height = stream.height;
+    let descriptor = stream.descriptor;
+    let bpp = stream.bpp;
+
+    // Tell the sink what's coming. After this, any error path must not
+    // call `sink.finish()`.
+    sink.begin(width, height, descriptor).map_err(wrap_sink)?;
+
+    let row_bytes = width as usize * bpp;
+
+    while let Some((y_start, pixel_slice)) = stream.next_batch()? {
+        // Cooperative cancellation between strips.
+        if let Some(ref s) = stop {
+            use enough::Stop;
+            s.check().map_err(|e| at!(DecodeError::from(e)))?;
+        }
+
+        let num_rows: u32 = pixel_slice.rows();
+        if num_rows == 0 {
+            continue;
+        }
+
+        let mut dst = sink
+            .provide_next_buffer(y_start, num_rows, width, descriptor)
+            .map_err(wrap_sink)?;
+
+        for row in 0..num_rows {
+            let src = pixel_slice.row(row);
+            let dst_row = dst.row_mut(row);
+            // PixelSlice rows are width*bpp; sink buffers may be wider
+            // (stride padding). Copy only the pixel bytes.
+            dst_row[..row_bytes].copy_from_slice(&src[..row_bytes]);
+        }
+        drop(dst);
+    }
+
+    sink.finish().map_err(wrap_sink)?;
+
+    Ok(OutputInfo::full_decode(width, height, descriptor))
 }
 
 // ── Streaming Decoder ─────────────────────────────────────────────────────

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -3198,10 +3198,7 @@ mod tests {
         }
     }
 
-    fn push_decode(
-        data: &[u8],
-        preferred: &[PixelDescriptor],
-    ) -> (CollectSink, OutputInfo) {
+    fn push_decode(data: &[u8], preferred: &[PixelDescriptor]) -> (CollectSink, OutputInfo) {
         use zencodec::decode::DecodeJob;
         let mut sink = CollectSink::new();
         let dec = WebpDecoderConfig::new();
@@ -3212,7 +3209,10 @@ mod tests {
         (sink, info)
     }
 
-    fn full_decode(data: &[u8], preferred: &[PixelDescriptor]) -> (alloc::vec::Vec<u8>, u32, u32, PixelDescriptor) {
+    fn full_decode(
+        data: &[u8],
+        preferred: &[PixelDescriptor],
+    ) -> (alloc::vec::Vec<u8>, u32, u32, PixelDescriptor) {
         use zencodec::decode::DecodeJob;
         let dec = WebpDecoderConfig::new();
         let out = dec
@@ -3255,7 +3255,12 @@ mod tests {
     fn push_decoder_parity_lossy_with_alpha() {
         let rgba = make_rgba8_pixels(48, 48);
         let enc = WebpEncoderConfig::lossy().with_quality(90.0);
-        let output = enc.job().encoder().unwrap().encode(rgba.as_slice()).unwrap();
+        let output = enc
+            .job()
+            .encoder()
+            .unwrap()
+            .encode(rgba.as_slice())
+            .unwrap();
         let data = output.data();
 
         // Only run the parity assertion if the encoder actually produced alpha.
@@ -3278,7 +3283,12 @@ mod tests {
     fn push_decoder_fallback_lossless() {
         let rgba = make_rgba8_pixels(32, 32);
         let enc = WebpEncoderConfig::lossless();
-        let output = enc.job().encoder().unwrap().encode(rgba.as_slice()).unwrap();
+        let output = enc
+            .job()
+            .encoder()
+            .unwrap()
+            .encode(rgba.as_slice())
+            .unwrap();
         let data = output.data();
 
         // Sanity: the container must actually be VP8L or VP8X+VP8L for the
@@ -3327,7 +3337,12 @@ mod tests {
     fn push_decoder_bgra_negotiation() {
         let rgba = make_rgba8_pixels(16, 16);
         let enc = WebpEncoderConfig::lossy().with_quality(90.0);
-        let output = enc.job().encoder().unwrap().encode(rgba.as_slice()).unwrap();
+        let output = enc
+            .job()
+            .encoder()
+            .unwrap()
+            .encode(rgba.as_slice())
+            .unwrap();
         let data = output.data();
 
         let native_info = crate::ImageInfo::from_webp(data).unwrap();


### PR DESCRIPTION
## Summary

- Adds a native row-streaming `push_decoder` path for lossy VP8 that feeds `DecodeRowSink` strips directly from the MB-row loop, avoiding full-frame RGB/RGBA materialization
- VP8L, animation, and streaming-ineligible inputs (no-filter VP8) fall back to `copy_decode_to_sink` automatically
- Detection via cheap RIFF walk (`is_lossy_streaming_candidate`) — never touches the bitstream before committing
- Cancellation via `StopToken` checked between strips

## Test plan

- [x] 8 parity tests (byte-exact match against full-decode reference path)
- [x] Lossy RGB, lossy+alpha RGBA, lossless fallback, Cow::Owned, BGRA negotiation
- [x] Real-world corpus images (gallery1, alpha, lossless)
- [ ] CI green on all platforms