### PR TITLE
fix: downgrade 1-frame animation to static WebP

### DIFF
--- a/src/mux/anim.rs
+++ b/src/mux/anim.rs
@@ -315,6 +315,12 @@ impl AnimationEncoder {
             self.mux.push_frame(frame)?;
         }
 
+        // If only one frame was pushed, downgrade to a static WebP.
+        // This avoids producing a 1-frame animated container (with ANIM/ANMF
+        // chunks) when the caller used the animation encoder optimistically
+        // without knowing the frame count in advance.
+        self.mux.downgrade_single_frame_to_static();
+
         self.mux.assemble()
     }
 

--- a/src/mux/assemble.rs
+++ b/src/mux/assemble.rs
@@ -258,6 +258,19 @@ impl WebPMux {
         self.frames.len() as u32
     }
 
+    /// Convert a 1-frame animation to a static image.
+    ///
+    /// Moves the single frame from the animation frames list to the
+    /// static `single_image` slot and clears the animation flag.
+    /// No-op if there isn't exactly 1 animation frame.
+    pub fn downgrade_single_frame_to_static(&mut self) {
+        if self.animation.is_some() && self.frames.len() == 1 {
+            let frame = self.frames.pop().unwrap();
+            self.animation = None;
+            self.single_image = Some(frame);
+        }
+    }
+
     /// Assemble the final WebP file.
     #[track_caller]
     pub fn assemble(&self) -> MuxResult<Vec<u8>> {

--- a/tests/mux_tests.rs
+++ b/tests/mux_tests.rs
@@ -1206,9 +1206,7 @@ fn single_frame_animation_produces_static_webp() {
 
     // Must not contain ANIM or ANMF chunks
     assert!(
-        !data
-            .windows(4)
-            .any(|w| w == b"ANIM" || w == b"ANMF"),
+        !data.windows(4).any(|w| w == b"ANIM" || w == b"ANMF"),
         "static WebP must not contain ANIM/ANMF chunks"
     );
 
@@ -1283,5 +1281,8 @@ fn single_frame_matches_static_encoder_output() {
     let (static_px, sw, sh) = zenwebp::oneshot::decode_rgba(&static_webp).unwrap();
     let (anim_px, aw, ah) = zenwebp::oneshot::decode_rgba(&anim_webp).unwrap();
     assert_eq!((sw, sh), (aw, ah));
-    assert_eq!(static_px, anim_px, "1-frame anim and static encode must decode identically");
+    assert_eq!(
+        static_px, anim_px,
+        "1-frame anim and static encode must decode identically"
+    );
 }

--- a/tests/mux_tests.rs
+++ b/tests/mux_tests.rs
@@ -1180,3 +1180,108 @@ fn metadata_embed_and_remove() {
     let decoder = WebPDecoder::new(&with_all).unwrap();
     assert_eq!(decoder.dimensions(), (8, 8));
 }
+
+// ============================================================================
+// Single-frame animation → static downgrade (issue #11)
+// ============================================================================
+
+#[test]
+fn single_frame_animation_produces_static_webp() {
+    let rgba = solid_rgba(16, 16, 200, 100, 50, 255);
+    let config = AnimationConfig::default();
+    let mut enc = AnimationEncoder::new(16, 16, config).unwrap();
+    let lossy_config = EncoderConfig::new_lossy().with_quality(75.0);
+    enc.add_frame(&rgba, PixelLayout::Rgba8, 0, &lossy_config)
+        .unwrap();
+    let data = enc.finalize(100).unwrap();
+
+    // Must decode as static (not animated)
+    let demuxer = WebPDemuxer::new(&data).unwrap();
+    assert!(
+        !demuxer.is_animated(),
+        "1-frame animation should produce a static WebP, not animated"
+    );
+    assert_eq!(demuxer.canvas_width(), 16);
+    assert_eq!(demuxer.canvas_height(), 16);
+
+    // Must not contain ANIM or ANMF chunks
+    assert!(
+        !data
+            .windows(4)
+            .any(|w| w == b"ANIM" || w == b"ANMF"),
+        "static WebP must not contain ANIM/ANMF chunks"
+    );
+
+    // Must decode correctly
+    let decoder = WebPDecoder::new(&data).unwrap();
+    assert_eq!(decoder.dimensions(), (16, 16));
+}
+
+#[test]
+fn single_frame_lossless_animation_produces_static_vp8l() {
+    let rgba = solid_rgba(8, 8, 50, 100, 200, 128);
+    let config = AnimationConfig::default();
+    let mut enc = AnimationEncoder::new(8, 8, config).unwrap();
+    let ll_config = EncoderConfig::new_lossless();
+    enc.add_frame(&rgba, PixelLayout::Rgba8, 0, &ll_config)
+        .unwrap();
+    let data = enc.finalize(100).unwrap();
+
+    let demuxer = WebPDemuxer::new(&data).unwrap();
+    assert!(!demuxer.is_animated());
+
+    // VP8L chunk should be present (lossless)
+    assert!(data.windows(4).any(|w| w == b"VP8L"));
+    assert!(!data.windows(4).any(|w| w == b"ANIM"));
+
+    // Lossless round-trip: pixels must match exactly
+    let (decoded, dw, dh) = zenwebp::oneshot::decode_rgba(&data).unwrap();
+    assert_eq!((dw, dh), (8, 8));
+    assert_eq!(decoded, rgba);
+}
+
+#[test]
+fn two_frame_animation_stays_animated() {
+    let red = solid_rgba(16, 16, 255, 0, 0, 255);
+    let blue = solid_rgba(16, 16, 0, 0, 255, 255);
+    let config = AnimationConfig::default();
+    let mut enc = AnimationEncoder::new(16, 16, config).unwrap();
+    let lossy_config = EncoderConfig::new_lossy().with_quality(75.0);
+    enc.add_frame(&red, PixelLayout::Rgba8, 0, &lossy_config)
+        .unwrap();
+    enc.add_frame(&blue, PixelLayout::Rgba8, 100, &lossy_config)
+        .unwrap();
+    let data = enc.finalize(100).unwrap();
+
+    let demuxer = WebPDemuxer::new(&data).unwrap();
+    assert!(
+        demuxer.is_animated(),
+        "2-frame animation must remain animated"
+    );
+    assert_eq!(demuxer.num_frames(), 2);
+    assert!(data.windows(4).any(|w| w == b"ANIM"));
+}
+
+#[test]
+fn single_frame_matches_static_encoder_output() {
+    let rgba = solid_rgba(8, 8, 100, 150, 200, 255);
+    let config_ll = EncoderConfig::new_lossless();
+
+    // Static encoder
+    let static_webp = EncodeRequest::new(&config_ll, &rgba, PixelLayout::Rgba8, 8, 8)
+        .encode()
+        .unwrap();
+
+    // Animation encoder with 1 frame
+    let anim_config = AnimationConfig::default();
+    let mut enc = AnimationEncoder::new(8, 8, anim_config).unwrap();
+    enc.add_frame(&rgba, PixelLayout::Rgba8, 0, &config_ll)
+        .unwrap();
+    let anim_webp = enc.finalize(100).unwrap();
+
+    // Both must decode to the same pixels
+    let (static_px, sw, sh) = zenwebp::oneshot::decode_rgba(&static_webp).unwrap();
+    let (anim_px, aw, ah) = zenwebp::oneshot::decode_rgba(&anim_webp).unwrap();
+    assert_eq!((sw, sh), (aw, ah));
+    assert_eq!(static_px, anim_px, "1-frame anim and static encode must decode identically");
+}


### PR DESCRIPTION
## Summary

- When `AnimationEncoder` receives only 1 frame, `finalize()` now emits a **static WebP** (no ANIM/ANMF chunks) instead of a 1-frame animated container
- 2+ frames still produce a normal animated WebP
- Adds `WebPMux::downgrade_single_frame_to_static()` which moves the single frame from the animation list to the static image slot and clears the animation flag

Closes #11

## Test plan

- [x] `single_frame_animation_produces_static_webp` — lossy 1-frame → no ANIM/ANMF, demuxer reports static
- [x] `single_frame_lossless_animation_produces_static_vp8l` — lossless 1-frame → VP8L, pixel-exact roundtrip
- [x] `two_frame_animation_stays_animated` — 2 frames → still has ANIM, demuxer reports animated
- [x] `single_frame_matches_static_encoder_output` — 1-frame anim decodes identically to direct static encode
- [x] Full test suite passes (all existing mux, decode, encode, lossless roundtrip tests)