### PR TITLE
cleanup(vp8): #35 bundle — trellis dedup + dead code + docs

### DIFF
--- a/src/encoder/quantize.rs
+++ b/src/encoder/quantize.rs
@@ -841,8 +841,13 @@ pub(crate) fn quantize_dequantize_block_sse2(
     _mm_movemask_epi8(_mm_cmpeq_epi8(packed, zero)) != 0xffff
 }
 
-/// Fused quantize+dequantize for AC-only (preserves DC at position 0).
-/// Used for Y1 blocks in I16 mode where DC goes to Y2 block.
+/// Fused quantize+dequantize for AC-only (zeroes DC at position 0).
+///
+/// Used for Y1 blocks in I16 mode where DC goes to the Y2 block. The DC slot
+/// is zeroed (matching libwebp's `QuantizeBlock_SSE2` behavior at `enc_sse2.c`)
+/// rather than left holding the original input value. Both produce identical
+/// final pixels because the WHT path overwrites slot 0 later — zeroing is just
+/// the clearer expression of intent. (#35-#11)
 #[cfg(target_arch = "x86_64")]
 pub fn quantize_dequantize_ac_only_simd(
     coeffs: &[i32; 16],
@@ -853,13 +858,13 @@ pub fn quantize_dequantize_ac_only_simd(
 ) -> bool {
     let has_nz =
         quantize_dequantize_block_simd(coeffs, matrix, use_sharpen, quantized, dequantized);
-    // Restore DC from input
-    quantized[0] = coeffs[0];
-    dequantized[0] = coeffs[0]; // DC will be handled by Y2 path
+    // Zero DC; Y2 path will overwrite slot 0 with the WHT result later.
+    quantized[0] = 0;
+    dequantized[0] = 0;
     has_nz || quantized[1..].iter().any(|&c| c != 0)
 }
 
-/// NEON fused quantize+dequantize for AC-only
+/// NEON fused quantize+dequantize for AC-only. See x86_64 variant for semantics.
 #[cfg(target_arch = "aarch64")]
 pub fn quantize_dequantize_ac_only_simd(
     coeffs: &[i32; 16],
@@ -870,12 +875,12 @@ pub fn quantize_dequantize_ac_only_simd(
 ) -> bool {
     let has_nz =
         quantize_dequantize_block_simd(coeffs, matrix, use_sharpen, quantized, dequantized);
-    quantized[0] = coeffs[0];
-    dequantized[0] = coeffs[0];
+    quantized[0] = 0;
+    dequantized[0] = 0;
     has_nz || quantized[1..].iter().any(|&c| c != 0)
 }
 
-/// WASM SIMD128 fused quantize+dequantize for AC-only
+/// WASM SIMD128 fused quantize+dequantize for AC-only. See x86_64 variant for semantics.
 #[cfg(target_arch = "wasm32")]
 pub fn quantize_dequantize_ac_only_simd(
     coeffs: &[i32; 16],
@@ -886,8 +891,8 @@ pub fn quantize_dequantize_ac_only_simd(
 ) -> bool {
     let has_nz =
         quantize_dequantize_block_simd(coeffs, matrix, use_sharpen, quantized, dequantized);
-    quantized[0] = coeffs[0];
-    dequantized[0] = coeffs[0];
+    quantized[0] = 0;
+    dequantized[0] = 0;
     has_nz || quantized[1..].iter().any(|&c| c != 0)
 }
 
@@ -907,8 +912,8 @@ pub fn quantize_dequantize_ac_only_simd(
     dequantized: &mut [i32; 16],
 ) -> bool {
     let has_nz = quantize_dequantize_block_scalar(coeffs, matrix, quantized, dequantized);
-    quantized[0] = coeffs[0];
-    dequantized[0] = coeffs[0];
+    quantized[0] = 0;
+    dequantized[0] = 0;
     has_nz || quantized[1..].iter().any(|&c| c != 0)
 }
 

--- a/src/encoder/trellis.rs
+++ b/src/encoder/trellis.rs
@@ -296,7 +296,13 @@ pub fn trellis_quantize_block(
             // Check if this is the best terminal node
             if level != 0 && best_cur_score < best_score {
                 // Add end-of-block cost: signaling "no more coefficients"
-                // Uses the context resulting from this level
+                // Uses the context resulting from this level.
+                //
+                // libwebp computes the EOB cost via a band-indexed lookup
+                // (`VP8EncBands[n + 1]` then `costs[band][ctx][0]`) inside
+                // TrellisQuantizeBlock; zenwebp factors the band lookup into
+                // `LevelCosts::get_eob_cost`. Different surface, same value
+                // for every (ctype, n, ctx) triple. (#35-#10)
                 let eob_cost = if n < 15 {
                     level_costs.get_eob_cost(ctype, n, ctx) as i64
                 } else {

--- a/src/encoder/trellis.rs
+++ b/src/encoder/trellis.rs
@@ -20,8 +20,13 @@ use super::tables::{
     MAX_LEVEL, MAX_VARIABLE_LEVEL, VP8_LEVEL_FIXED_COSTS, VP8_WEIGHT_TRELLIS, VP8_ZIGZAG,
 };
 
-/// Maximum cost value for RD optimization
-const MAX_COST: i64 = i64::MAX / 2;
+/// Maximum cost value for RD optimization.
+///
+/// Matches libwebp's `MAX_COST` (`cost_enc.h:32`): `0x7fffffffffffff` ≈ 3.6e16.
+/// Either value is fine in practice — the sentinel is never reached during
+/// trellis traversal — but harmonizing makes byte-comparison sweeps trivial
+/// and matches the reference implementation. (#35-#9)
+const MAX_COST: i64 = 0x7fffffffffffff;
 
 /// Trellis node for dynamic programming
 #[derive(Clone, Copy, Default)]

--- a/src/encoder/vp8/header.rs
+++ b/src/encoder/vp8/header.rs
@@ -44,10 +44,12 @@ impl<'a> super::Vp8Encoder<'a> {
         self.encoder.write_literal(6, self.frame.filter_level);
         self.encoder.write_literal(3, self.frame.sharpness_level);
 
-        self.encoder.write_flag(self.loop_filter_adjustments);
-        if self.loop_filter_adjustments {
-            self.encode_loop_filter_adjustments();
-        }
+        // loop_filter_adjustments_flag — always disabled (#35-#5).
+        // libwebp emits per-segment loop-filter level deltas via
+        // `update_segment_feature_data` (see encode_segment_updates above);
+        // it does not use this older `mb_lf_delta` mechanism. Hard-code to
+        // false to avoid carrying half-ported scaffolding.
+        self.encoder.write_flag(false);
 
         // partitions length must be 1, 2, 4 or 8, so value will be 0, 1, 2 or 3
         let partitions_value: u8 = self.partitions.len().ilog2().try_into().unwrap();
@@ -141,12 +143,6 @@ impl<'a> super::Vp8Encoder<'a> {
                 }
             }
         }
-    }
-
-    fn encode_loop_filter_adjustments(&mut self) {
-        // Whether the deltas are being updated this frame
-        self.encoder.write_flag(false);
-        // If false, no more data needed - use defaults or previous values
     }
 
     fn encode_quantization_indices(&mut self) {

--- a/src/encoder/vp8/mod.rs
+++ b/src/encoder/vp8/mod.rs
@@ -468,7 +468,6 @@ struct Vp8Encoder<'a> {
     /// flow at m0/m1. Empty for higher methods.
     fast_mb_hints: Vec<crate::encoder::analysis::MbModeHint>,
 
-    loop_filter_adjustments: bool,
     macroblock_no_skip_coeff: Option<u8>,
     quantization_indices: QuantizationIndices,
 
@@ -569,7 +568,6 @@ impl<'a> Vp8Encoder<'a> {
             segment_map: Vec::new(),
             fast_mb_hints: Vec::new(),
 
-            loop_filter_adjustments: false,
             macroblock_no_skip_coeff: None,
             quantization_indices: QuantizationIndices::default(),
 

--- a/src/encoder/vp8/mod.rs
+++ b/src/encoder/vp8/mod.rs
@@ -515,7 +515,13 @@ struct Vp8Encoder<'a> {
     macroblock_width: u16,
     macroblock_height: u16,
 
-    /// Partitions of encoders for the macroblock coefficient data
+    /// Coefficient-data partitions. The VP8 bitstream supports 1, 2, 4, or 8
+    /// partitions (interleaved by MB row mod num_parts), but zenwebp currently
+    /// always emits exactly one. Implementing multi-partition output would
+    /// require routing token emission through `partitions[r % num_parts]` and
+    /// growing this Vec — there is no public knob to request that today.
+    /// Kept as a Vec to avoid churning the header-emission code (which already
+    /// computes `partitions.len().ilog2()`) when multi-partition is added. (#35-#3)
     partitions: Vec<ArithmeticEncoder>,
 
     // the left borders used in prediction

--- a/src/encoder/vp8/mod.rs
+++ b/src/encoder/vp8/mod.rs
@@ -1096,9 +1096,20 @@ impl<'a> Vp8Encoder<'a> {
                         stop.check()?;
                     }
 
-                    // Mid-stream probability refresh (like libwebp's VP8EncTokenLoop)
-                    // We update probabilities mid-stream (helps compression: 1.0111x → 1.0101x)
-                    // but don't recalculate level_costs (hurts compression: 1.0101x → 1.0114x)
+                    // Mid-stream probability refresh (like libwebp's VP8EncTokenLoop).
+                    //
+                    // We refresh `updated_probs` periodically so the eventual emission
+                    // pass picks up evolving statistics, but we deliberately do NOT
+                    // rebuild `self.level_costs` at the same time. Empirically:
+                    // refreshing probs alone helps slightly (1.0111x → 1.0101x);
+                    // also rebuilding level_costs mid-row hurts (1.0101x → 1.0114x).
+                    //
+                    // Effect on this pass is therefore weak: cost-driven mode
+                    // selection inside the row continues to use the level_costs
+                    // computed at pass start. The real per-pass cost refresh happens
+                    // through the multi-pass loop (see #27 / two-pass at m4 path).
+                    // This call is mostly bookkeeping so the final probability
+                    // emission reflects accumulated stats. (#35-#6)
                     refresh_countdown -= 1;
                     if refresh_countdown < 0 {
                         self.compute_updated_probabilities();

--- a/src/encoder/vp8/mod.rs
+++ b/src/encoder/vp8/mod.rs
@@ -1221,12 +1221,17 @@ impl<'a> Vp8Encoder<'a> {
                                 self.stored_mb_coeffs.push(QuantizedMbCoeffs::ZERO);
                             }
                         } else {
+                            // Reuse trellis output from transform_luma_block to
+                            // skip the second trellis pass inside the recorder
+                            // (#35-#8). Always Some() on this branch because
+                            // do_trellis is true.
                             let stored_coeffs = self.record_residual_tokens_storing(
                                 &macroblock_info,
                                 mbx as usize,
                                 &y_block_data.coeffs,
                                 &u_block_data.coeffs,
                                 &v_block_data.coeffs,
+                                y_block_data.trellis_y1_zigzag.as_ref(),
                             );
                             // Track edge magnitude for I16 "blocky" MBs (#34).
                             if !is_i4 && stored_coeffs.is_blocky_i16() {

--- a/src/encoder/vp8/prediction.rs
+++ b/src/encoder/vp8/prediction.rs
@@ -21,6 +21,13 @@ pub(super) struct LumaBlockResult {
     /// The bordered prediction/reconstruction buffer.
     /// After transform, contains reconstructed pixels (prediction + IDCT).
     pub pred_block: [u8; LUMA_BLOCK_SIZE],
+    /// Trellis-quantized zigzag levels for each of the 16 Y1 sub-blocks,
+    /// produced during reconstruction when trellis is enabled. Used by
+    /// `record_residual_tokens_storing` to avoid running trellis twice on
+    /// the same data — once here for reconstruction, once again for token
+    /// emission. `None` when trellis is disabled (non-trellis methods 0-4
+    /// take a different code path entirely). (#35-#8)
+    pub trellis_y1_zigzag: Option<[[i32; 16]; 16]>,
 }
 
 /// Result from chroma block transform, containing quantized coefficients
@@ -228,8 +235,16 @@ impl<'a> super::Vp8Encoder<'a> {
         }
         transform::iwht4x4(&mut y2_dequant);
 
-        // Process each Y1 block
+        // Process each Y1 block.
+        // When trellis is enabled, capture the zigzag levels per sub-block so
+        // record_residual_tokens_storing can reuse them instead of re-running
+        // trellis on the exact same DCT input. (#35-#8)
         let mut dequantized_blocks = [0i32; 16 * 16];
+        let mut trellis_y1_zigzag: Option<[[i32; 16]; 16]> = if trellis_lambda.is_some() {
+            Some([[0i32; 16]; 16])
+        } else {
+            None
+        };
         for y in 0usize..4 {
             for x in 0usize..4 {
                 let i = y * 4 + x;
@@ -239,10 +254,10 @@ impl<'a> super::Vp8Encoder<'a> {
                 let dequant_block = if let Some(lambda) = trellis_lambda {
                     // Trellis quantization for better RD trade-off
                     let ctx0 = (u8::from(left_nz[y]) + u8::from(top_nz[x])).min(2) as usize;
-                    let mut zigzag_out = [0i32; 16];
+                    let zigzag_slot = &mut trellis_y1_zigzag.as_mut().unwrap()[i];
                     let has_nz = trellis_quantize_block(
                         &mut block,
-                        &mut zigzag_out,
+                        zigzag_slot,
                         y1_matrix,
                         lambda,
                         1, // first=1 for I16_AC (AC only)
@@ -306,6 +321,7 @@ impl<'a> super::Vp8Encoder<'a> {
         LumaBlockResult {
             coeffs: luma_blocks,
             pred_block: y_with_border,
+            trellis_y1_zigzag,
         }
     }
 
@@ -334,6 +350,14 @@ impl<'a> super::Vp8Encoder<'a> {
         let segment = self.get_segment_for_mb(mbx, mby);
         let trellis_lambda = if self.do_trellis {
             Some(segment.lambda_trellis_i4)
+        } else {
+            None
+        };
+
+        // Capture per-sub-block trellis zigzag levels so the recorder can skip
+        // re-trellising the same DCT input. (#35-#8)
+        let mut trellis_y1_zigzag: Option<[[i32; 16]; 16]> = if trellis_lambda.is_some() {
+            Some([[0i32; 16]; 16])
         } else {
             None
         };
@@ -402,10 +426,12 @@ impl<'a> super::Vp8Encoder<'a> {
                     // trellis_quantize_block modifies current_subblock to contain
                     // the dequantized values (level * q)
                     let ctx0 = (u8::from(left_nz[sby]) + u8::from(top_nz[sbx])).min(2) as usize;
-                    let mut zigzag_out = [0i32; 16];
+                    // Capture zigzag levels into the LumaBlockResult slot so the
+                    // recorder doesn't re-run trellis on the same input. (#35-#8)
+                    let zigzag_slot = &mut trellis_y1_zigzag.as_mut().unwrap()[i];
                     trellis_quantize_block(
                         &mut current_subblock,
-                        &mut zigzag_out,
+                        zigzag_slot,
                         y1_matrix,
                         lambda,
                         0, // first=0 for I4 (DC+AC)
@@ -446,6 +472,7 @@ impl<'a> super::Vp8Encoder<'a> {
         LumaBlockResult {
             coeffs: luma_blocks,
             pred_block: y_with_border,
+            trellis_y1_zigzag,
         }
     }
 

--- a/src/encoder/vp8/residuals.rs
+++ b/src/encoder/vp8/residuals.rs
@@ -1254,6 +1254,14 @@ impl<'a> super::Vp8Encoder<'a> {
 
     /// Record tokens for a macroblock's residual data and return the quantized coefficients.
     /// Used in multi-pass encoding: pass 1 calls this to get coefficients for storage.
+    ///
+    /// `pre_trellised_y1` is an optional set of trellis-quantized zigzag levels
+    /// for the 16 Y1 sub-blocks. When provided, the recorder reuses them
+    /// instead of running trellis a second time on the same DCT input — this
+    /// is what `transform_luma_block` already produced for reconstruction.
+    /// Pass `None` from contexts that did not run trellis (e.g. older code
+    /// paths or calls where the caller didn't capture trellis output).
+    /// (#35-#8)
     #[allow(clippy::needless_range_loop)] // i is used to index both ZIGZAG and output arrays
     pub(super) fn record_residual_tokens_storing(
         &mut self,
@@ -1262,6 +1270,7 @@ impl<'a> super::Vp8Encoder<'a> {
         y_block_data: &[i32; 16 * 16],
         u_block_data: &[i32; 16 * 4],
         v_block_data: &[i32; 16 * 4],
+        pre_trellised_y1: Option<&[[i32; 16]; 16]>,
     ) -> QuantizedMbCoeffs {
         // Extract segment data by value/copy to avoid borrow conflicts with proba_stats.
         // Only copies small scalar values (lambdas, flags), not the large matrices.
@@ -1332,21 +1341,30 @@ impl<'a> super::Vp8Encoder<'a> {
                 let ctx0 = (left + top).min(2) as usize;
 
                 if let Some(lambda) = y1_trellis_lambda {
-                    let mut coeffs = *block;
-                    // Borrow segment fields individually to avoid conflict with proba_stats
-                    let y1_matrix = self.segments[segment_id].y1_matrix.as_ref().unwrap();
-                    let psy_config = &self.segments[segment_id].psy_config;
-                    trellis_quantize_block(
-                        &mut coeffs,
-                        &mut stored.y1_zigzag[block_idx],
-                        y1_matrix,
-                        lambda,
-                        first_coeff_y1,
-                        &self.level_costs,
-                        token_type_y1 as usize,
-                        ctx0,
-                        psy_config,
-                    );
+                    if let Some(pre) = pre_trellised_y1 {
+                        // Reuse the trellis output captured during reconstruction
+                        // in transform_luma_block / transform_luma_blocks_4x4.
+                        // Saves running trellis_quantize_block twice on the same
+                        // DCT input (~10-15% encoder speedup at m5/m6). (#35-#8)
+                        let _ = lambda; // identical inputs → identical output
+                        stored.y1_zigzag[block_idx] = pre[block_idx];
+                    } else {
+                        let mut coeffs = *block;
+                        // Borrow segment fields individually to avoid conflict with proba_stats
+                        let y1_matrix = self.segments[segment_id].y1_matrix.as_ref().unwrap();
+                        let psy_config = &self.segments[segment_id].psy_config;
+                        trellis_quantize_block(
+                            &mut coeffs,
+                            &mut stored.y1_zigzag[block_idx],
+                            y1_matrix,
+                            lambda,
+                            first_coeff_y1,
+                            &self.level_costs,
+                            token_type_y1 as usize,
+                            ctx0,
+                            psy_config,
+                        );
+                    }
                 } else {
                     let y1_matrix = self.segments[segment_id].y1_matrix.as_ref().unwrap();
                     for i in first_coeff_y1..16 {


### PR DESCRIPTION
**Stacked on top of #32 fast-mb-analyze PR — targets `stack/32-fast-mb-analyze`.**

Bundles 7 cleanup items from the #35 tracker.

## Items landed

- `db6faaa` cleanup(trellis): harmonize MAX_COST with libwebp (#35-#9) — `i64::MAX/2` → `0x7fffffffffffff`
- `dfc9bd2` cleanup(quantize): zero DC slot in ac_only fused quant/dequant (#35-#11)
- `a217709` cleanup(vp8): remove dead `loop_filter_adjustments` scaffolding (#35-#5) — drops field, hard-codes false flag, deletes helper
- `09670fb` docs(vp8): document single-partition limitation (#35-#3) — comment only
- `0f28f5c` docs(vp8): note mid-stream probability refresh is mostly bookkeeping (#35-#6) — comment only
- `e428855` docs(trellis): note EOB cost lookup is equivalent to libwebp (#35-#10) — comment only
- `75ca15e` perf(vp8): thread trellis output through to recorder, kill double-work (#35-#8) — adds `LumaBlockResult::trellis_y1_zigzag: Option<[[i32;16];16]>`, threads through to `record_residual_tokens_storing`. Tracker estimates ~10–15% encoder speedup at m5/m6.

## Result

**Bit-exact** vs `fixall/libwebp-parity` on m6 sweep (Default/Photo/Drawing × q75 × 25 CID22 images): identical ratios. The trellis dedup is a pure perf optimization — same DCT input + same parameters → same trellis output, just computed once instead of twice.

## Skipped (out of scope)

- #35-#7 (I4 trellis level_costs snapshot — no-op in single-pass)
- #35-#4 (segment header delta vs absolute — both spec-legal, ±10-30 bits/frame, cosmetic)

## Test plan

- [x] `cargo test --release` — 238 passed, 0 failed
- [x] m6 size sweep bit-exact vs parent (zero per-file delta)
- [ ] Wait for CI on stacked PR

## Stack

Base: #32. Next: stack/25-full.