### PR TITLE
feat(vp8): port FastMBAnalyze for m0/m1 (closes #32)

### DIFF
--- a/src/encoder/analysis/mod.rs
+++ b/src/encoder/analysis/mod.rs
@@ -246,6 +246,23 @@ pub fn analyze_macroblock(
     (final_alpha_value(alpha), best_uv_alpha)
 }
 
+/// Per-macroblock mode hint from the analysis pass.
+///
+/// Populated only when `method <= 1`, mirroring libwebp's `FastMBAnalyze`
+/// which writes per-MB intra16/intra4 decisions during analysis that the
+/// encode pass then consumes via `RefineUsingDistortion(refine_uv_mode=0)`.
+///
+/// At higher methods (m>=2) the encode pass re-evaluates everything and
+/// these hints are irrelevant.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MbModeHint {
+    /// Use Intra16 with DC prediction (libwebp `VP8SetIntra16Mode(it, 0)`).
+    I16Dc,
+    /// Use Intra4 with all sub-blocks DC-predicted
+    /// (libwebp `VP8SetIntra4Mode(it, all_zeros)`).
+    I4AllDc,
+}
+
 /// Analysis result containing per-MB alphas and global statistics.
 pub struct AnalysisResult {
     /// Per-macroblock alpha values (finalized, for segment assignment)
@@ -255,6 +272,59 @@ pub struct AnalysisResult {
     /// Average UV alpha across all macroblocks (raw, for UV quant delta)
     /// Range is typically ~30 (bad) to ~100 (ok to decimate UV more).
     pub uv_alpha_avg: i32,
+    /// Per-macroblock mode hints (only populated when `method <= 1`).
+    ///
+    /// `None` means the encoder should run its normal mode-selection path.
+    /// `Some(hints)` means the encoder should consume the hints directly,
+    /// matching libwebp's `RefineUsingDistortion(try_both_modes=0)` flow.
+    pub mb_mode_hints: Option<Vec<MbModeHint>>,
+}
+
+/// Compute the FastMBAnalyze decision for a single macroblock.
+///
+/// Ported from libwebp's `FastMBAnalyze` (analysis_enc.c:260). Splits the
+/// 16×16 luma block into 16 4×4 sub-blocks, computes per-sub-block DC mean,
+/// and uses the variance ratio to pick between Intra16-DC (low variance,
+/// flat block) and Intra4-all-DC (high variance, more sub-block detail).
+///
+/// `quality` is the user-facing 0-100 quality (libwebp `config->quality`).
+/// `y_in` is the 16×16 luma source plane in BPS-strided layout
+/// (`yuv_in + Y_OFF_ENC` in libwebp).
+fn fast_mb_analyze(y_in: &[u8], stride: usize, quality: i32) -> MbModeHint {
+    // libwebp threshold: 8 + (17-8)*q/100, ranging from 8 (lowest q) to 17 (highest q).
+    // Higher q => higher threshold => more likely to pick I4 (more local detail preserved).
+    let q = quality.clamp(0, 100);
+    let k_threshold: u64 = 8 + (17 - 8) * q as u64 / 100;
+
+    // Compute 16 per-4×4-block DC sums (each is the sum of all 16 pixels in the 4×4 block).
+    // libwebp's `VP8Mean16x4` writes 4 DC values per call (one per 4×4 column in a 4-row strip),
+    // and is called 4 times to fill all 16. We compute the same 16 sums directly.
+    let mut dc = [0u32; 16];
+    for row_blk in 0..4 {
+        for col_blk in 0..4 {
+            let mut sum: u32 = 0;
+            for r in 0..4 {
+                let row_base = (row_blk * 4 + r) * stride + col_blk * 4;
+                for c in 0..4 {
+                    sum += y_in[row_base + c] as u32;
+                }
+            }
+            dc[row_blk * 4 + col_blk] = sum;
+        }
+    }
+
+    let (mut m, mut m2): (u64, u64) = (0, 0);
+    for &d in &dc {
+        m += d as u64;
+        m2 += (d as u64) * (d as u64);
+    }
+
+    // libwebp: `if (kThreshold * m2 < m * m) -> I16-DC, else -> I4-all-DC`
+    if k_threshold.saturating_mul(m2) < m.saturating_mul(m) {
+        MbModeHint::I16Dc
+    } else {
+        MbModeHint::I4AllDc
+    }
 }
 
 /// Run full analysis pass on image and return alpha histogram + per-MB alphas
@@ -264,6 +334,9 @@ pub struct AnalysisResult {
 /// `cost_model` selects between zenwebp's perceptual extensions
 /// (`ZenwebpDefault`) and strict libwebp parity (`StrictLibwebpParity`,
 /// which disables the SATD masking-alpha blend).
+///
+/// `quality` is the user-facing 0-100 quality, used by `FastMBAnalyze`
+/// when `method <= 1` to populate per-MB mode hints.
 #[allow(clippy::too_many_arguments)]
 pub fn analyze_image(
     y_src: &[u8],
@@ -276,6 +349,7 @@ pub fn analyze_image(
     method: u8,
     sns_strength: u8,
     cost_model: crate::encoder::api::CostModel,
+    quality: i32,
 ) -> AnalysisResult {
     let mut it = AnalysisIterator::new(width, height);
     it.reset();
@@ -285,8 +359,21 @@ pub fn analyze_image(
     let mut alpha_histogram = [0u32; 256];
     let mut uv_alpha_sum: i64 = 0;
 
+    // FastMBAnalyze is only used at method <= 1 in libwebp (analysis_enc.c:326-330).
+    let collect_mode_hints = method <= 1;
+    let mut mb_mode_hints: Vec<MbModeHint> = if collect_mode_hints {
+        Vec::with_capacity(total_mbs)
+    } else {
+        Vec::new()
+    };
+
     loop {
         it.import(y_src, u_src, v_src, y_stride, uv_stride);
+
+        if collect_mode_hints {
+            let hint = fast_mb_analyze(&it.yuv_in[Y_OFF_ENC..], BPS, quality);
+            mb_mode_hints.push(hint);
+        }
 
         let (alpha, uv_alpha) = analyze_macroblock(&mut it, method, sns_strength, cost_model);
         mb_alphas.push(alpha);
@@ -309,5 +396,10 @@ pub fn analyze_image(
         mb_alphas,
         alpha_histogram,
         uv_alpha_avg,
+        mb_mode_hints: if collect_mode_hints {
+            Some(mb_mode_hints)
+        } else {
+            None
+        },
     }
 }

--- a/src/encoder/vp8/mod.rs
+++ b/src/encoder/vp8/mod.rs
@@ -462,6 +462,11 @@ struct Vp8Encoder<'a> {
     segment_tree_probs: [Prob; 3],
     /// Segment ID for each macroblock (mb_width * mb_height)
     segment_map: Vec<u8>,
+    /// Per-MB FastMBAnalyze hints (only populated when `method <= 1`).
+    /// When `Some`, `choose_macroblock_info` consumes hints directly to skip
+    /// full RD mode evaluation, mirroring libwebp's `RefineUsingDistortion`
+    /// flow at m0/m1. Empty for higher methods.
+    fast_mb_hints: Vec<crate::encoder::analysis::MbModeHint>,
 
     loop_filter_adjustments: bool,
     macroblock_no_skip_coeff: Option<u8>,
@@ -562,6 +567,7 @@ impl<'a> Vp8Encoder<'a> {
             segments_update_map: false,
             segment_tree_probs: [255, 255, 255], // Default probs
             segment_map: Vec::new(),
+            fast_mb_hints: Vec::new(),
 
             loop_filter_adjustments: false,
             macroblock_no_skip_coeff: None,
@@ -1483,6 +1489,7 @@ impl<'a> Vp8Encoder<'a> {
             self.method,
             self.sns_strength,
             self.cost_model,
+            i32::from(quality),
         );
 
         // Auto-detect content type when Preset::Auto is selected.
@@ -1531,6 +1538,11 @@ impl<'a> Vp8Encoder<'a> {
             .iter()
             .map(|&alpha| alpha_to_segment[alpha as usize])
             .collect();
+
+        // Store FastMBAnalyze mode hints from the analysis pass. These are only
+        // populated at method <= 1 — the encode pass uses them to skip RD mode
+        // selection (mirroring libwebp's `RefineUsingDistortion(try_both_modes=0)`).
+        self.fast_mb_hints = analysis.mb_mode_hints.unwrap_or_default();
 
         // Smooth segment map (3x3 majority filter) only when the preprocessing
         // flag explicitly opts in. libwebp gates this on `config->preprocessing & 1`
@@ -1813,7 +1825,9 @@ impl<'a> Vp8Encoder<'a> {
                 self.frame.sharpness_level = self.filter_sharpness;
             }
         } else {
-            // Disable segments for small images (overhead not worth it)
+            // Disable segments for small images (overhead not worth it).
+            // Note: keep `fast_mb_hints` populated — they're independent of
+            // segmentation and still drive m0/m1 mode selection.
             self.segments_enabled = false;
             self.segments_update_map = false;
             self.segment_map = Vec::new();

--- a/src/encoder/vp8/mode_selection.rs
+++ b/src/encoder/vp8/mode_selection.rs
@@ -1822,10 +1822,7 @@ impl<'a> super::Vp8Encoder<'a> {
         // Chroma still goes through `pick_best_uv` here (zenwebp's path
         // matches libwebp m1's `refine_uv_mode=1`; m0 differs but UV mode
         // experiments showed zero size change on the worst offender).
-        if self.method <= 1
-            && self.partition_limit < 100
-            && !self.fast_mb_hints.is_empty()
-        {
+        if self.method <= 1 && self.partition_limit < 100 && !self.fast_mb_hints.is_empty() {
             let mb_idx = mby * usize::from(self.macroblock_width) + mbx;
             if let Some(&hint) = self.fast_mb_hints.get(mb_idx) {
                 use crate::encoder::analysis::MbModeHint;

--- a/src/encoder/vp8/mode_selection.rs
+++ b/src/encoder/vp8/mode_selection.rs
@@ -1808,6 +1808,59 @@ impl<'a> super::Vp8Encoder<'a> {
     }
 
     pub(super) fn choose_macroblock_info(&self, mbx: usize, mby: usize) -> MacroblockInfo {
+        // FastMBAnalyze fast path (libwebp `RefineUsingDistortion(try_both_modes=0,
+        // refine_uv_mode=method>=1)` at m0/m1, quant_enc.c:1447). The analysis
+        // pass already chose I16 vs I4 via the DC-variance test in
+        // `FastMBAnalyze`. Consume that hint directly:
+        //   - I16Dc  => LumaMode::DC (matches `pick_intra16_fast_dc`)
+        //   - I4AllDc => run `pick_best_intra4` to refine the per-sub-block
+        //     modes. libwebp uses an SSE-only loop here; we reuse our
+        //     existing RD path which is more accurate but slower. This
+        //     resolves #32 (4× size blowup on tiny low-color images at m0):
+        //     the previous code unconditionally picked I16-DC at m0/m1
+        //     regardless of source variance, missing the I4 case entirely.
+        // Chroma still goes through `pick_best_uv` here (zenwebp's path
+        // matches libwebp m1's `refine_uv_mode=1`; m0 differs but UV mode
+        // experiments showed zero size change on the worst offender).
+        if self.method <= 1
+            && self.partition_limit < 100
+            && !self.fast_mb_hints.is_empty()
+        {
+            let mb_idx = mby * usize::from(self.macroblock_width) + mbx;
+            if let Some(&hint) = self.fast_mb_hints.get(mb_idx) {
+                use crate::encoder::analysis::MbModeHint;
+                // For the I16 hint, use the fast DC scorer (current behavior);
+                // for I4, run `pick_best_intra4` so each sub-block's mode is
+                // chosen rather than left at all-DC (libwebp does the same,
+                // just via SSE rather than RD).
+                let (luma_mode, luma_bpred) = match hint {
+                    MbModeHint::I16Dc => (LumaMode::DC, None),
+                    MbModeHint::I4AllDc => {
+                        // Need a baseline I16 score to compare against I4. Use
+                        // the fast DC scorer (matches what we'd report for
+                        // an I16-DC mode at m0/m1).
+                        let (_, i16_score) = self.pick_intra16_fast_dc(mbx, mby);
+                        match self.pick_best_intra4(mbx, mby, i16_score) {
+                            Some((modes, _)) => (LumaMode::B, Some(modes)),
+                            // I4 didn't beat I16 — fall back to I16-DC (the
+                            // hint was advisory, libwebp's I4 path can also
+                            // bail out via `score_i4 >= best_score`).
+                            None => (LumaMode::DC, None),
+                        }
+                    }
+                };
+                let chroma_mode = self.pick_best_uv(mbx, mby);
+                let segment_id = self.get_segment_id_for_mb(mbx, mby);
+                return MacroblockInfo {
+                    luma_mode,
+                    luma_bpred,
+                    chroma_mode,
+                    segment_id,
+                    coeffs_skipped: false,
+                };
+            }
+        }
+
         // Pick the best 16x16 luma mode using RD cost selection
         let (luma_mode, i16_score) = self.pick_best_intra16(mbx, mby);
 

--- a/tests/auto_detection_tuning.rs
+++ b/tests/auto_detection_tuning.rs
@@ -147,7 +147,17 @@ fn classify_rgb(rgb: &[u8], w: u32, h: u32) -> zenwebp::encoder::ClassifierDiag 
     let v_buf = vec![128u8; uv_stride * mb_h * 8];
 
     let analysis = analyze_image(
-        &y_buf, &u_buf, &v_buf, width, height, y_stride, uv_stride, 4, 50,
+        &y_buf,
+        &u_buf,
+        &v_buf,
+        width,
+        height,
+        y_stride,
+        uv_stride,
+        4,
+        50,
+        zenwebp::encoder::api::CostModel::ZenwebpDefault,
+        75,
     );
 
     classify_image_type_diag(&y_buf, width, height, y_stride, &analysis.alpha_histogram)


### PR DESCRIPTION
**Stack base — targets `fixall/libwebp-parity` (PR #37).**

Closes #32 (the m0 4× outliers on tiny low-color images).

## What

Ports libwebp's `FastMBAnalyze` (`src/enc/analysis_enc.c:260`) — the DC-variance-based intra16/intra4 decision used at m0/m1 — to zenwebp. The pre-audit investigation (`differences/06-issue-32-fast-mb-analyze.md`) confirmed this requires wiring per-MB mode persistence through the analysis pass; this PR does that.

## Result

**Worst-offender** (`d88de4b9e6efe211.png` 128×128 grayscale, Photo Q95 m0):
- Before: zen 1882 B / lib 424 B = **4.44×**
- After: zen 346 B / lib 424 B = **0.82×** (now smaller than libwebp)

Photo Q90 m0 also fixed: 4.08× → 0.74×.

**CID22 25-image sweep at m0** (3 presets × 6 q = 18 cells):
- Mean **0.9510× → 0.9144×** (zenwebp now ~9% smaller than libwebp on average; was ~5%)
- All 18 cells < 1.0×, no regressions on photo content where zenwebp already won
- m4 unchanged (gated on `method <= 1`)

## Implementation

- New `MbModeHint` enum + `fast_mb_analyze` ported byte-for-byte from libwebp's threshold formula
- Encoder stores hints in `fast_mb_hints: Vec<MbModeHint>`
- `choose_macroblock_info` consumes hints at m0/m1: `I16Dc` → existing fast-DC path; `I4AllDc` → existing `pick_best_intra4`
- 4 files touched: `analysis/mod.rs`, `vp8/mod.rs`, `vp8/mode_selection.rs`, `tests/auto_detection_tuning.rs`

## Deferred (noted in commit message)

- `IsFlatSource16` border override
- m0 `refine_uv_mode=0` UV-skip — measured as zero-impact on the worst offender previously

## Test plan

- [x] `cargo test --release` — 238 passed, 0 failed
- [x] Worst-offender ratio drops 4.44× → 0.82×
- [x] m0 CID22 sweep mean improves
- [ ] Wait for CI on stacked PR

## Stack

This PR is the **base of a 3-PR stack** targeting `fixall/libwebp-parity`. Next: stack/35-cleanup, stack/25-full.