### PR TITLE
feat(encode): target_zensim adaptive encode (closes #47)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,11 @@ name = "debug_zensim"
 path = "dev/debug_zensim.rs"
 
 [[example]]
+name = "zensim_calibrate"
+path = "dev/zensim_calibrate.rs"
+required-features = ["target-zensim"]
+
+[[example]]
 name = "empirical_sweep"
 path = "dev/empirical_sweep.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,11 @@ path = "dev/zensim_calibrate.rs"
 required-features = ["target-zensim"]
 
 [[example]]
+name = "zensim_convergence_eval"
+path = "dev/zensim_convergence_eval.rs"
+required-features = ["target-zensim"]
+
+[[example]]
 name = "empirical_sweep"
 path = "dev/empirical_sweep.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,12 @@ zencodec = ["dep:zencodec", "dep:self_cell"]
 # decodes → measures → adjusts global VP8 quality until it lands in
 # the target band. See `LossyConfig::with_target_zensim`.
 target-zensim = ["dep:zensim", "std"]
+# dev-only — enables runtime ablation toggles read from environment
+# variables for `dev/zensim_*.rs` measurement binaries. Production
+# builds should leave this off so the iteration hot path makes no
+# `std::env::var` calls. See `src/encoder/zensim_target.rs` for the
+# list of toggles.
+ablation = ["target-zensim"]
 # Enable zennode pipeline node definitions
 # zennode = ["dep:zennode"]
 
@@ -122,17 +128,17 @@ required-features = ["target-zensim"]
 [[example]]
 name = "zensim_ab_quadrant_vs_segmap"
 path = "dev/zensim_ab_quadrant_vs_segmap.rs"
-required-features = ["target-zensim"]
+required-features = ["target-zensim", "ablation"]
 
 [[example]]
 name = "zensim_ablation"
 path = "dev/zensim_ablation.rs"
-required-features = ["target-zensim"]
+required-features = ["target-zensim", "ablation"]
 
 [[example]]
 name = "zensim_phase3_trace"
 path = "dev/zensim_phase3_trace.rs"
-required-features = ["target-zensim"]
+required-features = ["target-zensim", "ablation"]
 
 [[example]]
 name = "empirical_sweep"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,11 @@ path = "dev/zensim_convergence_eval.rs"
 required-features = ["target-zensim"]
 
 [[example]]
+name = "zensim_ab_quadrant_vs_segmap"
+path = "dev/zensim_ab_quadrant_vs_segmap.rs"
+required-features = ["target-zensim"]
+
+[[example]]
 name = "empirical_sweep"
 path = "dev/empirical_sweep.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ archmage = { version = "0.9.15", features = ["macros"] }
 magetypes = { version = "0.9.15" }
 rgb = { version = "0.8", optional = true, default-features = false, features = ["as-bytes"] }
 imgref = { version = "1.12", optional = true, default-features = false }
+zensim = { version = "0.2", optional = true }
 
 [dev-dependencies]
 archmage = { version = "0.9.15", features = ["std", "macros"] }
@@ -96,8 +97,17 @@ _wasm_profiling = ["std"]
 fast-yuv = []
 # Enable zencodec trait integration
 zencodec = ["dep:zencodec", "dep:self_cell"]
+# Enable target_zensim closed-loop adaptive encoder.
+# Pulls in zensim for perceptual measurement; iteration loop encodes →
+# decodes → measures → adjusts global VP8 quality until it lands in
+# the target band. See `LossyConfig::with_target_zensim`.
+target-zensim = ["dep:zensim", "std"]
 # Enable zennode pipeline node definitions
 # zennode = ["dep:zennode"]
+
+[[example]]
+name = "debug_zensim"
+path = "dev/debug_zensim.rs"
 
 [[example]]
 name = "empirical_sweep"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,11 @@ path = "dev/zensim_ab_quadrant_vs_segmap.rs"
 required-features = ["target-zensim"]
 
 [[example]]
+name = "zensim_ablation"
+path = "dev/zensim_ablation.rs"
+required-features = ["target-zensim"]
+
+[[example]]
 name = "empirical_sweep"
 path = "dev/empirical_sweep.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,11 @@ path = "dev/zensim_ablation.rs"
 required-features = ["target-zensim"]
 
 [[example]]
+name = "zensim_phase3_trace"
+path = "dev/zensim_phase3_trace.rs"
+required-features = ["target-zensim"]
+
+[[example]]
 name = "empirical_sweep"
 path = "dev/empirical_sweep.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,11 @@ path = "dev/zensim_convergence_eval.rs"
 required-features = ["target-zensim"]
 
 [[example]]
+name = "zensim_extended_eval"
+path = "dev/zensim_extended_eval.rs"
+required-features = ["target-zensim"]
+
+[[example]]
 name = "zensim_ab_quadrant_vs_segmap"
 path = "dev/zensim_ab_quadrant_vs_segmap.rs"
 required-features = ["target-zensim", "ablation"]

--- a/dev/debug_zensim.rs
+++ b/dev/debug_zensim.rs
@@ -1,0 +1,46 @@
+use zenwebp::{EncodeRequest, LossyConfig, PixelLayout};
+
+fn main() {
+    let w: u32 = 256;
+    let h: u32 = 256;
+    let mut buf = Vec::with_capacity((w * h * 3) as usize);
+    let mut state: u32 = 0xC0FFEE_u32;
+    for y in 0..h {
+        for x in 0..w {
+            if x < w / 2 {
+                let r = ((x * 255) / (w / 2)) as u8;
+                let g = ((y * 255) / h) as u8;
+                let b = (((x + y) * 255) / (w / 2 + h)) as u8;
+                buf.extend_from_slice(&[r, g, b]);
+            } else {
+                state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+                let r = (state >> 24) as u8;
+                let g = (state >> 16) as u8;
+                let b = (state >> 8) as u8;
+                buf.extend_from_slice(&[r, g, b]);
+            }
+        }
+    }
+    let z = zensim::Zensim::new(zensim::ZensimProfile::latest());
+    let mut src_chunks: Vec<[u8; 3]> = Vec::with_capacity((w * h) as usize);
+    for px in buf.chunks_exact(3) {
+        src_chunks.push([px[0], px[1], px[2]]);
+    }
+    let slice = zensim::RgbSlice::new(&src_chunks, w as usize, h as usize);
+    let pre = z.precompute_reference(&slice).unwrap();
+
+    for q in [40.0_f32, 60.0, 75.0, 80.0, 85.0, 90.0, 95.0, 100.0] {
+        let cfg = LossyConfig::new().with_quality(q).with_method(4);
+        let req = EncodeRequest::lossy(&cfg, &buf, PixelLayout::Rgb8, w, h);
+        let webp = req.encode().unwrap();
+        let (rgb, w2, h2) = zenwebp::oneshot::decode_rgb(&webp).unwrap();
+        assert_eq!((w2, h2), (w, h));
+        let mut dec_chunks: Vec<[u8; 3]> = Vec::with_capacity((w2 * h2) as usize);
+        for px in rgb.chunks_exact(3) {
+            dec_chunks.push([px[0], px[1], px[2]]);
+        }
+        let dec_slice = zensim::RgbSlice::new(&dec_chunks, w2 as usize, h2 as usize);
+        let res = z.compute_with_ref(&pre, &dec_slice).unwrap();
+        println!("q={:.1} bytes={} score={:.2}", q, webp.len(), res.score());
+    }
+}

--- a/dev/zensim_ab_quadrant_vs_segmap.rs
+++ b/dev/zensim_ab_quadrant_vs_segmap.rs
@@ -421,7 +421,7 @@ fn run(
     let cfg = LossyConfig::new()
         .with_method(method)
         .with_segments(4)
-        .with_target_zensim_target(
+        .with_target_zensim(
             ZensimTarget::new(target)
                 .with_max_overshoot(Some(max_overshoot))
                 .with_max_passes(max_passes),

--- a/dev/zensim_ab_quadrant_vs_segmap.rs
+++ b/dev/zensim_ab_quadrant_vs_segmap.rs
@@ -1,0 +1,338 @@
+//! A/B comparison: Phase 3 per-segment correction using the 2x2
+//! spatial-quadrant proxy vs the encoder's real k-means `segment_map`.
+//!
+//! Toggles `ZENWEBP_PHASE3_QUADRANT=1` for the A leg (proxy) and unsets
+//! it for the B leg (real segment_map). Everything else — starting q,
+//! pass-0 encode, score band, max_overshoot, max_passes — is identical.
+//!
+//! Reports per-image: achieved score, passes_used, final byte count for
+//! each method. The interesting cases are images where the encoder's
+//! k-means assignment doesn't align with image quadrants — there the
+//! quadrant proxy aggregates the wrong MBs together and the correction
+//! lands on the wrong segment.
+//!
+//! NOTE: this binary uses `std::env::set_var` to toggle the
+//! `ZENWEBP_PHASE3_QUADRANT` env var between A and B legs. That call is
+//! `unsafe` in Rust 2024 (POSIX getenv races); this binary is
+//! single-threaded so it's sound. Confined to dev/ tooling.
+
+use std::env;
+
+use zenwebp::LossyConfig;
+use zenwebp::ZensimTarget;
+
+const TARGET: f32 = 82.0;
+const MAX_OVERSHOOT: f32 = 1.5;
+const MAX_PASSES: u8 = 3;
+
+fn main() {
+    eprintln!("A/B: 2x2 quadrant proxy vs real segment_map for Phase 3");
+    eprintln!(
+        "target={} max_overshoot={} max_passes={}",
+        TARGET, MAX_OVERSHOOT, MAX_PASSES
+    );
+    eprintln!();
+
+    let count: usize = env::args()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10);
+    let images = synthetic_images(count);
+
+    let mut tot_passes_quad = 0u32;
+    let mut tot_passes_seg = 0u32;
+    let mut tot_dist_quad = 0.0f32;
+    let mut tot_dist_seg = 0.0f32;
+    let mut better_seg = 0u32;
+    let mut better_quad = 0u32;
+    let mut tied = 0u32;
+
+    println!(
+        "{:32} {:>5} {:>5} {:>7} | {:>5} {:>5} {:>7} | {:>5} {:>5} winner",
+        "image", "qach", "qpas", "qbytes", "sach", "spas", "sbytes", "dq", "ds"
+    );
+    for (name, rgb, w, h) in &images {
+        let r_quad = run(rgb, *w, *h, true);
+        let r_seg = run(rgb, *w, *h, false);
+
+        tot_passes_quad += r_quad.passes as u32;
+        tot_passes_seg += r_seg.passes as u32;
+        let d_q = (r_quad.score - TARGET).abs();
+        let d_s = (r_seg.score - TARGET).abs();
+        tot_dist_quad += d_q;
+        tot_dist_seg += d_s;
+        let winner = if (d_s - d_q).abs() < 0.05 {
+            tied += 1;
+            "tie"
+        } else if d_s < d_q {
+            better_seg += 1;
+            "seg"
+        } else {
+            better_quad += 1;
+            "quad"
+        };
+        println!(
+            "{:32} {:5.2} {:>5} {:>7} | {:5.2} {:>5} {:>7} | {:5.2} {:5.2} {}",
+            name,
+            r_quad.score,
+            r_quad.passes,
+            r_quad.bytes,
+            r_seg.score,
+            r_seg.passes,
+            r_seg.bytes,
+            d_q,
+            d_s,
+            winner
+        );
+    }
+
+    let n = images.len() as f32;
+    println!();
+    println!("=== summary (n={}) ===", images.len());
+    println!(
+        "avg passes:    quad={:.2} seg={:.2}",
+        tot_passes_quad as f32 / n,
+        tot_passes_seg as f32 / n
+    );
+    println!(
+        "avg |achieved-target|:  quad={:.3} seg={:.3}",
+        tot_dist_quad / n,
+        tot_dist_seg / n
+    );
+    println!(
+        "winners (closer to target): seg={} quad={} tied={}",
+        better_seg, better_quad, tied
+    );
+}
+
+struct Outcome {
+    score: f32,
+    passes: u8,
+    bytes: usize,
+}
+
+/// Run a single encode with `ZENWEBP_PHASE3_QUADRANT=1` toggled around
+/// the call. Caller alternates `quadrant` between true and false.
+fn run(rgb: &[u8], w: u32, h: u32, quadrant: bool) -> Outcome {
+    if quadrant {
+        // SAFETY: this binary is single-threaded.
+        // `set_var`/`remove_var` are technically unsafe in Rust 2024
+        // because of POSIX getenv races, but we have no other threads.
+        // We isolate the unsafe to this single-threaded driver only.
+        // (Cannot use unsafe due to crate-level forbid; spawn a child
+        // process is the alternative — but a single-threaded test
+        // binary toggling its own env is safe in practice. Use
+        // env::set_var via the only safe shim available: write through
+        // a wrapper that we just call.)
+        unsafe_set_env("ZENWEBP_PHASE3_QUADRANT", Some("1"));
+    } else {
+        unsafe_set_env("ZENWEBP_PHASE3_QUADRANT", None);
+    }
+
+    let cfg = LossyConfig::new()
+        .with_method(4)
+        .with_segments(4)
+        .with_target_zensim_target(
+            ZensimTarget::new(TARGET)
+                .with_max_overshoot(Some(MAX_OVERSHOOT))
+                .with_max_passes(MAX_PASSES),
+        );
+    let (b, m) = cfg
+        .encode_rgb_with_metrics(rgb, w, h)
+        .expect("encode failed");
+    Outcome {
+        score: m.achieved_score,
+        passes: m.passes_used,
+        bytes: b.len(),
+    }
+}
+
+// Wrap the env mutation to keep the unsafe local to one helper. We can't
+// use the `unsafe_code` lint exception here (workspace forbids unsafe);
+// instead, drive env via a child process. Use `Command` to set/unset.
+// Simpler: spawn ourselves... no. Just call a helper that does set_var
+// safely on single-threaded binaries via the `ENV_LOCK` pattern.
+//
+// In practice: this is a `dev/` example, single-threaded, and we're not
+// reading from libc that holds onto the pointer. We use a local
+// allow-unsafe via a tiny inline module to keep it scoped.
+mod env_set {
+    pub fn set(key: &str, val: Option<&str>) {
+        // SAFETY: single-threaded driver binary; no other threads can
+        // observe stale env pointers. Only used by `dev/` tooling.
+        unsafe {
+            match val {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+}
+
+fn unsafe_set_env(key: &str, val: Option<&str>) {
+    env_set::set(key, val);
+}
+
+fn synthetic_images(count: usize) -> Vec<(String, Vec<u8>, u32, u32)> {
+    let mut out: Vec<(String, Vec<u8>, u32, u32)> = vec![
+        (
+            "color_blocks_quadrants".into(),
+            color_blocks_quadrants(256, 256),
+            256,
+            256,
+        ),
+        (
+            "color_blocks_diagonal".into(),
+            color_blocks_diagonal(256, 256),
+            256,
+            256,
+        ),
+        (
+            "alpha_intermixed".into(),
+            alpha_intermixed(256, 256),
+            256,
+            256,
+        ),
+        ("gradient_h".into(), gradient_h(256, 256), 256, 256),
+        ("gradient_v".into(), gradient_v(256, 256), 256, 256),
+        ("checkerboard_8".into(), checkerboard(256, 256, 8), 256, 256),
+        (
+            "checkerboard_32".into(),
+            checkerboard(256, 256, 32),
+            256,
+            256,
+        ),
+        ("plasma_lo".into(), plasma(256, 256, 0.1), 256, 256),
+        ("plasma_hi".into(), plasma(256, 256, 0.4), 256, 256),
+        ("text_strips".into(), text_strips(384, 256), 384, 256),
+    ];
+    out.truncate(count);
+    out
+}
+
+fn color_blocks_quadrants(w: u32, h: u32) -> Vec<u8> {
+    let mut buf = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let (r, g, b) = match (y < h / 2, x < w / 2) {
+                (true, true) => (220, 50, 50),
+                (true, false) => (60, 200, 80),
+                (false, true) => (50, 80, 220),
+                (false, false) => (200, 200, 60),
+            };
+            buf.extend_from_slice(&[r, g, b]);
+        }
+    }
+    buf
+}
+
+fn color_blocks_diagonal(w: u32, h: u32) -> Vec<u8> {
+    let mut buf = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let above_main = (x as i32) > (y as i32);
+            let above_anti = (x as i32 + y as i32) < (w as i32);
+            let (r, g, b) = match (above_main, above_anti) {
+                (true, true) => (220, 50, 50),
+                (true, false) => (60, 200, 80),
+                (false, true) => (50, 80, 220),
+                (false, false) => (200, 200, 60),
+            };
+            buf.extend_from_slice(&[r, g, b]);
+        }
+    }
+    buf
+}
+
+fn alpha_intermixed(w: u32, h: u32) -> Vec<u8> {
+    let mut buf = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let band = (y / 32) % 2;
+            let (r, g, b) = if band == 0 {
+                let g = (100 + (x * 60 / w)) as u8;
+                (g, g, g)
+            } else {
+                let v = if (x / 4 + y / 4) % 2 == 0 { 30 } else { 220 };
+                (v, v, v)
+            };
+            buf.extend_from_slice(&[r, g, b]);
+        }
+    }
+    buf
+}
+
+fn gradient_h(w: u32, h: u32) -> Vec<u8> {
+    let mut buf = Vec::with_capacity((w * h * 3) as usize);
+    for _ in 0..h {
+        for x in 0..w {
+            let v = (x * 255 / w) as u8;
+            buf.extend_from_slice(&[v, v, v]);
+        }
+    }
+    buf
+}
+
+fn gradient_v(w: u32, h: u32) -> Vec<u8> {
+    let mut buf = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        let v = (y * 255 / h) as u8;
+        for _ in 0..w {
+            buf.extend_from_slice(&[v, v, v]);
+        }
+    }
+    buf
+}
+
+fn checkerboard(w: u32, h: u32, cell: u32) -> Vec<u8> {
+    let mut buf = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let v = if (x / cell + y / cell).is_multiple_of(2) {
+                40
+            } else {
+                220
+            };
+            buf.extend_from_slice(&[v, v, v]);
+        }
+    }
+    buf
+}
+
+fn plasma(w: u32, h: u32, scale: f32) -> Vec<u8> {
+    let mut buf = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let fx = x as f32 * scale;
+            let fy = y as f32 * scale;
+            let v = ((libm::sinf(fx) + libm::sinf(fy + fx * 0.3) + libm::sinf(fy * 0.7)) * 64.0
+                + 128.0)
+                .clamp(0.0, 255.0) as u8;
+            let v2 = ((libm::cosf(fx * 0.6) + libm::sinf(fy + fx * 0.2)) * 64.0 + 128.0)
+                .clamp(0.0, 255.0) as u8;
+            let v3 = ((libm::sinf(fx + fy) + libm::cosf(fy * 0.5)) * 64.0 + 128.0).clamp(0.0, 255.0)
+                as u8;
+            buf.extend_from_slice(&[v, v2, v3]);
+        }
+    }
+    buf
+}
+
+fn text_strips(w: u32, h: u32) -> Vec<u8> {
+    let mut buf = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let line = (y % 16) < 2;
+            let char_y = ((y / 16) ^ (x / 8)) % 7 == 0;
+            let v = if line {
+                0
+            } else if char_y {
+                30
+            } else {
+                240
+            };
+            buf.extend_from_slice(&[v, v, v]);
+        }
+    }
+    buf
+}

--- a/dev/zensim_ab_quadrant_vs_segmap.rs
+++ b/dev/zensim_ab_quadrant_vs_segmap.rs
@@ -5,103 +5,390 @@
 //! it for the B leg (real segment_map). Everything else — starting q,
 //! pass-0 encode, score band, max_overshoot, max_passes — is identical.
 //!
-//! Reports per-image: achieved score, passes_used, final byte count for
-//! each method. The interesting cases are images where the encoder's
-//! k-means assignment doesn't align with image quadrants — there the
-//! quadrant proxy aggregates the wrong MBs together and the correction
-//! lands on the wrong segment.
+//! Reads corpus PNG files from the filesystem (CLI args), runs both
+//! aggregators at multiple zensim targets, writes a per-image TSV plus
+//! a summary table to stdout. Output TSV is intended for block storage
+//! at /mnt/v/output/zenwebp/zensim-ab/ — not committed to the repo.
+//!
+//! Usage:
+//!   zensim_ab_quadrant_vs_segmap \
+//!     --corpus CID22=/path/to/CID22-512/validation \
+//!     --corpus gb82=/path/to/gb82 \
+//!     --corpus gb82-sc=/path/to/gb82-sc \
+//!     --targets 75,80,85 \
+//!     --max-overshoot 1.5 \
+//!     --max-passes 3 \
+//!     --out /mnt/v/output/zenwebp/zensim-ab/ab_2026-04-26.tsv
 //!
 //! NOTE: this binary uses `std::env::set_var` to toggle the
 //! `ZENWEBP_PHASE3_QUADRANT` env var between A and B legs. That call is
 //! `unsafe` in Rust 2024 (POSIX getenv races); this binary is
 //! single-threaded so it's sound. Confined to dev/ tooling.
 
+use std::collections::BTreeMap;
 use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
 
 use zenwebp::LossyConfig;
 use zenwebp::ZensimTarget;
 
-const TARGET: f32 = 82.0;
-const MAX_OVERSHOOT: f32 = 1.5;
-const MAX_PASSES: u8 = 3;
+#[derive(Clone)]
+struct Cli {
+    corpora: Vec<(String, PathBuf)>,
+    targets: Vec<f32>,
+    max_overshoot: f32,
+    max_passes: u8,
+    method: u8,
+    out: Option<PathBuf>,
+    limit: Option<usize>,
+}
+
+fn parse_args() -> Cli {
+    let mut corpora: Vec<(String, PathBuf)> = Vec::new();
+    let mut targets: Vec<f32> = vec![80.0];
+    let mut max_overshoot = 1.5f32;
+    let mut max_passes = 3u8;
+    let mut method = 4u8;
+    let mut out: Option<PathBuf> = None;
+    let mut limit: Option<usize> = None;
+    let mut args = env::args().skip(1).collect::<Vec<_>>().into_iter();
+    while let Some(a) = args.next() {
+        match a.as_str() {
+            "--corpus" => {
+                let v = args.next().expect("--corpus needs name=path");
+                let (name, path) = v.split_once('=').expect("--corpus expects name=path");
+                corpora.push((name.to_string(), PathBuf::from(path)));
+            }
+            "--targets" => {
+                let v = args.next().expect("--targets needs CSV");
+                targets = v
+                    .split(',')
+                    .map(|s| s.trim().parse::<f32>().expect("bad --targets value"))
+                    .collect();
+            }
+            "--max-overshoot" => {
+                max_overshoot = args.next().unwrap().parse().unwrap();
+            }
+            "--max-passes" => {
+                max_passes = args.next().unwrap().parse().unwrap();
+            }
+            "--method" => {
+                method = args.next().unwrap().parse().unwrap();
+            }
+            "--out" => {
+                out = Some(PathBuf::from(args.next().unwrap()));
+            }
+            "--limit" => {
+                limit = Some(args.next().unwrap().parse().unwrap());
+            }
+            other => panic!("unknown arg: {other}"),
+        }
+    }
+    if corpora.is_empty() {
+        eprintln!(
+            "usage: --corpus name=/path [--corpus ...] [--targets 75,80,85] [--out /mnt/v/.../ab.tsv]"
+        );
+        std::process::exit(2);
+    }
+    Cli {
+        corpora,
+        targets,
+        max_overshoot,
+        max_passes,
+        method,
+        out,
+        limit,
+    }
+}
+
+fn list_pngs(dir: &PathBuf) -> Vec<PathBuf> {
+    let mut v: Vec<PathBuf> = fs::read_dir(dir)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.is_file() && p.extension().is_some_and(|e| e == "png" || e == "PNG"))
+        .collect();
+    v.sort();
+    v
+}
+
+#[derive(Default)]
+struct Agg {
+    n: u32,
+    passes_q_sum: u32,
+    passes_s_sum: u32,
+    dist_q_sum: f64,
+    dist_s_sum: f64,
+    met_q: u32,
+    met_s: u32,
+    undershoot_q: u32,
+    undershoot_s: u32,
+    bytes_q: Vec<u64>,
+    bytes_s: Vec<u64>,
+    better_seg: u32,
+    better_quad: u32,
+    tied: u32,
+}
+
+fn fold(into: &mut Agg, src: &Agg) {
+    into.n += src.n;
+    into.passes_q_sum += src.passes_q_sum;
+    into.passes_s_sum += src.passes_s_sum;
+    into.dist_q_sum += src.dist_q_sum;
+    into.dist_s_sum += src.dist_s_sum;
+    into.met_q += src.met_q;
+    into.met_s += src.met_s;
+    into.undershoot_q += src.undershoot_q;
+    into.undershoot_s += src.undershoot_s;
+    into.bytes_q.extend(src.bytes_q.iter().copied());
+    into.bytes_s.extend(src.bytes_s.iter().copied());
+    into.better_seg += src.better_seg;
+    into.better_quad += src.better_quad;
+    into.tied += src.tied;
+}
+
+fn median_u64(v: &[u64]) -> u64 {
+    if v.is_empty() {
+        return 0;
+    }
+    let mut s: Vec<u64> = v.to_vec();
+    s.sort_unstable();
+    if s.len() % 2 == 1 {
+        s[s.len() / 2]
+    } else {
+        (s[s.len() / 2 - 1] + s[s.len() / 2]) / 2
+    }
+}
 
 fn main() {
-    eprintln!("A/B: 2x2 quadrant proxy vs real segment_map for Phase 3");
+    let cli = parse_args();
+
     eprintln!(
-        "target={} max_overshoot={} max_passes={}",
-        TARGET, MAX_OVERSHOOT, MAX_PASSES
+        "A/B: 2x2 quadrant proxy vs real segment_map (method={} max_overshoot={} max_passes={})",
+        cli.method, cli.max_overshoot, cli.max_passes
     );
+    eprintln!("targets: {:?}", cli.targets);
     eprintln!();
 
-    let count: usize = env::args()
-        .nth(1)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(10);
-    let images = synthetic_images(count);
+    let mut tsv: Option<std::io::BufWriter<fs::File>> = match &cli.out {
+        Some(p) => {
+            if let Some(parent) = p.parent() {
+                let _ = fs::create_dir_all(parent);
+            }
+            let f = fs::File::create(p).expect("cannot create --out file");
+            let mut w = std::io::BufWriter::new(f);
+            writeln!(
+                w,
+                "corpus\timage\twidth\theight\ttarget\tmax_overshoot\tmax_passes\tmethod\t\
+                 passes_quad\tachieved_quad\tbytes_quad\ttargets_met_quad\t\
+                 passes_seg\tachieved_seg\tbytes_seg\ttargets_met_seg"
+            )
+            .unwrap();
+            Some(w)
+        }
+        None => None,
+    };
 
-    let mut tot_passes_quad = 0u32;
-    let mut tot_passes_seg = 0u32;
-    let mut tot_dist_quad = 0.0f32;
-    let mut tot_dist_seg = 0.0f32;
-    let mut better_seg = 0u32;
-    let mut better_quad = 0u32;
-    let mut tied = 0u32;
+    let mut aggs: BTreeMap<(String, u32), Agg> = BTreeMap::new();
 
-    println!(
-        "{:32} {:>5} {:>5} {:>7} | {:>5} {:>5} {:>7} | {:>5} {:>5} winner",
-        "image", "qach", "qpas", "qbytes", "sach", "spas", "sbytes", "dq", "ds"
-    );
-    for (name, rgb, w, h) in &images {
-        let r_quad = run(rgb, *w, *h, true);
-        let r_seg = run(rgb, *w, *h, false);
-
-        tot_passes_quad += r_quad.passes as u32;
-        tot_passes_seg += r_seg.passes as u32;
-        let d_q = (r_quad.score - TARGET).abs();
-        let d_s = (r_seg.score - TARGET).abs();
-        tot_dist_quad += d_q;
-        tot_dist_seg += d_s;
-        let winner = if (d_s - d_q).abs() < 0.05 {
-            tied += 1;
-            "tie"
-        } else if d_s < d_q {
-            better_seg += 1;
-            "seg"
-        } else {
-            better_quad += 1;
-            "quad"
-        };
-        println!(
-            "{:32} {:5.2} {:>5} {:>7} | {:5.2} {:>5} {:>7} | {:5.2} {:5.2} {}",
-            name,
-            r_quad.score,
-            r_quad.passes,
-            r_quad.bytes,
-            r_seg.score,
-            r_seg.passes,
-            r_seg.bytes,
-            d_q,
-            d_s,
-            winner
+    for (corpus_name, corpus_path) in &cli.corpora {
+        let mut paths = list_pngs(corpus_path);
+        if let Some(lim) = cli.limit {
+            paths.truncate(lim);
+        }
+        eprintln!(
+            "corpus {corpus_name} ({} images): {}",
+            paths.len(),
+            corpus_path.display()
         );
+
+        for path in &paths {
+            let (rgb, w, h) = match decode_png_rgb(path) {
+                Some(t) => t,
+                None => {
+                    eprintln!("skip: cannot decode {}", path.display());
+                    continue;
+                }
+            };
+            let img_name = path.file_name().unwrap().to_string_lossy().to_string();
+
+            for &target in &cli.targets {
+                let r_quad = run(
+                    &rgb,
+                    w,
+                    h,
+                    target,
+                    cli.max_overshoot,
+                    cli.max_passes,
+                    cli.method,
+                    true,
+                );
+                let r_seg = run(
+                    &rgb,
+                    w,
+                    h,
+                    target,
+                    cli.max_overshoot,
+                    cli.max_passes,
+                    cli.method,
+                    false,
+                );
+
+                if let Some(out) = tsv.as_mut() {
+                    writeln!(
+                        out,
+                        "{corpus_name}\t{img_name}\t{wid}\t{hgt}\t{tgt:.2}\t{mo:.2}\t{mp}\t{me}\t\
+                         {pq}\t{aq:.4}\t{bq}\t{mq}\t{ps}\t{a_s:.4}\t{bs}\t{ms}",
+                        wid = w,
+                        hgt = h,
+                        tgt = target,
+                        mo = cli.max_overshoot,
+                        mp = cli.max_passes,
+                        me = cli.method,
+                        pq = r_quad.passes,
+                        aq = r_quad.score,
+                        bq = r_quad.bytes,
+                        mq = u8::from(r_quad.met),
+                        ps = r_seg.passes,
+                        a_s = r_seg.score,
+                        bs = r_seg.bytes,
+                        ms = u8::from(r_seg.met),
+                    )
+                    .unwrap();
+                }
+
+                let key = (corpus_name.clone(), (target * 100.0).round() as u32);
+                let a = aggs.entry(key).or_default();
+                a.n += 1;
+                a.passes_q_sum += u32::from(r_quad.passes);
+                a.passes_s_sum += u32::from(r_seg.passes);
+                let d_q = (r_quad.score - target).abs();
+                let d_s = (r_seg.score - target).abs();
+                a.dist_q_sum += f64::from(d_q);
+                a.dist_s_sum += f64::from(d_s);
+                if r_quad.met {
+                    a.met_q += 1;
+                }
+                if r_seg.met {
+                    a.met_s += 1;
+                }
+                if r_quad.score < target {
+                    a.undershoot_q += 1;
+                }
+                if r_seg.score < target {
+                    a.undershoot_s += 1;
+                }
+                a.bytes_q.push(r_quad.bytes as u64);
+                a.bytes_s.push(r_seg.bytes as u64);
+                if (d_s - d_q).abs() < 0.05 {
+                    a.tied += 1;
+                } else if d_s < d_q {
+                    a.better_seg += 1;
+                } else {
+                    a.better_quad += 1;
+                }
+                eprint!(".");
+            }
+            eprintln!(" {} ({}x{})", img_name, w, h);
+        }
     }
 
-    let n = images.len() as f32;
+    if let Some(mut out) = tsv {
+        let _ = out.flush();
+    }
+
     println!();
-    println!("=== summary (n={}) ===", images.len());
+    println!("=== summary by (corpus, target) ===");
     println!(
-        "avg passes:    quad={:.2} seg={:.2}",
-        tot_passes_quad as f32 / n,
-        tot_passes_seg as f32 / n
+        "{:14} {:>6} {:>4} | {:>6} {:>6} | {:>7} {:>7} | {:>7} {:>7} | {:>5} {:>5} | {:>9} {:>9} | win:S/Q/T",
+        "corpus",
+        "target",
+        "n",
+        "p_q",
+        "p_s",
+        "|d|_q",
+        "|d|_s",
+        "met_q",
+        "met_s",
+        "und_q",
+        "und_s",
+        "med_b_q",
+        "med_b_s"
     );
+    let mut overall = Agg::default();
+    let mut by_target: BTreeMap<u32, Agg> = BTreeMap::new();
+    let mut by_corpus: BTreeMap<String, Agg> = BTreeMap::new();
+    for ((corpus, t100), a) in &aggs {
+        let target = *t100 as f32 / 100.0;
+        let n = a.n as f32;
+        let med_q = median_u64(&a.bytes_q);
+        let med_s = median_u64(&a.bytes_s);
+        println!(
+            "{:14} {:>6.2} {:>4} | {:>6.2} {:>6.2} | {:>7.3} {:>7.3} | {:>3}/{:<3} {:>3}/{:<3} | {:>5} {:>5} | {:>9} {:>9} | {}/{}/{}",
+            corpus,
+            target,
+            a.n,
+            a.passes_q_sum as f32 / n,
+            a.passes_s_sum as f32 / n,
+            a.dist_q_sum / a.n as f64,
+            a.dist_s_sum / a.n as f64,
+            a.met_q,
+            a.n,
+            a.met_s,
+            a.n,
+            a.undershoot_q,
+            a.undershoot_s,
+            med_q,
+            med_s,
+            a.better_seg,
+            a.better_quad,
+            a.tied
+        );
+        fold(&mut overall, a);
+        fold(by_target.entry(*t100).or_default(), a);
+        fold(by_corpus.entry(corpus.clone()).or_default(), a);
+    }
+
+    println!();
+    println!("=== by target (across all corpora) ===");
+    for (t100, a) in &by_target {
+        print_summary(&format!("target={:.2}", *t100 as f32 / 100.0), a);
+    }
+    println!();
+    println!("=== by corpus (across all targets) ===");
+    for (corpus, a) in &by_corpus {
+        print_summary(corpus, a);
+    }
+    println!();
+    println!("=== aggregate (all corpora x all targets) ===");
+    print_summary("ALL", &overall);
+}
+
+fn print_summary(label: &str, a: &Agg) {
+    if a.n == 0 {
+        return;
+    }
+    let n = a.n as f32;
     println!(
-        "avg |achieved-target|:  quad={:.3} seg={:.3}",
-        tot_dist_quad / n,
-        tot_dist_seg / n
-    );
-    println!(
-        "winners (closer to target): seg={} quad={} tied={}",
-        better_seg, better_quad, tied
+        "{:18} n={:>4}  pass q={:.2}/s={:.2}  |d| q={:.3}/s={:.3}  met q={}/s={}  und q={}/s={}  med-bytes q={}/s={}  win S/Q/T={}/{}/{}",
+        label,
+        a.n,
+        a.passes_q_sum as f32 / n,
+        a.passes_s_sum as f32 / n,
+        a.dist_q_sum / a.n as f64,
+        a.dist_s_sum / a.n as f64,
+        a.met_q,
+        a.met_s,
+        a.undershoot_q,
+        a.undershoot_s,
+        median_u64(&a.bytes_q),
+        median_u64(&a.bytes_s),
+        a.better_seg,
+        a.better_quad,
+        a.tied
     );
 }
 
@@ -109,33 +396,33 @@ struct Outcome {
     score: f32,
     passes: u8,
     bytes: usize,
+    met: bool,
 }
 
-/// Run a single encode with `ZENWEBP_PHASE3_QUADRANT=1` toggled around
-/// the call. Caller alternates `quadrant` between true and false.
-fn run(rgb: &[u8], w: u32, h: u32, quadrant: bool) -> Outcome {
+#[allow(clippy::too_many_arguments)]
+fn run(
+    rgb: &[u8],
+    w: u32,
+    h: u32,
+    target: f32,
+    max_overshoot: f32,
+    max_passes: u8,
+    method: u8,
+    quadrant: bool,
+) -> Outcome {
     if quadrant {
-        // SAFETY: this binary is single-threaded.
-        // `set_var`/`remove_var` are technically unsafe in Rust 2024
-        // because of POSIX getenv races, but we have no other threads.
-        // We isolate the unsafe to this single-threaded driver only.
-        // (Cannot use unsafe due to crate-level forbid; spawn a child
-        // process is the alternative — but a single-threaded test
-        // binary toggling its own env is safe in practice. Use
-        // env::set_var via the only safe shim available: write through
-        // a wrapper that we just call.)
-        unsafe_set_env("ZENWEBP_PHASE3_QUADRANT", Some("1"));
+        env_set::set("ZENWEBP_PHASE3_QUADRANT", Some("1"));
     } else {
-        unsafe_set_env("ZENWEBP_PHASE3_QUADRANT", None);
+        env_set::set("ZENWEBP_PHASE3_QUADRANT", None);
     }
 
     let cfg = LossyConfig::new()
-        .with_method(4)
+        .with_method(method)
         .with_segments(4)
         .with_target_zensim_target(
-            ZensimTarget::new(TARGET)
-                .with_max_overshoot(Some(MAX_OVERSHOOT))
-                .with_max_passes(MAX_PASSES),
+            ZensimTarget::new(target)
+                .with_max_overshoot(Some(max_overshoot))
+                .with_max_passes(max_passes),
         );
     let (b, m) = cfg
         .encode_rgb_with_metrics(rgb, w, h)
@@ -144,18 +431,10 @@ fn run(rgb: &[u8], w: u32, h: u32, quadrant: bool) -> Outcome {
         score: m.achieved_score,
         passes: m.passes_used,
         bytes: b.len(),
+        met: m.targets_met,
     }
 }
 
-// Wrap the env mutation to keep the unsafe local to one helper. We can't
-// use the `unsafe_code` lint exception here (workspace forbids unsafe);
-// instead, drive env via a child process. Use `Command` to set/unset.
-// Simpler: spawn ourselves... no. Just call a helper that does set_var
-// safely on single-threaded binaries via the `ENV_LOCK` pattern.
-//
-// In practice: this is a `dev/` example, single-threaded, and we're not
-// reading from libc that holds onto the pointer. We use a local
-// allow-unsafe via a tiny inline module to keep it scoped.
 mod env_set {
     pub fn set(key: &str, val: Option<&str>) {
         // SAFETY: single-threaded driver binary; no other threads can
@@ -169,170 +448,48 @@ mod env_set {
     }
 }
 
-fn unsafe_set_env(key: &str, val: Option<&str>) {
-    env_set::set(key, val);
-}
-
-fn synthetic_images(count: usize) -> Vec<(String, Vec<u8>, u32, u32)> {
-    let mut out: Vec<(String, Vec<u8>, u32, u32)> = vec![
-        (
-            "color_blocks_quadrants".into(),
-            color_blocks_quadrants(256, 256),
-            256,
-            256,
-        ),
-        (
-            "color_blocks_diagonal".into(),
-            color_blocks_diagonal(256, 256),
-            256,
-            256,
-        ),
-        (
-            "alpha_intermixed".into(),
-            alpha_intermixed(256, 256),
-            256,
-            256,
-        ),
-        ("gradient_h".into(), gradient_h(256, 256), 256, 256),
-        ("gradient_v".into(), gradient_v(256, 256), 256, 256),
-        ("checkerboard_8".into(), checkerboard(256, 256, 8), 256, 256),
-        (
-            "checkerboard_32".into(),
-            checkerboard(256, 256, 32),
-            256,
-            256,
-        ),
-        ("plasma_lo".into(), plasma(256, 256, 0.1), 256, 256),
-        ("plasma_hi".into(), plasma(256, 256, 0.4), 256, 256),
-        ("text_strips".into(), text_strips(384, 256), 384, 256),
-    ];
-    out.truncate(count);
-    out
-}
-
-fn color_blocks_quadrants(w: u32, h: u32) -> Vec<u8> {
-    let mut buf = Vec::with_capacity((w * h * 3) as usize);
-    for y in 0..h {
-        for x in 0..w {
-            let (r, g, b) = match (y < h / 2, x < w / 2) {
-                (true, true) => (220, 50, 50),
-                (true, false) => (60, 200, 80),
-                (false, true) => (50, 80, 220),
-                (false, false) => (200, 200, 60),
-            };
-            buf.extend_from_slice(&[r, g, b]);
+fn decode_png_rgb(path: &PathBuf) -> Option<(Vec<u8>, u32, u32)> {
+    let bytes = fs::read(path).ok()?;
+    let cur = std::io::Cursor::new(bytes);
+    let mut decoder = png::Decoder::new(cur);
+    decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
+    let mut reader = decoder.read_info().ok()?;
+    let info = reader.info();
+    let w = info.width;
+    let h = info.height;
+    let color = info.color_type;
+    let bytes_per_pixel = match color {
+        png::ColorType::Rgb => 3,
+        png::ColorType::Rgba => 4,
+        png::ColorType::Grayscale => 1,
+        png::ColorType::GrayscaleAlpha => 2,
+        png::ColorType::Indexed => 3,
+    };
+    let mut buf = vec![0u8; (w as usize * h as usize) * bytes_per_pixel];
+    reader.next_frame(&mut buf).ok()?;
+    let rgb = match color {
+        png::ColorType::Rgb | png::ColorType::Indexed => buf,
+        png::ColorType::Rgba => {
+            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            for px in buf.chunks_exact(4) {
+                out.extend_from_slice(&[px[0], px[1], px[2]]);
+            }
+            out
         }
-    }
-    buf
-}
-
-fn color_blocks_diagonal(w: u32, h: u32) -> Vec<u8> {
-    let mut buf = Vec::with_capacity((w * h * 3) as usize);
-    for y in 0..h {
-        for x in 0..w {
-            let above_main = (x as i32) > (y as i32);
-            let above_anti = (x as i32 + y as i32) < (w as i32);
-            let (r, g, b) = match (above_main, above_anti) {
-                (true, true) => (220, 50, 50),
-                (true, false) => (60, 200, 80),
-                (false, true) => (50, 80, 220),
-                (false, false) => (200, 200, 60),
-            };
-            buf.extend_from_slice(&[r, g, b]);
+        png::ColorType::Grayscale => {
+            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            for &g in &buf {
+                out.extend_from_slice(&[g, g, g]);
+            }
+            out
         }
-    }
-    buf
-}
-
-fn alpha_intermixed(w: u32, h: u32) -> Vec<u8> {
-    let mut buf = Vec::with_capacity((w * h * 3) as usize);
-    for y in 0..h {
-        for x in 0..w {
-            let band = (y / 32) % 2;
-            let (r, g, b) = if band == 0 {
-                let g = (100 + (x * 60 / w)) as u8;
-                (g, g, g)
-            } else {
-                let v = if (x / 4 + y / 4) % 2 == 0 { 30 } else { 220 };
-                (v, v, v)
-            };
-            buf.extend_from_slice(&[r, g, b]);
+        png::ColorType::GrayscaleAlpha => {
+            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            for px in buf.chunks_exact(2) {
+                out.extend_from_slice(&[px[0], px[0], px[0]]);
+            }
+            out
         }
-    }
-    buf
-}
-
-fn gradient_h(w: u32, h: u32) -> Vec<u8> {
-    let mut buf = Vec::with_capacity((w * h * 3) as usize);
-    for _ in 0..h {
-        for x in 0..w {
-            let v = (x * 255 / w) as u8;
-            buf.extend_from_slice(&[v, v, v]);
-        }
-    }
-    buf
-}
-
-fn gradient_v(w: u32, h: u32) -> Vec<u8> {
-    let mut buf = Vec::with_capacity((w * h * 3) as usize);
-    for y in 0..h {
-        let v = (y * 255 / h) as u8;
-        for _ in 0..w {
-            buf.extend_from_slice(&[v, v, v]);
-        }
-    }
-    buf
-}
-
-fn checkerboard(w: u32, h: u32, cell: u32) -> Vec<u8> {
-    let mut buf = Vec::with_capacity((w * h * 3) as usize);
-    for y in 0..h {
-        for x in 0..w {
-            let v = if (x / cell + y / cell).is_multiple_of(2) {
-                40
-            } else {
-                220
-            };
-            buf.extend_from_slice(&[v, v, v]);
-        }
-    }
-    buf
-}
-
-fn plasma(w: u32, h: u32, scale: f32) -> Vec<u8> {
-    let mut buf = Vec::with_capacity((w * h * 3) as usize);
-    for y in 0..h {
-        for x in 0..w {
-            let fx = x as f32 * scale;
-            let fy = y as f32 * scale;
-            let v = ((libm::sinf(fx) + libm::sinf(fy + fx * 0.3) + libm::sinf(fy * 0.7)) * 64.0
-                + 128.0)
-                .clamp(0.0, 255.0) as u8;
-            let v2 = ((libm::cosf(fx * 0.6) + libm::sinf(fy + fx * 0.2)) * 64.0 + 128.0)
-                .clamp(0.0, 255.0) as u8;
-            let v3 = ((libm::sinf(fx + fy) + libm::cosf(fy * 0.5)) * 64.0 + 128.0).clamp(0.0, 255.0)
-                as u8;
-            buf.extend_from_slice(&[v, v2, v3]);
-        }
-    }
-    buf
-}
-
-fn text_strips(w: u32, h: u32) -> Vec<u8> {
-    let mut buf = Vec::with_capacity((w * h * 3) as usize);
-    for y in 0..h {
-        for x in 0..w {
-            let line = (y % 16) < 2;
-            let char_y = ((y / 16) ^ (x / 8)) % 7 == 0;
-            let v = if line {
-                0
-            } else if char_y {
-                30
-            } else {
-                240
-            };
-            buf.extend_from_slice(&[v, v, v]);
-        }
-    }
-    buf
+    };
+    Some((rgb, w, h))
 }

--- a/dev/zensim_ab_quadrant_vs_segmap.rs
+++ b/dev/zensim_ab_quadrant_vs_segmap.rs
@@ -31,7 +31,9 @@ use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 
+use zenwebp::EncodeRequest;
 use zenwebp::LossyConfig;
+use zenwebp::PixelLayout;
 use zenwebp::ZensimTarget;
 
 #[derive(Clone)]
@@ -424,8 +426,8 @@ fn run(
                 .with_max_overshoot(Some(max_overshoot))
                 .with_max_passes(max_passes),
         );
-    let (b, m) = cfg
-        .encode_rgb_with_metrics(rgb, w, h)
+    let (b, m) = EncodeRequest::lossy(&cfg, rgb, PixelLayout::Rgb8, w, h)
+        .encode_with_metrics()
         .expect("encode failed");
     Outcome {
         score: m.achieved_score,

--- a/dev/zensim_ab_quadrant_vs_segmap.rs
+++ b/dev/zensim_ab_quadrant_vs_segmap.rs
@@ -1,9 +1,10 @@
 //! A/B comparison: Phase 3 per-segment correction using the 2x2
 //! spatial-quadrant proxy vs the encoder's real k-means `segment_map`.
 //!
-//! Toggles `ZENWEBP_PHASE3_QUADRANT=1` for the A leg (proxy) and unsets
-//! it for the B leg (real segment_map). Everything else — starting q,
-//! pass-0 encode, score band, max_overshoot, max_passes — is identical.
+//! Toggles [`AblationToggles::use_quadrant_proxy`] for the A leg
+//! (proxy) and unsets it for the B leg (real segment_map). Everything
+//! else — starting q, pass-0 encode, score band, max_overshoot,
+//! max_passes — is identical.
 //!
 //! Reads corpus PNG files from the filesystem (CLI args), runs both
 //! aggregators at multiple zensim targets, writes a per-image TSV plus
@@ -20,10 +21,8 @@
 //!     --max-passes 3 \
 //!     --out /mnt/v/output/zenwebp/zensim-ab/ab_2026-04-26.tsv
 //!
-//! NOTE: this binary uses `std::env::set_var` to toggle the
-//! `ZENWEBP_PHASE3_QUADRANT` env var between A and B legs. That call is
-//! `unsafe` in Rust 2024 (POSIX getenv races); this binary is
-//! single-threaded so it's sound. Confined to dev/ tooling.
+//! No environment variables are read or written: the toggle is a
+//! thread-local cell flipped via [`zenwebp::set_ablation_toggles`].
 
 use std::collections::BTreeMap;
 use std::env;
@@ -31,10 +30,12 @@ use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 
+use zenwebp::AblationToggles;
 use zenwebp::EncodeRequest;
 use zenwebp::LossyConfig;
 use zenwebp::PixelLayout;
 use zenwebp::ZensimTarget;
+use zenwebp::set_ablation_toggles;
 
 #[derive(Clone)]
 struct Cli {
@@ -412,11 +413,10 @@ fn run(
     method: u8,
     quadrant: bool,
 ) -> Outcome {
-    if quadrant {
-        env_set::set("ZENWEBP_PHASE3_QUADRANT", Some("1"));
-    } else {
-        env_set::set("ZENWEBP_PHASE3_QUADRANT", None);
-    }
+    set_ablation_toggles(AblationToggles {
+        use_quadrant_proxy: quadrant,
+        ..AblationToggles::default()
+    });
 
     let cfg = LossyConfig::new()
         .with_method(method)
@@ -434,19 +434,6 @@ fn run(
         passes: m.passes_used,
         bytes: b.len(),
         met: m.targets_met,
-    }
-}
-
-mod env_set {
-    pub fn set(key: &str, val: Option<&str>) {
-        // SAFETY: single-threaded driver binary; no other threads can
-        // observe stale env pointers. Only used by `dev/` tooling.
-        unsafe {
-            match val {
-                Some(v) => std::env::set_var(key, v),
-                None => std::env::remove_var(key),
-            }
-        }
     }
 }
 

--- a/dev/zensim_ablation.rs
+++ b/dev/zensim_ablation.rs
@@ -526,7 +526,7 @@ fn run(
     let cfg = LossyConfig::new()
         .with_method(method)
         .with_segments(4)
-        .with_target_zensim_target(
+        .with_target_zensim(
             ZensimTarget::new(target)
                 .with_max_overshoot(Some(max_overshoot))
                 .with_max_passes(max_passes),

--- a/dev/zensim_ablation.rs
+++ b/dev/zensim_ablation.rs
@@ -43,7 +43,9 @@ use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 
+use zenwebp::EncodeRequest;
 use zenwebp::LossyConfig;
+use zenwebp::PixelLayout;
 use zenwebp::ZensimTarget;
 
 #[derive(Clone)]
@@ -529,8 +531,8 @@ fn run(
                 .with_max_overshoot(Some(max_overshoot))
                 .with_max_passes(max_passes),
         );
-    let (b, m) = cfg
-        .encode_rgb_with_metrics(rgb, w, h)
+    let (b, m) = EncodeRequest::lossy(&cfg, rgb, PixelLayout::Rgb8, w, h)
+        .encode_with_metrics()
         .expect("encode failed");
     Outcome {
         score: m.achieved_score,

--- a/dev/zensim_ablation.rs
+++ b/dev/zensim_ablation.rs
@@ -193,6 +193,7 @@ fn reset_env() {
         "ZENWEBP_ABLATE_NO_MULTI_PASS_STATS",
         "ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS",
         "ZENWEBP_ABLATE_NO_SECANT",
+        "ZENWEBP_PHASE3_FINE_GAP",
     ];
     for k in &keys {
         env_set::set(k, None);
@@ -211,7 +212,12 @@ fn apply_variant(name: &str) {
             "noD" => env_set::set("ZENWEBP_ABLATE_NO_MULTI_PASS_STATS", Some("1")),
             "noE" => env_set::set("ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS", Some("1")),
             "noF" => env_set::set("ZENWEBP_ABLATE_NO_SECANT", Some("1")),
-            other => panic!("unknown variant token: {other} (valid: baseline,noA..noF)"),
+            // `alwaysOn` recovers the pre-fix net-negative always-on Phase 3
+            // (per-segment correction takes precedence over global-q secant
+            // even at large gaps). Used to A/B against the post-fix
+            // baseline.
+            "alwaysOn" => env_set::set("ZENWEBP_PHASE3_FINE_GAP", Some("1000")),
+            other => panic!("unknown variant token: {other} (valid: baseline,noA..noF,alwaysOn)"),
         }
     }
 }

--- a/dev/zensim_ablation.rs
+++ b/dev/zensim_ablation.rs
@@ -1,0 +1,594 @@
+//! Ablation harness — measure each chunk of the target_zensim PR
+//! independently against a real-world corpus.
+//!
+//! The full PR (commits aefc345..fac6fb5 on `feat/target-zensim`) ships:
+//!
+//!   - Chunk A: Phase 3 per-segment correction (~250 LOC + EncodeDiagnostics)
+//!   - Chunk B: real `segment_map` vs 2x2 quadrant proxy (~80 LOC plumbing)
+//!   - Chunk C: per-bucket starting-q calibration (~3 anchor tables + classifier)
+//!   - Chunk D: forced `multi_pass_stats=true` inside the loop (~0 LOC, 1 flag)
+//!   - Chunk E: Phase 2 fitted anchors (replaced hand-distilled values)
+//!   - Chunk F: secant step in pass 2+ (~20 LOC of state)
+//!
+//! This binary toggles each chunk off via env vars
+//! (`ZENWEBP_ABLATE_NO_PHASE3`, `ZENWEBP_ABLATE_NAIVE_Q`,
+//! `ZENWEBP_ABLATE_NO_MULTI_PASS_STATS`, `ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS`,
+//! `ZENWEBP_ABLATE_NO_SECANT`) and the existing `ZENWEBP_PHASE3_QUADRANT`
+//! for chunk B. It runs the same 76-image x 3-target sweep used in the
+//! original A/B (CID22 + gb82 + gb82-sc, targets {75, 80, 85},
+//! max_overshoot=1.5, max_passes=3, m4) for the BASELINE plus each
+//! variant, writes a per-image TSV, and prints a per-variant summary
+//! table to stdout.
+//!
+//! Output TSV format (one row per (variant, image, target)):
+//!   variant  corpus  image  width  height  target  passes  achieved
+//!   bytes  targets_met
+//!
+//! Single-threaded (env vars must be flipped between encodes).
+//!
+//! Usage:
+//!   zensim_ablation \
+//!     --corpus CID22=/path \
+//!     --corpus gb82=/path \
+//!     --corpus gb82-sc=/path \
+//!     --targets 75,80,85 \
+//!     --max-overshoot 1.5 \
+//!     --max-passes 3 \
+//!     --variants baseline,noA,noB,noC,noD,noE,noF \
+//!     --out /mnt/v/output/zenwebp/zensim-ab/ablations/run_2026-04-27.tsv
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+use zenwebp::LossyConfig;
+use zenwebp::ZensimTarget;
+
+#[derive(Clone)]
+struct Cli {
+    corpora: Vec<(String, PathBuf)>,
+    targets: Vec<f32>,
+    max_overshoot: f32,
+    max_passes: u8,
+    method: u8,
+    variants: Vec<String>,
+    out: Option<PathBuf>,
+    limit: Option<usize>,
+}
+
+fn parse_args() -> Cli {
+    let mut corpora: Vec<(String, PathBuf)> = Vec::new();
+    let mut targets: Vec<f32> = vec![80.0];
+    let mut max_overshoot = 1.5f32;
+    let mut max_passes = 3u8;
+    let mut method = 4u8;
+    let mut variants: Vec<String> = vec![
+        "baseline".into(),
+        "noA".into(),
+        "noB".into(),
+        "noC".into(),
+        "noD".into(),
+        "noE".into(),
+        "noF".into(),
+        "noA_noD".into(),
+    ];
+    let mut out: Option<PathBuf> = None;
+    let mut limit: Option<usize> = None;
+    let mut args = env::args().skip(1).collect::<Vec<_>>().into_iter();
+    while let Some(a) = args.next() {
+        match a.as_str() {
+            "--corpus" => {
+                let v = args.next().expect("--corpus needs name=path");
+                let (name, path) = v.split_once('=').expect("--corpus expects name=path");
+                corpora.push((name.to_string(), PathBuf::from(path)));
+            }
+            "--targets" => {
+                let v = args.next().expect("--targets needs CSV");
+                targets = v
+                    .split(',')
+                    .map(|s| s.trim().parse::<f32>().expect("bad --targets value"))
+                    .collect();
+            }
+            "--max-overshoot" => {
+                max_overshoot = args.next().unwrap().parse().unwrap();
+            }
+            "--max-passes" => {
+                max_passes = args.next().unwrap().parse().unwrap();
+            }
+            "--method" => {
+                method = args.next().unwrap().parse().unwrap();
+            }
+            "--variants" => {
+                let v = args.next().expect("--variants needs CSV");
+                variants = v.split(',').map(|s| s.trim().to_string()).collect();
+            }
+            "--out" => {
+                out = Some(PathBuf::from(args.next().unwrap()));
+            }
+            "--limit" => {
+                limit = Some(args.next().unwrap().parse().unwrap());
+            }
+            other => panic!("unknown arg: {other}"),
+        }
+    }
+    if corpora.is_empty() {
+        eprintln!(
+            "usage: --corpus name=/path [--corpus ...] [--targets 75,80,85] [--variants baseline,noA,noB,...] [--out /mnt/v/.../ablation.tsv]"
+        );
+        std::process::exit(2);
+    }
+    Cli {
+        corpora,
+        targets,
+        max_overshoot,
+        max_passes,
+        method,
+        variants,
+        out,
+        limit,
+    }
+}
+
+fn list_pngs(dir: &PathBuf) -> Vec<PathBuf> {
+    let mut v: Vec<PathBuf> = fs::read_dir(dir)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.is_file() && p.extension().is_some_and(|e| e == "png" || e == "PNG"))
+        .collect();
+    v.sort();
+    v
+}
+
+#[derive(Default, Clone)]
+struct Agg {
+    n: u32,
+    passes_sum: u32,
+    dist_sum: f64,
+    met: u32,
+    undershoot: u32,
+    bytes: Vec<u64>,
+    // Head-to-head against baseline (not populated for baseline itself).
+    // wins = variant strictly better |achieved-target| (margin >= 0.05)
+    // losses = baseline strictly better; ties = within 0.05.
+    wins_vs_base: u32,
+    losses_vs_base: u32,
+    ties_vs_base: u32,
+}
+
+fn fold(into: &mut Agg, src: &Agg) {
+    into.n += src.n;
+    into.passes_sum += src.passes_sum;
+    into.dist_sum += src.dist_sum;
+    into.met += src.met;
+    into.undershoot += src.undershoot;
+    into.bytes.extend(src.bytes.iter().copied());
+    into.wins_vs_base += src.wins_vs_base;
+    into.losses_vs_base += src.losses_vs_base;
+    into.ties_vs_base += src.ties_vs_base;
+}
+
+fn median_u64(v: &[u64]) -> u64 {
+    if v.is_empty() {
+        return 0;
+    }
+    let mut s: Vec<u64> = v.to_vec();
+    s.sort_unstable();
+    if s.len() % 2 == 1 {
+        s[s.len() / 2]
+    } else {
+        (s[s.len() / 2 - 1] + s[s.len() / 2]) / 2
+    }
+}
+
+/// Reset all ablation env vars to off.
+fn reset_env() {
+    let keys = [
+        "ZENWEBP_PHASE3_QUADRANT",
+        "ZENWEBP_ABLATE_NO_PHASE3",
+        "ZENWEBP_ABLATE_NAIVE_Q",
+        "ZENWEBP_ABLATE_NO_MULTI_PASS_STATS",
+        "ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS",
+        "ZENWEBP_ABLATE_NO_SECANT",
+    ];
+    for k in &keys {
+        env_set::set(k, None);
+    }
+}
+
+/// Apply env-var state for a named variant.
+fn apply_variant(name: &str) {
+    reset_env();
+    for tok in name.split('_') {
+        match tok {
+            "baseline" => {} // all defaults
+            "noA" => env_set::set("ZENWEBP_ABLATE_NO_PHASE3", Some("1")),
+            "noB" => env_set::set("ZENWEBP_PHASE3_QUADRANT", Some("1")),
+            "noC" => env_set::set("ZENWEBP_ABLATE_NAIVE_Q", Some("1")),
+            "noD" => env_set::set("ZENWEBP_ABLATE_NO_MULTI_PASS_STATS", Some("1")),
+            "noE" => env_set::set("ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS", Some("1")),
+            "noF" => env_set::set("ZENWEBP_ABLATE_NO_SECANT", Some("1")),
+            other => panic!("unknown variant token: {other} (valid: baseline,noA..noF)"),
+        }
+    }
+}
+
+fn main() {
+    let cli = parse_args();
+
+    eprintln!(
+        "ablation sweep (method={} max_overshoot={} max_passes={})",
+        cli.method, cli.max_overshoot, cli.max_passes
+    );
+    eprintln!("targets: {:?}", cli.targets);
+    eprintln!("variants: {:?}", cli.variants);
+    eprintln!();
+
+    // Prep TSV output if requested.
+    let mut tsv: Option<std::io::BufWriter<fs::File>> = match &cli.out {
+        Some(p) => {
+            if let Some(parent) = p.parent() {
+                let _ = fs::create_dir_all(parent);
+            }
+            let f = fs::File::create(p).expect("cannot create --out file");
+            let mut w = std::io::BufWriter::new(f);
+            writeln!(
+                w,
+                "variant\tcorpus\timage\twidth\theight\ttarget\tmax_overshoot\tmax_passes\tmethod\t\
+                 passes\tachieved\tbytes\ttargets_met"
+            )
+            .unwrap();
+            Some(w)
+        }
+        None => None,
+    };
+
+    // Load all images up-front so we don't redecode per variant.
+    eprintln!("loading corpus...");
+    let mut images: Vec<LoadedImage> = Vec::new();
+    for (corpus_name, corpus_path) in &cli.corpora {
+        let mut paths = list_pngs(corpus_path);
+        if let Some(lim) = cli.limit {
+            paths.truncate(lim);
+        }
+        eprintln!(
+            "  corpus {corpus_name} ({} images): {}",
+            paths.len(),
+            corpus_path.display()
+        );
+        for path in paths {
+            let img_name = path.file_name().unwrap().to_string_lossy().to_string();
+            match decode_png_rgb(&path) {
+                Some((rgb, w, h)) => images.push(LoadedImage {
+                    corpus: corpus_name.clone(),
+                    name: img_name,
+                    rgb,
+                    w,
+                    h,
+                }),
+                None => eprintln!("    skip: cannot decode {}", path.display()),
+            }
+        }
+    }
+    eprintln!("loaded {} images.", images.len());
+    eprintln!();
+
+    // For each (variant, image, target), record the outcome.
+    // Variant 0 is the baseline; we use it for head-to-head wins.
+    let mut variant_aggs: BTreeMap<(String, String, u32), Agg> = BTreeMap::new();
+    let mut variant_outcomes: BTreeMap<String, Vec<Outcome>> = BTreeMap::new();
+
+    let cells = images.len() * cli.targets.len();
+    for variant in &cli.variants {
+        eprintln!("=== variant: {variant} ({cells} cells) ===");
+        apply_variant(variant);
+        let t0 = std::time::Instant::now();
+        let mut outcomes: Vec<Outcome> = Vec::with_capacity(cells);
+        for img in &images {
+            for &target in &cli.targets {
+                let out = run(
+                    &img.rgb,
+                    img.w,
+                    img.h,
+                    target,
+                    cli.max_overshoot,
+                    cli.max_passes,
+                    cli.method,
+                );
+
+                if let Some(out_w) = tsv.as_mut() {
+                    writeln!(
+                        out_w,
+                        "{variant}\t{corpus}\t{name}\t{wid}\t{hgt}\t{tgt:.2}\t{mo:.2}\t{mp}\t{me}\t\
+                         {p}\t{a:.4}\t{b}\t{m}",
+                        variant = variant,
+                        corpus = img.corpus,
+                        name = img.name,
+                        wid = img.w,
+                        hgt = img.h,
+                        tgt = target,
+                        mo = cli.max_overshoot,
+                        mp = cli.max_passes,
+                        me = cli.method,
+                        p = out.passes,
+                        a = out.score,
+                        b = out.bytes,
+                        m = u8::from(out.met),
+                    )
+                    .unwrap();
+                }
+
+                let key = (variant.clone(), img.corpus.clone(), (target * 100.0) as u32);
+                let a = variant_aggs.entry(key).or_default();
+                a.n += 1;
+                a.passes_sum += u32::from(out.passes);
+                a.dist_sum += f64::from((out.score - target).abs());
+                if out.met {
+                    a.met += 1;
+                }
+                if out.score < target {
+                    a.undershoot += 1;
+                }
+                a.bytes.push(out.bytes as u64);
+
+                outcomes.push(out);
+                eprint!(".");
+            }
+        }
+        eprintln!();
+        eprintln!(
+            "  variant {variant}: {} cells in {:.1}s",
+            outcomes.len(),
+            t0.elapsed().as_secs_f32()
+        );
+        variant_outcomes.insert(variant.clone(), outcomes);
+    }
+
+    // Compute head-to-head vs baseline for each non-baseline variant.
+    if let Some(base_outs) = variant_outcomes.get("baseline") {
+        for variant in cli.variants.iter() {
+            if variant == "baseline" {
+                continue;
+            }
+            let v_outs = match variant_outcomes.get(variant) {
+                Some(v) => v,
+                None => continue,
+            };
+            let mut idx = 0usize;
+            for img in &images {
+                for &target in &cli.targets {
+                    let bo = &base_outs[idx];
+                    let vo = &v_outs[idx];
+                    let db = (bo.score - target).abs();
+                    let dv = (vo.score - target).abs();
+                    let key = (variant.clone(), img.corpus.clone(), (target * 100.0) as u32);
+                    let a = variant_aggs.get_mut(&key).unwrap();
+                    if (dv - db).abs() < 0.05 {
+                        a.ties_vs_base += 1;
+                    } else if dv < db {
+                        a.wins_vs_base += 1;
+                    } else {
+                        a.losses_vs_base += 1;
+                    }
+                    idx += 1;
+                }
+            }
+        }
+    }
+
+    if let Some(mut out) = tsv {
+        let _ = out.flush();
+    }
+
+    // Print summary table.
+    println!();
+    println!("=== summary by (variant, corpus) [aggregated across targets] ===");
+    println!(
+        "{:14} {:10} {:>4} | {:>5} | {:>7} | {:>9} | {:>5} | {:>9} | win/loss/tie vs base",
+        "variant", "corpus", "n", "passes", "|d|", "met", "und", "med-bytes"
+    );
+    let mut by_variant_corpus: BTreeMap<(String, String), Agg> = BTreeMap::new();
+    let mut by_variant: BTreeMap<String, Agg> = BTreeMap::new();
+    let mut by_variant_target: BTreeMap<(String, u32), Agg> = BTreeMap::new();
+    for ((variant, corpus, target100), a) in &variant_aggs {
+        fold(
+            by_variant_corpus
+                .entry((variant.clone(), corpus.clone()))
+                .or_default(),
+            a,
+        );
+        fold(by_variant.entry(variant.clone()).or_default(), a);
+        fold(
+            by_variant_target
+                .entry((variant.clone(), *target100))
+                .or_default(),
+            a,
+        );
+    }
+    for ((variant, corpus), a) in &by_variant_corpus {
+        if a.n == 0 {
+            continue;
+        }
+        let n = a.n as f32;
+        println!(
+            "{:14} {:10} {:>4} | {:>5.2} | {:>7.3} | {:>3}/{:<3}  | {:>5} | {:>9} | {}/{}/{}",
+            variant,
+            corpus,
+            a.n,
+            a.passes_sum as f32 / n,
+            a.dist_sum / a.n as f64,
+            a.met,
+            a.n,
+            a.undershoot,
+            median_u64(&a.bytes),
+            a.wins_vs_base,
+            a.losses_vs_base,
+            a.ties_vs_base,
+        );
+    }
+
+    println!();
+    println!("=== summary by (variant, target) [aggregated across corpora] ===");
+    println!(
+        "{:14} {:>6} {:>4} | {:>5} | {:>7} | {:>9} | {:>5} | {:>9} | win/loss/tie vs base",
+        "variant", "target", "n", "passes", "|d|", "met", "und", "med-bytes"
+    );
+    for ((variant, t100), a) in &by_variant_target {
+        if a.n == 0 {
+            continue;
+        }
+        let n = a.n as f32;
+        println!(
+            "{:14} {:>6.2} {:>4} | {:>5.2} | {:>7.3} | {:>3}/{:<3}  | {:>5} | {:>9} | {}/{}/{}",
+            variant,
+            *t100 as f32 / 100.0,
+            a.n,
+            a.passes_sum as f32 / n,
+            a.dist_sum / a.n as f64,
+            a.met,
+            a.n,
+            a.undershoot,
+            median_u64(&a.bytes),
+            a.wins_vs_base,
+            a.losses_vs_base,
+            a.ties_vs_base,
+        );
+    }
+
+    println!();
+    println!("=== aggregate by variant (all corpora x all targets) ===");
+    println!(
+        "{:14} {:>4} | {:>5} | {:>7} | {:>9} | {:>5} | {:>9} | win/loss/tie vs base",
+        "variant", "n", "passes", "|d|", "met", "und", "med-bytes"
+    );
+    for variant in cli.variants.iter() {
+        let a = match by_variant.get(variant) {
+            Some(a) => a,
+            None => continue,
+        };
+        if a.n == 0 {
+            continue;
+        }
+        let n = a.n as f32;
+        println!(
+            "{:14} {:>4} | {:>5.2} | {:>7.3} | {:>3}/{:<3}  | {:>5} | {:>9} | {}/{}/{}",
+            variant,
+            a.n,
+            a.passes_sum as f32 / n,
+            a.dist_sum / a.n as f64,
+            a.met,
+            a.n,
+            a.undershoot,
+            median_u64(&a.bytes),
+            a.wins_vs_base,
+            a.losses_vs_base,
+            a.ties_vs_base,
+        );
+    }
+}
+
+struct LoadedImage {
+    corpus: String,
+    name: String,
+    rgb: Vec<u8>,
+    w: u32,
+    h: u32,
+}
+
+#[derive(Clone, Copy)]
+struct Outcome {
+    score: f32,
+    passes: u8,
+    bytes: usize,
+    met: bool,
+}
+
+fn run(
+    rgb: &[u8],
+    w: u32,
+    h: u32,
+    target: f32,
+    max_overshoot: f32,
+    max_passes: u8,
+    method: u8,
+) -> Outcome {
+    let cfg = LossyConfig::new()
+        .with_method(method)
+        .with_segments(4)
+        .with_target_zensim_target(
+            ZensimTarget::new(target)
+                .with_max_overshoot(Some(max_overshoot))
+                .with_max_passes(max_passes),
+        );
+    let (b, m) = cfg
+        .encode_rgb_with_metrics(rgb, w, h)
+        .expect("encode failed");
+    Outcome {
+        score: m.achieved_score,
+        passes: m.passes_used,
+        bytes: b.len(),
+        met: m.targets_met,
+    }
+}
+
+mod env_set {
+    pub fn set(key: &str, val: Option<&str>) {
+        // SAFETY: single-threaded driver binary; no other threads can
+        // observe stale env pointers. Only used by `dev/` tooling.
+        unsafe {
+            match val {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+}
+
+fn decode_png_rgb(path: &PathBuf) -> Option<(Vec<u8>, u32, u32)> {
+    let bytes = fs::read(path).ok()?;
+    let cur = std::io::Cursor::new(bytes);
+    let mut decoder = png::Decoder::new(cur);
+    decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
+    let mut reader = decoder.read_info().ok()?;
+    let info = reader.info();
+    let w = info.width;
+    let h = info.height;
+    let color = info.color_type;
+    let bytes_per_pixel = match color {
+        png::ColorType::Rgb => 3,
+        png::ColorType::Rgba => 4,
+        png::ColorType::Grayscale => 1,
+        png::ColorType::GrayscaleAlpha => 2,
+        png::ColorType::Indexed => 3,
+    };
+    let mut buf = vec![0u8; (w as usize * h as usize) * bytes_per_pixel];
+    reader.next_frame(&mut buf).ok()?;
+    let rgb = match color {
+        png::ColorType::Rgb | png::ColorType::Indexed => buf,
+        png::ColorType::Rgba => {
+            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            for px in buf.chunks_exact(4) {
+                out.extend_from_slice(&[px[0], px[1], px[2]]);
+            }
+            out
+        }
+        png::ColorType::Grayscale => {
+            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            for &g in &buf {
+                out.extend_from_slice(&[g, g, g]);
+            }
+            out
+        }
+        png::ColorType::GrayscaleAlpha => {
+            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            for px in buf.chunks_exact(2) {
+                out.extend_from_slice(&[px[0], px[0], px[0]]);
+            }
+            out
+        }
+    };
+    Some((rgb, w, h))
+}

--- a/dev/zensim_ablation.rs
+++ b/dev/zensim_ablation.rs
@@ -10,11 +10,10 @@
 //!   - Chunk E: Phase 2 fitted anchors (replaced hand-distilled values)
 //!   - Chunk F: secant step in pass 2+ (~20 LOC of state)
 //!
-//! This binary toggles each chunk off via env vars
-//! (`ZENWEBP_ABLATE_NO_PHASE3`, `ZENWEBP_ABLATE_NAIVE_Q`,
-//! `ZENWEBP_ABLATE_NO_MULTI_PASS_STATS`, `ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS`,
-//! `ZENWEBP_ABLATE_NO_SECANT`) and the existing `ZENWEBP_PHASE3_QUADRANT`
-//! for chunk B. It runs the same 76-image x 3-target sweep used in the
+//! This binary toggles each chunk off by calling
+//! [`zenwebp::set_ablation_toggles`] (gated on the unstable `ablation`
+//! Cargo feature) — the toggles are thread-local and require no
+//! environment variables. It runs the same 76-image x 3-target sweep used in the
 //! original A/B (CID22 + gb82 + gb82-sc, targets {75, 80, 85},
 //! max_overshoot=1.5, max_passes=3, m4) for the BASELINE plus each
 //! variant, writes a per-image TSV, and prints a per-variant summary
@@ -24,7 +23,7 @@
 //!   variant  corpus  image  width  height  target  passes  achieved
 //!   bytes  targets_met
 //!
-//! Single-threaded (env vars must be flipped between encodes).
+//! Single-threaded (toggles must be flipped between encodes).
 //!
 //! Usage:
 //!   zensim_ablation \
@@ -43,10 +42,12 @@ use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 
+use zenwebp::AblationToggles;
 use zenwebp::EncodeRequest;
 use zenwebp::LossyConfig;
 use zenwebp::PixelLayout;
 use zenwebp::ZensimTarget;
+use zenwebp::set_ablation_toggles;
 
 #[derive(Clone)]
 struct Cli {
@@ -186,42 +187,27 @@ fn median_u64(v: &[u64]) -> u64 {
     }
 }
 
-/// Reset all ablation env vars to off.
-fn reset_env() {
-    let keys = [
-        "ZENWEBP_PHASE3_QUADRANT",
-        "ZENWEBP_ABLATE_NO_PHASE3",
-        "ZENWEBP_ABLATE_NAIVE_Q",
-        "ZENWEBP_ABLATE_NO_MULTI_PASS_STATS",
-        "ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS",
-        "ZENWEBP_ABLATE_NO_SECANT",
-        "ZENWEBP_PHASE3_FINE_GAP",
-    ];
-    for k in &keys {
-        env_set::set(k, None);
-    }
-}
-
-/// Apply env-var state for a named variant.
+/// Apply thread-local ablation state for a named variant.
 fn apply_variant(name: &str) {
-    reset_env();
+    let mut t = AblationToggles::default();
     for tok in name.split('_') {
         match tok {
             "baseline" => {} // all defaults
-            "noA" => env_set::set("ZENWEBP_ABLATE_NO_PHASE3", Some("1")),
-            "noB" => env_set::set("ZENWEBP_PHASE3_QUADRANT", Some("1")),
-            "noC" => env_set::set("ZENWEBP_ABLATE_NAIVE_Q", Some("1")),
-            "noD" => env_set::set("ZENWEBP_ABLATE_NO_MULTI_PASS_STATS", Some("1")),
-            "noE" => env_set::set("ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS", Some("1")),
-            "noF" => env_set::set("ZENWEBP_ABLATE_NO_SECANT", Some("1")),
+            "noA" => t.disable_phase3 = true,
+            "noB" => t.use_quadrant_proxy = true,
+            "noC" => t.naive_starting_q = true,
+            "noD" => t.no_multi_pass_stats = true,
+            "noE" => t.pre_phase2_anchors = true,
+            "noF" => t.no_secant = true,
             // `alwaysOn` recovers the pre-fix net-negative always-on Phase 3
             // (per-segment correction takes precedence over global-q secant
             // even at large gaps). Used to A/B against the post-fix
             // baseline.
-            "alwaysOn" => env_set::set("ZENWEBP_PHASE3_FINE_GAP", Some("1000")),
+            "alwaysOn" => t.phase3_fine_gap = Some(1000.0),
             other => panic!("unknown variant token: {other} (valid: baseline,noA..noF,alwaysOn)"),
         }
     }
+    set_ablation_toggles(t);
 }
 
 fn main() {
@@ -539,19 +525,6 @@ fn run(
         passes: m.passes_used,
         bytes: b.len(),
         met: m.targets_met,
-    }
-}
-
-mod env_set {
-    pub fn set(key: &str, val: Option<&str>) {
-        // SAFETY: single-threaded driver binary; no other threads can
-        // observe stale env pointers. Only used by `dev/` tooling.
-        unsafe {
-            match val {
-                Some(v) => std::env::set_var(key, v),
-                None => std::env::remove_var(key),
-            }
-        }
     }
 }
 

--- a/dev/zensim_calibrate.rs
+++ b/dev/zensim_calibrate.rs
@@ -1,0 +1,364 @@
+//! Per-bucket starting-q calibration for `target_zensim`.
+//!
+//! Sweeps a corpus at a small ladder of VP8 quality values, decodes each
+//! result, measures zensim vs the source, and per (content-bucket,
+//! target-zensim) cell emits the median quality value that meets the
+//! target. The output is an anchor table (TSV + Rust const block) ready
+//! to paste into `src/encoder/zensim_target.rs`.
+//!
+//! Usage:
+//!   cargo run --release --features target-zensim --example zensim_calibrate -- \
+//!       <corpus_dir> [output_dir]
+//!
+//! Defaults: corpus=`~/work/codec-corpus/CID22/CID22-512/validation`,
+//! output=`/mnt/v/output/zenwebp/zensim-calibrate`.
+//!
+//! Methodology:
+//!   1. For each PNG: decode RGB, run zenwebp's `Preset::Auto` content
+//!      classifier to determine the bucket (Photo / Drawing / Icon).
+//!   2. Encode at q ∈ {30, 40, 50, 60, 65, 70, 75, 80, 85, 90, 92, 94,
+//!      96, 98, 100} via the standard non-target-zensim path. Decode
+//!      back to RGB, measure zensim vs source.
+//!   3. For each target ∈ {60, 70, 75, 80, 85, 90, 95}, find the
+//!      smallest q whose decoded zensim meets target. That's the
+//!      "fitted q" for this image at this target.
+//!   4. Median-aggregate fitted-q values per bucket → anchor table.
+//!   5. Print as Rust const blocks ready to paste.
+
+#![forbid(unsafe_code)]
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+use zenwebp::encoder::analysis::{ImageContentType, classify_image_type};
+use zenwebp::{EncodeRequest, LossyConfig, PixelLayout};
+
+const Q_LADDER: &[u8] = &[
+    30, 40, 50, 60, 65, 70, 75, 80, 85, 88, 90, 92, 94, 96, 98, 100,
+];
+const TARGETS: &[f32] = &[60.0, 70.0, 75.0, 80.0, 85.0, 90.0, 95.0];
+
+fn main() {
+    let corpus_dir = env::args().nth(1).unwrap_or_else(|| {
+        // Default corpus path.
+        let home = env::var("HOME").expect("HOME not set");
+        format!("{home}/work/codec-corpus/CID22/CID22-512/validation")
+    });
+    let output_dir = env::args()
+        .nth(2)
+        .unwrap_or_else(|| "/mnt/v/output/zenwebp/zensim-calibrate".to_string());
+
+    fs::create_dir_all(&output_dir).expect("create output dir");
+    eprintln!("corpus: {corpus_dir}");
+    eprintln!("output: {output_dir}");
+
+    let mut paths: Vec<PathBuf> = fs::read_dir(&corpus_dir)
+        .expect("read corpus dir")
+        .filter_map(|e| {
+            let p = e.ok()?.path();
+            (p.extension().is_some_and(|e| e == "png" || e == "PNG")).then_some(p)
+        })
+        .collect();
+    paths.sort();
+
+    // Cap at 20 images for the fit (issue #47 spec) — deterministic stride.
+    let max_images = 20;
+    if paths.len() > max_images {
+        let stride = paths.len() / max_images;
+        paths = paths
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| i % stride == 0)
+            .take(max_images)
+            .map(|(_, p)| p.clone())
+            .collect();
+    }
+    eprintln!("processing {} images", paths.len());
+
+    let z = zensim::Zensim::new(zensim::ZensimProfile::latest());
+
+    // (bucket, target) → Vec<fitted_q>
+    let mut fits: BTreeMap<(BucketKey, OrderedF32), Vec<f32>> = BTreeMap::new();
+
+    let tsv_path = PathBuf::from(&output_dir).join("zensim_calibrate_raw.tsv");
+    let mut tsv = fs::File::create(&tsv_path).expect("create tsv");
+    use std::io::Write;
+    writeln!(tsv, "file\tw\th\tbucket\tq\tbytes\tscore").unwrap();
+
+    for (i, path) in paths.iter().enumerate() {
+        eprintln!(
+            "[{}/{}] {}",
+            i + 1,
+            paths.len(),
+            path.file_name().unwrap().to_string_lossy()
+        );
+        let (rgb, w, h) = match decode_png_rgb(path) {
+            Some(t) => t,
+            None => continue,
+        };
+        if w < 32 || h < 32 {
+            continue;
+        }
+        let bucket = classify_via_y(&rgb, w, h);
+
+        let pre = match build_pre(&z, &rgb, w, h) {
+            Some(p) => p,
+            None => continue,
+        };
+
+        // Per-q encode + measure.
+        let mut probes: Vec<(u8, f32)> = Vec::with_capacity(Q_LADDER.len());
+        for &q in Q_LADDER {
+            let cfg = LossyConfig::new().with_quality(q as f32).with_method(4);
+            let req = EncodeRequest::lossy(&cfg, &rgb, PixelLayout::Rgb8, w, h);
+            let webp = match req.encode() {
+                Ok(b) => b,
+                Err(_) => continue,
+            };
+            let (rgb_dec, w2, h2) = match zenwebp::oneshot::decode_rgb(&webp) {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            if w2 != w || h2 != h {
+                continue;
+            }
+            let n = (w * h * 3) as usize;
+            let dec_chunks: Vec<[u8; 3]> = rgb_dec[..n]
+                .chunks_exact(3)
+                .map(|p| [p[0], p[1], p[2]])
+                .collect();
+            let dec_slice = zensim::RgbSlice::new(&dec_chunks, w as usize, h as usize);
+            let res = match z.compute_with_ref(&pre, &dec_slice) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+            let score = res.score() as f32;
+            probes.push((q, score));
+            writeln!(
+                tsv,
+                "{}\t{}\t{}\t{:?}\t{}\t{}\t{:.3}",
+                path.file_name().unwrap().to_string_lossy(),
+                w,
+                h,
+                bucket,
+                q,
+                webp.len(),
+                score,
+            )
+            .unwrap();
+        }
+        // For each target, find the smallest q whose score >= target.
+        for &t in TARGETS {
+            let fitted = probes.iter().find(|(_, s)| *s >= t).map(|(q, _)| *q as f32);
+            if let Some(q) = fitted {
+                fits.entry((BucketKey::from(bucket), OrderedF32(t)))
+                    .or_default()
+                    .push(q);
+            } else {
+                // Target unreachable — record as 100 (the q ceiling) so the
+                // anchor still maps to a sensible starting point.
+                fits.entry((BucketKey::from(bucket), OrderedF32(t)))
+                    .or_default()
+                    .push(100.0);
+            }
+        }
+    }
+
+    drop(tsv);
+
+    // Aggregate: per (bucket, target) → median, p25, p75, n.
+    eprintln!();
+    eprintln!("================================================================");
+    eprintln!("Per-bucket anchor table (median fitted-q per target_zensim)");
+    eprintln!("================================================================");
+    let summary_path = PathBuf::from(&output_dir).join("zensim_calibrate_summary.tsv");
+    let mut sum = fs::File::create(&summary_path).expect("create summary");
+    writeln!(sum, "bucket\ttarget\tmedian_q\tp25_q\tp75_q\tn").unwrap();
+
+    let mut by_bucket: BTreeMap<BucketKey, Vec<(f32, f32)>> = BTreeMap::new();
+    for ((b, t), qs) in &fits {
+        let med = median(qs.clone());
+        let p25 = percentile(qs.clone(), 0.25);
+        let p75 = percentile(qs.clone(), 0.75);
+        eprintln!(
+            "  {:<10} target={:>5.1}  median_q={:>5.1}  p25={:>5.1}  p75={:>5.1}  n={}",
+            format!("{:?}", b),
+            t.0,
+            med,
+            p25,
+            p75,
+            qs.len()
+        );
+        writeln!(
+            sum,
+            "{:?}\t{}\t{}\t{}\t{}\t{}",
+            b,
+            t.0,
+            med,
+            p25,
+            p75,
+            qs.len()
+        )
+        .unwrap();
+        by_bucket.entry(*b).or_default().push((t.0, med));
+    }
+    drop(sum);
+
+    eprintln!();
+    eprintln!("================================================================");
+    eprintln!("Rust const block (paste into zensim_target.rs):");
+    eprintln!("================================================================");
+    for (bucket, mut anchors) in by_bucket {
+        anchors.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        eprintln!("    const {}: &[(f32, f32)] = &[", bucket.const_name());
+        for (t, q) in anchors {
+            eprintln!("        ({:.1}, {:.1}),", t, q);
+        }
+        eprintln!("    ];");
+    }
+    eprintln!();
+    eprintln!("Raw  TSV: {}", tsv_path.display());
+    eprintln!("Summary : {}", summary_path.display());
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum BucketKey {
+    Photo,
+    Drawing,
+    Icon,
+}
+
+impl BucketKey {
+    fn from(c: ImageContentType) -> Self {
+        match c {
+            ImageContentType::Photo => Self::Photo,
+            ImageContentType::Icon => Self::Icon,
+            // Drawing, Text, and any future variants → Drawing.
+            _ => Self::Drawing,
+        }
+    }
+    fn const_name(self) -> &'static str {
+        match self {
+            Self::Photo => "PHOTO",
+            Self::Drawing => "DRAWING",
+            Self::Icon => "ICON",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct OrderedF32(f32);
+impl PartialEq for OrderedF32 {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.to_bits() == other.0.to_bits()
+    }
+}
+impl Eq for OrderedF32 {}
+impl PartialOrd for OrderedF32 {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for OrderedF32 {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0
+            .partial_cmp(&other.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    }
+}
+
+fn decode_png_rgb(path: &PathBuf) -> Option<(Vec<u8>, u32, u32)> {
+    let bytes = fs::read(path).ok()?;
+    let cur = std::io::Cursor::new(bytes);
+    let mut decoder = png::Decoder::new(cur);
+    decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
+    let mut reader = decoder.read_info().ok()?;
+    let info = reader.info();
+    let w = info.width;
+    let h = info.height;
+    let color = info.color_type;
+    let bytes_per_pixel = match color {
+        png::ColorType::Rgb => 3,
+        png::ColorType::Rgba => 4,
+        png::ColorType::Grayscale => 1,
+        png::ColorType::GrayscaleAlpha => 2,
+        png::ColorType::Indexed => 3,
+    };
+    let mut buf = vec![0u8; (w as usize * h as usize) * bytes_per_pixel];
+    reader.next_frame(&mut buf).ok()?;
+    let rgb = match color {
+        png::ColorType::Rgb | png::ColorType::Indexed => buf,
+        png::ColorType::Rgba => {
+            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            for px in buf.chunks_exact(4) {
+                out.extend_from_slice(&[px[0], px[1], px[2]]);
+            }
+            out
+        }
+        png::ColorType::Grayscale => {
+            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            for &g in &buf {
+                out.extend_from_slice(&[g, g, g]);
+            }
+            out
+        }
+        png::ColorType::GrayscaleAlpha => {
+            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            for px in buf.chunks_exact(2) {
+                out.extend_from_slice(&[px[0], px[0], px[0]]);
+            }
+            out
+        }
+    };
+    Some((rgb, w, h))
+}
+
+fn classify_via_y(rgb: &[u8], w: u32, h: u32) -> ImageContentType {
+    let w = w as usize;
+    let h = h as usize;
+    let mut y_plane: Vec<u8> = Vec::with_capacity(w * h);
+    let mut hist = [0u32; 256];
+    for px in rgb.chunks_exact(3) {
+        let y =
+            ((u32::from(px[0]) * 76 + u32::from(px[1]) * 150 + u32::from(px[2]) * 30) >> 8) as u8;
+        y_plane.push(y);
+        hist[y as usize] += 1;
+    }
+    classify_image_type(&y_plane, w, h, w, &hist)
+}
+
+fn build_pre(
+    z: &zensim::Zensim,
+    rgb: &[u8],
+    w: u32,
+    h: u32,
+) -> Option<zensim::PrecomputedReference> {
+    let chunks: Vec<[u8; 3]> = rgb[..(w as usize * h as usize * 3)]
+        .chunks_exact(3)
+        .map(|p| [p[0], p[1], p[2]])
+        .collect();
+    let slice = zensim::RgbSlice::new(&chunks, w as usize, h as usize);
+    z.precompute_reference(&slice).ok()
+}
+
+fn median(mut v: Vec<f32>) -> f32 {
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    if v.is_empty() {
+        0.0
+    } else if v.len() % 2 == 1 {
+        v[v.len() / 2]
+    } else {
+        (v[v.len() / 2 - 1] + v[v.len() / 2]) / 2.0
+    }
+}
+
+fn percentile(mut v: Vec<f32>, p: f32) -> f32 {
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    if v.is_empty() {
+        return 0.0;
+    }
+    let idx = ((v.len() as f32 - 1.0) * p).round() as usize;
+    v[idx.min(v.len() - 1)]
+}

--- a/dev/zensim_convergence_eval.rs
+++ b/dev/zensim_convergence_eval.rs
@@ -7,7 +7,7 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
-use zenwebp::{LossyConfig, ZensimTarget};
+use zenwebp::{EncodeRequest, LossyConfig, PixelLayout, ZensimTarget};
 
 fn main() {
     let corpus_dir = env::args().nth(1).unwrap_or_else(|| {
@@ -63,7 +63,8 @@ fn main() {
                 .with_max_overshoot(Some(1.5))
                 .with_max_passes(max_passes),
         );
-        let result = cfg.encode_rgb_with_metrics(&rgb, w, h);
+        let result =
+            EncodeRequest::lossy(&cfg, &rgb, PixelLayout::Rgb8, w, h).encode_with_metrics();
         match result {
             Ok((b, m)) => {
                 eprintln!(

--- a/dev/zensim_convergence_eval.rs
+++ b/dev/zensim_convergence_eval.rs
@@ -58,7 +58,7 @@ fn main() {
         if w < 32 || h < 32 {
             continue;
         }
-        let cfg = LossyConfig::new().with_method(4).with_target_zensim_target(
+        let cfg = LossyConfig::new().with_method(4).with_target_zensim(
             ZensimTarget::new(target_v)
                 .with_max_overshoot(Some(1.5))
                 .with_max_passes(max_passes),

--- a/dev/zensim_convergence_eval.rs
+++ b/dev/zensim_convergence_eval.rs
@@ -1,0 +1,182 @@
+//! Run target_zensim against a corpus and report convergence stats.
+//! Used to populate the PR description with real numbers.
+
+#![forbid(unsafe_code)]
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+use zenwebp::{LossyConfig, ZensimTarget};
+
+fn main() {
+    let corpus_dir = env::args().nth(1).unwrap_or_else(|| {
+        let home = env::var("HOME").expect("HOME not set");
+        format!("{home}/work/codec-corpus/CID22/CID22-512/validation")
+    });
+    let target_str = env::args().nth(2).unwrap_or_else(|| "80".to_string());
+    let target_v: f32 = target_str.parse().unwrap_or(80.0);
+    let max_passes: u8 = env::args().nth(3).and_then(|s| s.parse().ok()).unwrap_or(2);
+
+    let mut paths: Vec<PathBuf> = fs::read_dir(&corpus_dir)
+        .expect("read corpus dir")
+        .filter_map(|e| {
+            let p = e.ok()?.path();
+            (p.extension().is_some_and(|e| e == "png" || e == "PNG")).then_some(p)
+        })
+        .collect();
+    paths.sort();
+    if paths.len() > 20 {
+        let stride = paths.len() / 20;
+        paths = paths
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| i % stride == 0)
+            .take(20)
+            .map(|(_, p)| p.clone())
+            .collect();
+    }
+
+    let mut passes_used: Vec<u8> = Vec::new();
+    let mut achieved: Vec<f32> = Vec::new();
+    let mut bytes: Vec<usize> = Vec::new();
+    let mut targets_met = 0;
+    let mut undershoot_count = 0;
+    let mut overshoot_count = 0;
+
+    eprintln!(
+        "target={} max_passes={} corpus={}",
+        target_v, max_passes, corpus_dir
+    );
+    eprintln!("file\twidth\theight\tachieved\tpasses\tbytes");
+
+    for path in &paths {
+        let (rgb, w, h) = match decode_png_rgb(path) {
+            Some(t) => t,
+            None => continue,
+        };
+        if w < 32 || h < 32 {
+            continue;
+        }
+        let cfg = LossyConfig::new().with_method(4).with_target_zensim_target(
+            ZensimTarget::new(target_v)
+                .with_max_overshoot(Some(1.5))
+                .with_max_passes(max_passes),
+        );
+        let result = cfg.encode_rgb_with_metrics(&rgb, w, h);
+        match result {
+            Ok((b, m)) => {
+                eprintln!(
+                    "{}\t{}\t{}\t{:.2}\t{}\t{}",
+                    path.file_name().unwrap().to_string_lossy(),
+                    w,
+                    h,
+                    m.achieved_score,
+                    m.passes_used,
+                    b.len(),
+                );
+                passes_used.push(m.passes_used);
+                achieved.push(m.achieved_score);
+                bytes.push(b.len());
+                if m.targets_met {
+                    targets_met += 1;
+                }
+                if m.achieved_score < target_v {
+                    undershoot_count += 1;
+                }
+                if m.achieved_score > target_v + 1.5 {
+                    overshoot_count += 1;
+                }
+            }
+            Err(e) => {
+                eprintln!(
+                    "{}\tERROR\t{:?}",
+                    path.file_name().unwrap().to_string_lossy(),
+                    e
+                );
+            }
+        }
+    }
+
+    if passes_used.is_empty() {
+        eprintln!("no successful encodes");
+        return;
+    }
+    passes_used.sort();
+    achieved.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let n = passes_used.len();
+    let p25 = |v: &[u8]| v[(n / 4).min(n - 1)];
+    let p50 = |v: &[u8]| v[n / 2];
+    let p75 = |v: &[u8]| v[((n * 3) / 4).min(n - 1)];
+    let avg_passes: f32 = passes_used.iter().map(|&p| p as f32).sum::<f32>() / n as f32;
+    let avg_score: f32 = achieved.iter().sum::<f32>() / n as f32;
+    eprintln!();
+    eprintln!("=== summary (n={n}, target={target_v}) ===");
+    eprintln!(
+        "passes_used: avg={:.2} p25={} p50={} p75={}",
+        avg_passes,
+        p25(&passes_used),
+        p50(&passes_used),
+        p75(&passes_used),
+    );
+    eprintln!(
+        "achieved: avg={:.2} p25={:.2} p50={:.2} p75={:.2}",
+        avg_score,
+        achieved[n / 4],
+        achieved[n / 2],
+        achieved[(n * 3) / 4],
+    );
+    eprintln!("targets_met: {}/{n}", targets_met);
+    eprintln!("undershoot (<target): {}/{n}", undershoot_count);
+    eprintln!("overshoot (>target+1.5): {}/{n}", overshoot_count);
+    eprintln!(
+        "in-band ([target, target+1.5]): {}/{n}",
+        n - undershoot_count - overshoot_count
+    );
+}
+
+fn decode_png_rgb(path: &PathBuf) -> Option<(Vec<u8>, u32, u32)> {
+    let bytes = fs::read(path).ok()?;
+    let cur = std::io::Cursor::new(bytes);
+    let mut decoder = png::Decoder::new(cur);
+    decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
+    let mut reader = decoder.read_info().ok()?;
+    let info = reader.info();
+    let w = info.width;
+    let h = info.height;
+    let color = info.color_type;
+    let bytes_per_pixel = match color {
+        png::ColorType::Rgb => 3,
+        png::ColorType::Rgba => 4,
+        png::ColorType::Grayscale => 1,
+        png::ColorType::GrayscaleAlpha => 2,
+        png::ColorType::Indexed => 3,
+    };
+    let mut buf = vec![0u8; (w as usize * h as usize) * bytes_per_pixel];
+    reader.next_frame(&mut buf).ok()?;
+    let rgb = match color {
+        png::ColorType::Rgb | png::ColorType::Indexed => buf,
+        png::ColorType::Rgba => {
+            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            for px in buf.chunks_exact(4) {
+                out.extend_from_slice(&[px[0], px[1], px[2]]);
+            }
+            out
+        }
+        png::ColorType::Grayscale => {
+            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            for &g in &buf {
+                out.extend_from_slice(&[g, g, g]);
+            }
+            out
+        }
+        png::ColorType::GrayscaleAlpha => {
+            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            for px in buf.chunks_exact(2) {
+                out.extend_from_slice(&[px[0], px[0], px[0]]);
+            }
+            out
+        }
+    };
+    Some((rgb, w, h))
+}

--- a/dev/zensim_convergence_eval.rs
+++ b/dev/zensim_convergence_eval.rs
@@ -1,142 +1,323 @@
-//! Run target_zensim against a corpus and report convergence stats.
-//! Used to populate the PR description with real numbers.
+//! Run target_zensim against one or more corpora and report convergence
+//! stats (single-pass-success rate, avg passes, achieved-score
+//! distribution, undershoot/overshoot/in-band counts).
+//!
+//! Usage (legacy positional form, single corpus + single target):
+//!   zensim_convergence_eval [corpus_dir] [target] [max_passes]
+//!
+//! Usage (flag form, multi-corpus + multi-target + asymmetric ship-band
+//! sweep):
+//!   zensim_convergence_eval \
+//!     --corpus CID22=/path/to/CID22/CID22-512/validation \
+//!     --corpus gb82=/path/to/gb82 \
+//!     --corpus gb82-sc=/path/to/gb82-sc \
+//!     --targets 75,80,85 \
+//!     --max-passes 2 \
+//!     --max-overshoot 1.5 \
+//!     [--max-undershoot-ship 0.5]   # explicit ship-band override
+//!     [--strict-ship]               # equivalent to --max-undershoot-ship 0
+//!     [--limit 30]
+//!
+//! `--strict-ship` recovers the pre-Task-2 (PR #48) iteration semantics
+//! where any undershoot — even 0.001 — triggers a second pass. The
+//! default ship-band (Some(0.5)) is the post-Task-2 default. Pair the
+//! two runs to A/B the ship-band change.
 
 #![forbid(unsafe_code)]
 
+use std::collections::BTreeMap;
 use std::env;
 use std::fs;
 use std::path::PathBuf;
 
 use zenwebp::{EncodeRequest, LossyConfig, PixelLayout, ZensimTarget};
 
-fn main() {
-    let corpus_dir = env::args().nth(1).unwrap_or_else(|| {
-        let home = env::var("HOME").expect("HOME not set");
-        format!("{home}/work/codec-corpus/CID22/CID22-512/validation")
-    });
-    let target_str = env::args().nth(2).unwrap_or_else(|| "80".to_string());
-    let target_v: f32 = target_str.parse().unwrap_or(80.0);
-    let max_passes: u8 = env::args().nth(3).and_then(|s| s.parse().ok()).unwrap_or(2);
+#[derive(Default)]
+struct Cli {
+    corpora: Vec<(String, PathBuf)>,
+    targets: Vec<f32>,
+    max_passes: u8,
+    max_overshoot: f32,
+    max_undershoot_ship: Option<Option<f32>>, // outer Option = "user provided?"
+    method: u8,
+    limit: Option<usize>,
+}
 
-    let mut paths: Vec<PathBuf> = fs::read_dir(&corpus_dir)
-        .expect("read corpus dir")
-        .filter_map(|e| {
-            let p = e.ok()?.path();
-            (p.extension().is_some_and(|e| e == "png" || e == "PNG")).then_some(p)
-        })
-        .collect();
-    paths.sort();
-    if paths.len() > 20 {
-        let stride = paths.len() / 20;
-        paths = paths
-            .iter()
-            .enumerate()
-            .filter(|(i, _)| i % stride == 0)
-            .take(20)
-            .map(|(_, p)| p.clone())
-            .collect();
+fn parse_args() -> Cli {
+    let argv: Vec<String> = env::args().skip(1).collect();
+    let mut cli = Cli {
+        corpora: vec![],
+        targets: vec![],
+        max_passes: 2,
+        max_overshoot: 1.5,
+        max_undershoot_ship: None,
+        method: 4,
+        limit: None,
+    };
+    // If no flags are present, fall back to the historical positional form.
+    let has_flag = argv.iter().any(|a| a.starts_with("--"));
+    if !has_flag {
+        let corpus_dir = argv.first().cloned().unwrap_or_else(|| {
+            let home = env::var("HOME").expect("HOME not set");
+            format!("{home}/work/codec-corpus/CID22/CID22-512/validation")
+        });
+        let target_v: f32 = argv.get(1).and_then(|s| s.parse().ok()).unwrap_or(80.0);
+        let max_passes: u8 = argv.get(2).and_then(|s| s.parse().ok()).unwrap_or(2);
+        cli.corpora
+            .push(("default".into(), PathBuf::from(corpus_dir)));
+        cli.targets.push(target_v);
+        cli.max_passes = max_passes;
+        return cli;
     }
-
-    let mut passes_used: Vec<u8> = Vec::new();
-    let mut achieved: Vec<f32> = Vec::new();
-    let mut bytes: Vec<usize> = Vec::new();
-    let mut targets_met = 0;
-    let mut undershoot_count = 0;
-    let mut overshoot_count = 0;
-
-    eprintln!(
-        "target={} max_passes={} corpus={}",
-        target_v, max_passes, corpus_dir
-    );
-    eprintln!("file\twidth\theight\tachieved\tpasses\tbytes");
-
-    for path in &paths {
-        let (rgb, w, h) = match decode_png_rgb(path) {
-            Some(t) => t,
-            None => continue,
-        };
-        if w < 32 || h < 32 {
-            continue;
+    let mut i = 0;
+    while i < argv.len() {
+        let a = &argv[i];
+        let next = || -> &str { argv.get(i + 1).map(|s| s.as_str()).unwrap_or("") };
+        match a.as_str() {
+            "--corpus" => {
+                let v = next();
+                let (name, path) = v.split_once('=').expect("--corpus expects name=path");
+                cli.corpora.push((name.to_string(), PathBuf::from(path)));
+                i += 2;
+            }
+            "--targets" => {
+                cli.targets = next()
+                    .split(',')
+                    .map(|s| s.trim().parse::<f32>().expect("bad --targets value"))
+                    .collect();
+                i += 2;
+            }
+            "--max-passes" => {
+                cli.max_passes = next().parse().unwrap();
+                i += 2;
+            }
+            "--max-overshoot" => {
+                cli.max_overshoot = next().parse().unwrap();
+                i += 2;
+            }
+            "--max-undershoot-ship" => {
+                cli.max_undershoot_ship = Some(Some(next().parse().unwrap()));
+                i += 2;
+            }
+            "--strict-ship" => {
+                cli.max_undershoot_ship = Some(None); // means: explicitly set field to None
+                i += 1;
+            }
+            "--method" => {
+                cli.method = next().parse().unwrap();
+                i += 2;
+            }
+            "--limit" => {
+                cli.limit = Some(next().parse().unwrap());
+                i += 2;
+            }
+            other => panic!("unknown arg: {other}"),
         }
-        let cfg = LossyConfig::new().with_method(4).with_target_zensim(
-            ZensimTarget::new(target_v)
-                .with_max_overshoot(Some(1.5))
-                .with_max_passes(max_passes),
+    }
+    if cli.corpora.is_empty() {
+        eprintln!(
+            "usage: --corpus name=/path [--corpus ...] --targets 75,80,85 [--max-passes 2] [--strict-ship]"
         );
-        let result =
-            EncodeRequest::lossy(&cfg, &rgb, PixelLayout::Rgb8, w, h).encode_with_metrics();
-        match result {
-            Ok((b, m)) => {
-                eprintln!(
-                    "{}\t{}\t{}\t{:.2}\t{}\t{}",
-                    path.file_name().unwrap().to_string_lossy(),
-                    w,
-                    h,
-                    m.achieved_score,
-                    m.passes_used,
-                    b.len(),
-                );
-                passes_used.push(m.passes_used);
-                achieved.push(m.achieved_score);
-                bytes.push(b.len());
-                if m.targets_met {
-                    targets_met += 1;
-                }
-                if m.achieved_score < target_v {
-                    undershoot_count += 1;
-                }
-                if m.achieved_score > target_v + 1.5 {
-                    overshoot_count += 1;
-                }
-            }
-            Err(e) => {
-                eprintln!(
-                    "{}\tERROR\t{:?}",
-                    path.file_name().unwrap().to_string_lossy(),
-                    e
-                );
-            }
-        }
+        std::process::exit(2);
     }
+    if cli.targets.is_empty() {
+        cli.targets.push(80.0);
+    }
+    cli
+}
 
-    if passes_used.is_empty() {
-        eprintln!("no successful encodes");
+fn list_pngs(dir: &PathBuf) -> Vec<PathBuf> {
+    let mut v: Vec<PathBuf> = fs::read_dir(dir)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.is_file() && p.extension().is_some_and(|e| e == "png" || e == "PNG"))
+        .collect();
+    v.sort();
+    v
+}
+
+#[derive(Default, Clone)]
+struct Agg {
+    n: u32,
+    passes_sum: u32,
+    passes_one: u32,
+    achieved_sum: f64,
+    targets_met: u32,
+    undershoot: u32,
+    overshoot: u32,
+    bytes: Vec<u64>,
+}
+
+fn fold(into: &mut Agg, src: &Agg) {
+    into.n += src.n;
+    into.passes_sum += src.passes_sum;
+    into.passes_one += src.passes_one;
+    into.achieved_sum += src.achieved_sum;
+    into.targets_met += src.targets_met;
+    into.undershoot += src.undershoot;
+    into.overshoot += src.overshoot;
+    into.bytes.extend(src.bytes.iter().copied());
+}
+
+fn median_u64(v: &[u64]) -> u64 {
+    if v.is_empty() {
+        return 0;
+    }
+    let mut s = v.to_vec();
+    s.sort_unstable();
+    if s.len() % 2 == 1 {
+        s[s.len() / 2]
+    } else {
+        (s[s.len() / 2 - 1] + s[s.len() / 2]) / 2
+    }
+}
+
+fn print_summary(label: &str, target: Option<f32>, a: &Agg) {
+    if a.n == 0 {
         return;
     }
-    passes_used.sort();
-    achieved.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    let n = passes_used.len();
-    let p25 = |v: &[u8]| v[(n / 4).min(n - 1)];
-    let p50 = |v: &[u8]| v[n / 2];
-    let p75 = |v: &[u8]| v[((n * 3) / 4).min(n - 1)];
-    let avg_passes: f32 = passes_used.iter().map(|&p| p as f32).sum::<f32>() / n as f32;
-    let avg_score: f32 = achieved.iter().sum::<f32>() / n as f32;
-    eprintln!();
-    eprintln!("=== summary (n={n}, target={target_v}) ===");
-    eprintln!(
-        "passes_used: avg={:.2} p25={} p50={} p75={}",
-        avg_passes,
-        p25(&passes_used),
-        p50(&passes_used),
-        p75(&passes_used),
-    );
-    eprintln!(
-        "achieved: avg={:.2} p25={:.2} p50={:.2} p75={:.2}",
-        avg_score,
-        achieved[n / 4],
-        achieved[n / 2],
-        achieved[(n * 3) / 4],
-    );
-    eprintln!("targets_met: {}/{n}", targets_met);
-    eprintln!("undershoot (<target): {}/{n}", undershoot_count);
-    eprintln!("overshoot (>target+1.5): {}/{n}", overshoot_count);
-    eprintln!(
-        "in-band ([target, target+1.5]): {}/{n}",
-        n - undershoot_count - overshoot_count
+    let n = a.n as f32;
+    let tgt_str = target.map(|t| format!("{t:.1}")).unwrap_or("ALL".into());
+    println!(
+        "{:24} target={:>5} n={:>4}  passes_avg={:.2}  pass1_share={:.0}%  achieved_avg={:.2}  met={}/{}  und={} ovs={}  med_bytes={}",
+        label,
+        tgt_str,
+        a.n,
+        a.passes_sum as f32 / n,
+        100.0 * a.passes_one as f32 / n,
+        a.achieved_sum / a.n as f64,
+        a.targets_met,
+        a.n,
+        a.undershoot,
+        a.overshoot,
+        median_u64(&a.bytes),
     );
 }
 
-fn decode_png_rgb(path: &PathBuf) -> Option<(Vec<u8>, u32, u32)> {
+struct LoadedImage {
+    corpus: String,
+    name: String,
+    rgb: Vec<u8>,
+    rgba: Option<Vec<u8>>,
+    w: u32,
+    h: u32,
+}
+
+fn main() {
+    let cli = parse_args();
+
+    eprintln!(
+        "convergence-eval: max_passes={} max_overshoot={} method={} ship_override={:?}",
+        cli.max_passes, cli.max_overshoot, cli.method, cli.max_undershoot_ship
+    );
+    eprintln!("corpora:");
+    for (n, p) in &cli.corpora {
+        eprintln!("  {n} = {}", p.display());
+    }
+    eprintln!("targets: {:?}", cli.targets);
+
+    // Load images.
+    let mut images: Vec<LoadedImage> = Vec::new();
+    for (corpus_name, corpus_path) in &cli.corpora {
+        let mut paths = list_pngs(corpus_path);
+        if let Some(lim) = cli.limit {
+            paths.truncate(lim);
+        }
+        eprintln!("  {corpus_name}: {} images", paths.len());
+        for path in paths {
+            let img_name = path.file_name().unwrap().to_string_lossy().to_string();
+            match decode_png(&path) {
+                Some(decoded) => images.push(LoadedImage {
+                    corpus: corpus_name.clone(),
+                    name: img_name,
+                    rgb: decoded.rgb,
+                    rgba: decoded.rgba,
+                    w: decoded.w,
+                    h: decoded.h,
+                }),
+                None => eprintln!("    skip {}", path.display()),
+            }
+        }
+    }
+    eprintln!("loaded {} images", images.len());
+
+    // Run.
+    let mut by_target: BTreeMap<u32, Agg> = BTreeMap::new();
+    let mut by_corpus: BTreeMap<String, Agg> = BTreeMap::new();
+    let mut by_corpus_target: BTreeMap<(String, u32), Agg> = BTreeMap::new();
+    let mut overall = Agg::default();
+
+    for img in &images {
+        let _ = &img.rgba; // silence dead-code when no rgba uses (handled by extended eval binary)
+        for &target in &cli.targets {
+            let mut t = ZensimTarget::new(target)
+                .with_max_overshoot(Some(cli.max_overshoot))
+                .with_max_passes(cli.max_passes);
+            if let Some(ship) = cli.max_undershoot_ship {
+                t = t.with_max_undershoot_ship(ship);
+            }
+            let cfg = LossyConfig::new()
+                .with_method(cli.method)
+                .with_target_zensim(t);
+            let result = EncodeRequest::lossy(&cfg, &img.rgb, PixelLayout::Rgb8, img.w, img.h)
+                .encode_with_metrics();
+            match result {
+                Ok((b, m)) => {
+                    let a = Agg {
+                        n: 1,
+                        passes_sum: u32::from(m.passes_used),
+                        passes_one: u32::from(m.passes_used == 1),
+                        achieved_sum: f64::from(m.achieved_score),
+                        targets_met: u32::from(m.targets_met),
+                        undershoot: u32::from(m.achieved_score < target),
+                        overshoot: u32::from(m.achieved_score > target + cli.max_overshoot),
+                        bytes: vec![b.len() as u64],
+                    };
+                    fold(&mut overall, &a);
+                    fold(by_target.entry((target * 100.0) as u32).or_default(), &a);
+                    fold(by_corpus.entry(img.corpus.clone()).or_default(), &a);
+                    fold(
+                        by_corpus_target
+                            .entry((img.corpus.clone(), (target * 100.0) as u32))
+                            .or_default(),
+                        &a,
+                    );
+                }
+                Err(e) => {
+                    eprintln!("ERROR {} target={}: {:?}", img.name, target, e);
+                }
+            }
+        }
+        eprint!(".");
+    }
+    eprintln!();
+
+    println!("\n=== by target (across all corpora) ===");
+    for (t100, a) in &by_target {
+        print_summary("(all)", Some(*t100 as f32 / 100.0), a);
+    }
+    println!("\n=== by corpus (across all targets) ===");
+    for (corpus, a) in &by_corpus {
+        print_summary(corpus, None, a);
+    }
+    println!("\n=== by (corpus, target) ===");
+    for ((corpus, t100), a) in &by_corpus_target {
+        print_summary(corpus, Some(*t100 as f32 / 100.0), a);
+    }
+    println!("\n=== overall ===");
+    print_summary("ALL", None, &overall);
+}
+
+struct DecodedPng {
+    rgb: Vec<u8>,
+    rgba: Option<Vec<u8>>,
+    w: u32,
+    h: u32,
+}
+
+fn decode_png(path: &PathBuf) -> Option<DecodedPng> {
     let bytes = fs::read(path).ok()?;
     let cur = std::io::Cursor::new(bytes);
     let mut decoder = png::Decoder::new(cur);
@@ -155,29 +336,29 @@ fn decode_png_rgb(path: &PathBuf) -> Option<(Vec<u8>, u32, u32)> {
     };
     let mut buf = vec![0u8; (w as usize * h as usize) * bytes_per_pixel];
     reader.next_frame(&mut buf).ok()?;
-    let rgb = match color {
-        png::ColorType::Rgb | png::ColorType::Indexed => buf,
+    let (rgb, rgba) = match color {
+        png::ColorType::Rgb | png::ColorType::Indexed => (buf, None),
         png::ColorType::Rgba => {
-            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            let mut rgb = Vec::with_capacity(w as usize * h as usize * 3);
             for px in buf.chunks_exact(4) {
-                out.extend_from_slice(&[px[0], px[1], px[2]]);
+                rgb.extend_from_slice(&[px[0], px[1], px[2]]);
             }
-            out
+            (rgb, Some(buf))
         }
         png::ColorType::Grayscale => {
-            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            let mut rgb = Vec::with_capacity(w as usize * h as usize * 3);
             for &g in &buf {
-                out.extend_from_slice(&[g, g, g]);
+                rgb.extend_from_slice(&[g, g, g]);
             }
-            out
+            (rgb, None)
         }
         png::ColorType::GrayscaleAlpha => {
-            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            let mut rgb = Vec::with_capacity(w as usize * h as usize * 3);
             for px in buf.chunks_exact(2) {
-                out.extend_from_slice(&[px[0], px[0], px[0]]);
+                rgb.extend_from_slice(&[px[0], px[0], px[0]]);
             }
-            out
+            (rgb, None)
         }
     };
-    Some((rgb, w, h))
+    Some(DecodedPng { rgb, rgba, w, h })
 }

--- a/dev/zensim_extended_eval.rs
+++ b/dev/zensim_extended_eval.rs
@@ -1,15 +1,15 @@
-//! Extended convergence evaluation: CLIC2025 corpus + per-frame
-//! convergence on an animated WebP. Companion to
-//! `dev/zensim_convergence_eval.rs` — that one stays focused on the
+//! Extended convergence evaluation: CLIC2025 corpus + synthetic RGBA
+//! convergence + per-frame convergence on an animated WebP. Companion
+//! to `dev/zensim_convergence_eval.rs` — that one stays focused on the
 //! standard 76-image RGB sweep; this one adds the broader sanity
-//! checks the user wants for PR #48 Task 3.
+//! checks for PR #48 Task 3.
 //!
-//! Plus an RGBA "unsupported-layout" smoke test that asserts the
-//! encoder cleanly refuses RGBA + target_zensim with the typed
-//! [`zenwebp::EncodeError::TargetZensimUnsupportedLayout`] error
-//! (rather than silently dropping alpha to make iteration fire). This
-//! documents the current limitation in code; proper RGBA support is
-//! tracked separately.
+//! Phase 3b is a real synthetic RGBA convergence sweep: 8 images
+//! (smooth gradient + alpha gradient, photo-like, screen content,
+//! checkerboard alpha, semi-transparent overlay, radial alpha, noisy
+//! photo, alpha-fade banner) crossed with the requested targets. The
+//! encoder uses zensim's deterministic-noise compositing path; targets
+//! are expected to converge in 1–3 passes per cell.
 //!
 //! Usage:
 //!   zensim_extended_eval [--clic /path/to/clic2025-1024]
@@ -18,6 +18,7 @@
 //!     [--max-passes 2]
 //!     [--max-overshoot 1.5]
 //!     [--clic-limit 30]
+//!     [--rgba-out-dir /tmp/rgba-synth]
 //!
 //! Defaults (when flags omitted):
 //!   --clic   $HOME/work/codec-corpus/clic2025-1024
@@ -35,7 +36,7 @@ use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 
-use zenwebp::{EncodeError, EncodeRequest, LossyConfig, PixelLayout, ZensimTarget};
+use zenwebp::{EncodeRequest, LossyConfig, PixelLayout, ZensimTarget};
 
 #[derive(Clone)]
 struct Cli {
@@ -46,6 +47,7 @@ struct Cli {
     max_overshoot: f32,
     method: u8,
     clic_limit: usize,
+    rgba_out_dir: Option<PathBuf>,
 }
 
 fn parse_args() -> Cli {
@@ -60,6 +62,7 @@ fn parse_args() -> Cli {
         max_overshoot: 1.5,
         method: 4,
         clic_limit: 30,
+        rgba_out_dir: None,
     };
     let argv: Vec<String> = env::args().skip(1).collect();
     let mut i = 0;
@@ -96,6 +99,10 @@ fn parse_args() -> Cli {
             }
             "--clic-limit" => {
                 cli.clic_limit = next().parse().unwrap();
+                i += 2;
+            }
+            "--rgba-out-dir" => {
+                cli.rgba_out_dir = Some(PathBuf::from(next()));
                 i += 2;
             }
             other => panic!("unknown arg: {other}"),
@@ -191,12 +198,12 @@ fn main() {
     run_clic_phase(&cli);
 
     // ============================================================
-    // 3b — RGBA "unsupported-layout" smoke test
+    // 3b — Synthetic RGBA convergence
     // ============================================================
     println!("\n==============================================");
-    println!("=== Phase 3b: RGBA unsupported-layout smoke ===");
+    println!("=== Phase 3b: synthetic RGBA convergence    ===");
     println!("==============================================");
-    run_rgba_unsupported_smoke();
+    run_rgba_phase(&cli);
 
     // ============================================================
     // 3c — Animation per-frame convergence
@@ -316,71 +323,264 @@ fn run_clic_phase(cli: &Cli) {
 }
 
 // --------------------------------------------------------------------
-// 3b: RGBA "unsupported-layout" smoke test
+// 3b: Synthetic RGBA convergence
 // --------------------------------------------------------------------
 
-/// Confirm the encoder cleanly refuses RGBA + target_zensim with the
-/// typed [`EncodeError::TargetZensimUnsupportedLayout`] error. This
-/// documents the current limitation in code: an earlier iteration of
-/// PR #48 silently dropped alpha into a transient RGB buffer for the
-/// iteration probes — that hid the unhonored-target footgun. The gate
-/// now refuses non-RGB8 inputs whenever target_zensim is set, leaving
-/// proper RGBA support as a separate follow-up.
-///
-/// Synthetic 32x32 RGBA image, single target. We're checking the
-/// gate, not convergence quality — a tiny image keeps the test fast
-/// even though it never actually reaches the iteration loop.
-fn run_rgba_unsupported_smoke() {
-    let w: u32 = 32;
-    let h: u32 = 32;
-    let mut rgba = Vec::with_capacity((w * h * 4) as usize);
-    for y in 0..h {
-        for x in 0..w {
-            let r = ((x * 255) / w) as u8;
-            let g = ((y * 255) / h) as u8;
-            let b = (((x + y) * 255) / (w + h)) as u8;
-            let a = if (x + y) & 1 == 0 { 255 } else { 128 };
-            rgba.extend_from_slice(&[r, g, b, a]);
-        }
-    }
-    let cfg = LossyConfig::new()
-        .with_method(4)
-        .with_target_zensim(ZensimTarget::new(80.0));
-    let r = EncodeRequest::lossy(&cfg, &rgba, PixelLayout::Rgba8, w, h).encode_with_metrics();
-    match r {
-        Ok((bytes, m)) => {
-            panic!(
-                "expected TargetZensimUnsupportedLayout error for RGBA + target_zensim, \
-                 got Ok({} bytes, achieved={:.2}, passes={})",
-                bytes.len(),
-                m.achieved_score,
-                m.passes_used,
+/// Build the canonical synthetic RGBA test set (8 images, 256x256):
+/// smooth gradient + alpha gradient, photo-like (mixed sin), screen
+/// content (sharp blocks), checkerboard alpha, semi-transparent
+/// overlay, translucent radial-alpha corners, noisy-photo facsimile,
+/// and a horizontal alpha-fade banner. Covers the alpha-shape space
+/// the encoder will see in real-world RGBA traffic.
+fn synthetic_rgba_set() -> Vec<(String, Vec<u8>, u32, u32)> {
+    let w: u32 = 256;
+    let h: u32 = 256;
+    let mut out = Vec::new();
+
+    // 1. smooth gradient + alpha gradient
+    out.push((
+        "smooth_grad_alpha_grad".into(),
+        {
+            let mut buf = Vec::with_capacity((w * h * 4) as usize);
+            for y in 0..h {
+                for x in 0..w {
+                    let r = ((x * 255) / w) as u8;
+                    let g = ((y * 255) / h) as u8;
+                    let b = (((x + y) * 255) / (w + h)) as u8;
+                    let a = ((x * 255) / w) as u8;
+                    buf.extend_from_slice(&[r, g, b, a]);
+                }
+            }
+            buf
+        },
+        w,
+        h,
+    ));
+
+    // 2. photo-like mixed content (full alpha)
+    out.push((
+        "photo_mixed_full_alpha".into(),
+        {
+            let mut buf = Vec::with_capacity((w * h * 4) as usize);
+            for y in 0..h {
+                for x in 0..w {
+                    let fx = x as f32 / w as f32;
+                    let fy = y as f32 / h as f32;
+                    let base_r = 80.0 + 100.0 * fx;
+                    let base_g = 100.0 + 80.0 * fy;
+                    let base_b = 90.0 + 80.0 * (1.0 - fx);
+                    let tex = 18.0
+                        * ((fx * 9.0).sin() * (fy * 7.0).cos()
+                            + 0.6 * (fx * 17.0 + fy * 11.0).sin());
+                    let r = (base_r + tex).clamp(0.0, 255.0) as u8;
+                    let g = (base_g + tex * 0.7).clamp(0.0, 255.0) as u8;
+                    let b = (base_b - tex * 0.5).clamp(0.0, 255.0) as u8;
+                    buf.extend_from_slice(&[r, g, b, 255]);
+                }
+            }
+            buf
+        },
+        w,
+        h,
+    ));
+
+    // 3. screen-content sharp blocks (alpha=255)
+    out.push((
+        "screen_content_blocks".into(),
+        {
+            let mut buf = Vec::with_capacity((w * h * 4) as usize);
+            for y in 0..h {
+                for x in 0..w {
+                    let qy = (y / 32) as u8;
+                    let qx = (x / 32) as u8;
+                    let id = (qy ^ qx) % 4;
+                    let (r, g, b) = match id {
+                        0 => (240, 240, 240),
+                        1 => (50, 50, 60),
+                        2 => (210, 60, 60),
+                        _ => (60, 130, 220),
+                    };
+                    buf.extend_from_slice(&[r, g, b, 255]);
+                }
+            }
+            buf
+        },
+        w,
+        h,
+    ));
+
+    // 4. checkerboard alpha (sharp transparency edges)
+    out.push((
+        "checkerboard_alpha".into(),
+        {
+            let mut buf = Vec::with_capacity((w * h * 4) as usize);
+            for y in 0..h {
+                for x in 0..w {
+                    let cell = ((x / 16) ^ (y / 16)) & 1;
+                    let a = if cell == 0 { 255u8 } else { 0u8 };
+                    buf.extend_from_slice(&[200, 80, 100, a]);
+                }
+            }
+            buf
+        },
+        w,
+        h,
+    ));
+
+    // 5. semi-transparent overlay (constant 128 alpha)
+    out.push((
+        "semi_transparent".into(),
+        {
+            let mut buf = Vec::with_capacity((w * h * 4) as usize);
+            for y in 0..h {
+                for x in 0..w {
+                    let r = ((x * 200) / w) as u8;
+                    let g = ((y * 200) / h) as u8;
+                    buf.extend_from_slice(&[r, g, 100, 128]);
+                }
+            }
+            buf
+        },
+        w,
+        h,
+    ));
+
+    // 6. translucent corners (radial alpha)
+    out.push((
+        "radial_alpha".into(),
+        {
+            let mut buf = Vec::with_capacity((w * h * 4) as usize);
+            let cx = (w / 2) as f32;
+            let cy = (h / 2) as f32;
+            let max_d = (cx.powi(2) + cy.powi(2)).sqrt();
+            for y in 0..h {
+                for x in 0..w {
+                    let dx = x as f32 - cx;
+                    let dy = y as f32 - cy;
+                    let d = (dx * dx + dy * dy).sqrt();
+                    let a = (255.0 * (1.0 - (d / max_d))).clamp(0.0, 255.0) as u8;
+                    buf.extend_from_slice(&[180, 90, 220, a]);
+                }
+            }
+            buf
+        },
+        w,
+        h,
+    ));
+
+    // 7. noisy-photo facsimile (small spatial noise added to a texture)
+    out.push((
+        "noisy_photo".into(),
+        {
+            let mut buf = Vec::with_capacity((w * h * 4) as usize);
+            for y in 0..h {
+                for x in 0..w {
+                    let fx = x as f32 / w as f32;
+                    let fy = y as f32 / h as f32;
+                    let base = 90.0 + 60.0 * fx + 40.0 * fy;
+                    let h = ((x.wrapping_mul(2654435761)) ^ y.wrapping_mul(40503)) as u8;
+                    let n = (h as i32 - 128) / 6;
+                    let r = (base + n as f32).clamp(0.0, 255.0) as u8;
+                    let g = (base * 0.95 + n as f32).clamp(0.0, 255.0) as u8;
+                    let b = (base * 0.85 + n as f32).clamp(0.0, 255.0) as u8;
+                    buf.extend_from_slice(&[r, g, b, 255]);
+                }
+            }
+            buf
+        },
+        w,
+        h,
+    ));
+
+    // 8. horizontal alpha-fade banner
+    out.push((
+        "alpha_fade_banner".into(),
+        {
+            let mut buf = Vec::with_capacity((w * h * 4) as usize);
+            for y in 0..h {
+                for x in 0..w {
+                    let band = (y as i32 - 128).abs();
+                    let a = if band > 32 {
+                        0u8
+                    } else {
+                        ((32 - band) * 8).clamp(0, 255) as u8
+                    };
+                    let r = ((x * 200) / w) as u8;
+                    buf.extend_from_slice(&[r, 60, 240 - r, a]);
+                }
+            }
+            buf
+        },
+        w,
+        h,
+    ));
+
+    out
+}
+
+/// Run the synthetic RGBA convergence sweep. Each (image, target)
+/// cell goes through the full closed loop with the encoder's
+/// alpha-bearing path; targets are matched against the achieved score
+/// from zensim's deterministic-noise composite.
+fn run_rgba_phase(cli: &Cli) {
+    let images = synthetic_rgba_set();
+    eprintln!("RGBA: synthesized {} images (256x256)", images.len());
+
+    if let Some(out_dir) = &cli.rgba_out_dir {
+        let _ = fs::create_dir_all(out_dir);
+        for (name, _, _, _) in &images {
+            // Names only — no PNG re-encoding, just so the operator can
+            // grep for the sweep in the directory listing.
+            let _ = std::fs::write(
+                out_dir.join(format!("{name}.txt")),
+                b"synth-rgba placeholder",
             );
         }
-        Err(at) => {
-            // Decompose to inspect the inner variant. Other variants
-            // would mean the gate is misbehaving.
-            let inner: EncodeError = at.into();
-            match inner {
-                EncodeError::TargetZensimUnsupportedLayout(layout) => {
+    }
+
+    use std::collections::BTreeMap;
+    let mut by_target: BTreeMap<u32, Agg> = BTreeMap::new();
+    let mut by_image: BTreeMap<String, Agg> = BTreeMap::new();
+    let mut overall = Agg::default();
+
+    for (name, rgba, w, h) in &images {
+        for &target in &cli.targets {
+            let cfg = LossyConfig::new()
+                .with_method(cli.method)
+                .with_target_zensim(
+                    ZensimTarget::new(target)
+                        .with_max_overshoot(Some(cli.max_overshoot))
+                        .with_max_passes(cli.max_passes.max(3)),
+                );
+            let r =
+                EncodeRequest::lossy(&cfg, rgba, PixelLayout::Rgba8, *w, *h).encode_with_metrics();
+            match r {
+                Ok((b, m)) => {
+                    let a = agg_one(target, cli.max_overshoot, m, b.len());
+                    fold(&mut overall, &a);
+                    fold(by_target.entry((target * 100.0) as u32).or_default(), &a);
+                    fold(by_image.entry(name.clone()).or_default(), &a);
                     eprintln!(
-                        "  ok: RGBA + target_zensim -> TargetZensimUnsupportedLayout({:?})",
-                        layout,
-                    );
-                    println!(
-                        "RGBA-smoke: PASS — target_zensim cleanly rejects PixelLayout::{:?}",
-                        layout,
-                    );
-                }
-                other => {
-                    panic!(
-                        "expected TargetZensimUnsupportedLayout, got: {:?} ({})",
-                        other, other,
+                        "  rgba {name} target={target} achieved={:.2} passes={} bytes={} met={}",
+                        m.achieved_score,
+                        m.passes_used,
+                        b.len(),
+                        m.targets_met,
                     );
                 }
+                Err(e) => eprintln!("RGBA ERROR {name} target={target}: {:?}", e),
             }
         }
     }
+    println!("--- RGBA by target ---");
+    for (t100, a) in &by_target {
+        print_summary("RGBA-synth", Some(*t100 as f32 / 100.0), a);
+    }
+    println!("--- RGBA by image (across all targets) ---");
+    for (name, a) in &by_image {
+        print_summary(name, None, a);
+    }
+    print_summary("RGBA-synth ALL", None, &overall);
 }
 
 // --------------------------------------------------------------------
@@ -432,15 +632,9 @@ fn run_anim_phase(cli: &Cli) {
             }
         };
         let (rgba_buf, w, h) = rgba;
-        // target_zensim is RGB8-only; explicitly drop alpha here at
-        // the test driver so the encoder gate doesn't refuse the
-        // input. Alpha-preserving target_zensim is a tracked
-        // follow-up; this test is purely about per-frame iteration
-        // convergence on the underlying RGB content.
-        let mut rgb_buf = Vec::with_capacity(rgba_buf.len() / 4 * 3);
-        for px in rgba_buf.chunks_exact(4) {
-            rgb_buf.extend_from_slice(&[px[0], px[1], px[2]]);
-        }
+        // target_zensim now accepts RGBA inputs directly: the encoder
+        // emits alpha-bearing WebP and zensim's deterministic-noise
+        // composite measures the pair consistently.
         let cfg = LossyConfig::new()
             .with_method(cli.method)
             .with_target_zensim(
@@ -448,7 +642,8 @@ fn run_anim_phase(cli: &Cli) {
                     .with_max_overshoot(Some(cli.max_overshoot))
                     .with_max_passes(max_passes),
             );
-        let r = EncodeRequest::lossy(&cfg, &rgb_buf, PixelLayout::Rgb8, w, h).encode_with_metrics();
+        let r =
+            EncodeRequest::lossy(&cfg, &rgba_buf, PixelLayout::Rgba8, w, h).encode_with_metrics();
         match r {
             Ok((b, m)) => {
                 let a = agg_one(target, cli.max_overshoot, m, b.len());

--- a/dev/zensim_extended_eval.rs
+++ b/dev/zensim_extended_eval.rs
@@ -1,12 +1,18 @@
-//! Extended convergence evaluation: CLIC2025 corpus, RGBA inputs, and
-//! per-frame convergence on an animated WebP. Companion to
+//! Extended convergence evaluation: CLIC2025 corpus + per-frame
+//! convergence on an animated WebP. Companion to
 //! `dev/zensim_convergence_eval.rs` — that one stays focused on the
 //! standard 76-image RGB sweep; this one adds the broader sanity
 //! checks the user wants for PR #48 Task 3.
 //!
+//! Plus an RGBA "unsupported-layout" smoke test that asserts the
+//! encoder cleanly refuses RGBA + target_zensim with the typed
+//! [`zenwebp::EncodeError::TargetZensimUnsupportedLayout`] error
+//! (rather than silently dropping alpha to make iteration fire). This
+//! documents the current limitation in code; proper RGBA support is
+//! tracked separately.
+//!
 //! Usage:
 //!   zensim_extended_eval [--clic /path/to/clic2025-1024]
-//!     [--rgba-out-dir /tmp/rgba-synth]
 //!     [--anim /path/to/anim.webp]
 //!     [--targets 75,80,85]
 //!     [--max-passes 2]
@@ -20,8 +26,7 @@
 //!
 //! Reports aggregate stats per phase. Saves a CLIC TSV under
 //! /mnt/v/output/zenwebp/zensim-clic-eval/ for traceability (not
-//! committed). Synthetic RGBA images are generated in-memory; no
-//! filesystem I/O for them unless --rgba-out-dir is set.
+//! committed).
 
 #![forbid(unsafe_code)]
 
@@ -30,13 +35,12 @@ use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 
-use zenwebp::{EncodeRequest, LossyConfig, PixelLayout, ZensimTarget};
+use zenwebp::{EncodeError, EncodeRequest, LossyConfig, PixelLayout, ZensimTarget};
 
 #[derive(Clone)]
 struct Cli {
     clic: PathBuf,
     anim: PathBuf,
-    rgba_out_dir: Option<PathBuf>,
     targets: Vec<f32>,
     max_passes: u8,
     max_overshoot: f32,
@@ -51,7 +55,6 @@ fn parse_args() -> Cli {
         anim: PathBuf::from(format!(
             "{home}/work/codec-corpus/webp-conformance/valid/anim.webp"
         )),
-        rgba_out_dir: None,
         targets: vec![75.0, 80.0, 85.0],
         max_passes: 2,
         max_overshoot: 1.5,
@@ -70,10 +73,6 @@ fn parse_args() -> Cli {
             }
             "--anim" => {
                 cli.anim = PathBuf::from(next());
-                i += 2;
-            }
-            "--rgba-out-dir" => {
-                cli.rgba_out_dir = Some(PathBuf::from(next()));
                 i += 2;
             }
             "--targets" => {
@@ -192,12 +191,12 @@ fn main() {
     run_clic_phase(&cli);
 
     // ============================================================
-    // 3b — RGBA convergence
+    // 3b — RGBA "unsupported-layout" smoke test
     // ============================================================
-    println!("\n========================================");
-    println!("=== Phase 3b: RGBA convergence       ===");
-    println!("========================================");
-    run_rgba_phase(&cli);
+    println!("\n==============================================");
+    println!("=== Phase 3b: RGBA unsupported-layout smoke ===");
+    println!("==============================================");
+    run_rgba_unsupported_smoke();
 
     // ============================================================
     // 3c — Animation per-frame convergence
@@ -317,262 +316,71 @@ fn run_clic_phase(cli: &Cli) {
 }
 
 // --------------------------------------------------------------------
-// 3b: RGBA synthesis + convergence
+// 3b: RGBA "unsupported-layout" smoke test
 // --------------------------------------------------------------------
 
-/// Build the canonical synthetic RGBA test set (8 images: smooth
-/// gradient + alpha gradient, photo-like (mixed sin), screen-content
-/// (sharp blocks), checkerboard alpha, semi-transparent overlay,
-/// translucent gradient corners, a noisy-photo facsimile, a
-/// horizontal alpha-fade banner).
-fn synthetic_rgba_set() -> Vec<(String, Vec<u8>, u32, u32)> {
-    let w: u32 = 256;
-    let h: u32 = 256;
-    let mut out = Vec::new();
-
-    // 1. smooth gradient + alpha gradient
-    out.push((
-        "smooth_grad_alpha_grad".into(),
-        {
-            let mut buf = Vec::with_capacity((w * h * 4) as usize);
-            for y in 0..h {
-                for x in 0..w {
-                    let r = ((x * 255) / w) as u8;
-                    let g = ((y * 255) / h) as u8;
-                    let b = (((x + y) * 255) / (w + h)) as u8;
-                    let a = ((x * 255) / w) as u8;
-                    buf.extend_from_slice(&[r, g, b, a]);
-                }
-            }
-            buf
-        },
-        w,
-        h,
-    ));
-
-    // 2. photo-like mixed content (full alpha)
-    out.push((
-        "photo_mixed_full_alpha".into(),
-        {
-            let mut buf = Vec::with_capacity((w * h * 4) as usize);
-            for y in 0..h {
-                for x in 0..w {
-                    let fx = x as f32 / w as f32;
-                    let fy = y as f32 / h as f32;
-                    let base_r = 80.0 + 100.0 * fx;
-                    let base_g = 100.0 + 80.0 * fy;
-                    let base_b = 90.0 + 80.0 * (1.0 - fx);
-                    let tex = 18.0
-                        * ((fx * 9.0).sin() * (fy * 7.0).cos()
-                            + 0.6 * (fx * 17.0 + fy * 11.0).sin());
-                    let r = (base_r + tex).clamp(0.0, 255.0) as u8;
-                    let g = (base_g + tex * 0.7).clamp(0.0, 255.0) as u8;
-                    let b = (base_b - tex * 0.5).clamp(0.0, 255.0) as u8;
-                    buf.extend_from_slice(&[r, g, b, 255]);
-                }
-            }
-            buf
-        },
-        w,
-        h,
-    ));
-
-    // 3. screen-content sharp blocks (alpha=255)
-    out.push((
-        "screen_content_blocks".into(),
-        {
-            let mut buf = Vec::with_capacity((w * h * 4) as usize);
-            for y in 0..h {
-                for x in 0..w {
-                    let qy = (y / 32) as u8;
-                    let qx = (x / 32) as u8;
-                    let id = (qy ^ qx) % 4;
-                    let (r, g, b) = match id {
-                        0 => (240, 240, 240),
-                        1 => (50, 50, 60),
-                        2 => (210, 60, 60),
-                        _ => (60, 130, 220),
-                    };
-                    buf.extend_from_slice(&[r, g, b, 255]);
-                }
-            }
-            buf
-        },
-        w,
-        h,
-    ));
-
-    // 4. checkerboard alpha (sharp transparency edges)
-    out.push((
-        "checkerboard_alpha".into(),
-        {
-            let mut buf = Vec::with_capacity((w * h * 4) as usize);
-            for y in 0..h {
-                for x in 0..w {
-                    let cell = ((x / 16) ^ (y / 16)) & 1;
-                    let a = if cell == 0 { 255u8 } else { 0u8 };
-                    buf.extend_from_slice(&[200, 80, 100, a]);
-                }
-            }
-            buf
-        },
-        w,
-        h,
-    ));
-
-    // 5. semi-transparent overlay (constant 128 alpha)
-    out.push((
-        "semi_transparent".into(),
-        {
-            let mut buf = Vec::with_capacity((w * h * 4) as usize);
-            for y in 0..h {
-                for x in 0..w {
-                    let r = ((x * 200) / w) as u8;
-                    let g = ((y * 200) / h) as u8;
-                    buf.extend_from_slice(&[r, g, 100, 128]);
-                }
-            }
-            buf
-        },
-        w,
-        h,
-    ));
-
-    // 6. translucent corners (radial alpha)
-    out.push((
-        "radial_alpha".into(),
-        {
-            let mut buf = Vec::with_capacity((w * h * 4) as usize);
-            let cx = (w / 2) as f32;
-            let cy = (h / 2) as f32;
-            let max_d = (cx.powi(2) + cy.powi(2)).sqrt();
-            for y in 0..h {
-                for x in 0..w {
-                    let dx = x as f32 - cx;
-                    let dy = y as f32 - cy;
-                    let d = (dx * dx + dy * dy).sqrt();
-                    let a = (255.0 * (1.0 - (d / max_d))).clamp(0.0, 255.0) as u8;
-                    buf.extend_from_slice(&[180, 90, 220, a]);
-                }
-            }
-            buf
-        },
-        w,
-        h,
-    ));
-
-    // 7. noisy-photo facsimile (small spatial noise added to a texture)
-    out.push((
-        "noisy_photo".into(),
-        {
-            let mut buf = Vec::with_capacity((w * h * 4) as usize);
-            for y in 0..h {
-                for x in 0..w {
-                    let fx = x as f32 / w as f32;
-                    let fy = y as f32 / h as f32;
-                    let base = 90.0 + 60.0 * fx + 40.0 * fy;
-                    // Cheap pseudorandom noise — don't import rand.
-                    let h = ((x.wrapping_mul(2654435761)) ^ y.wrapping_mul(40503)) as u8;
-                    let n = (h as i32 - 128) / 6;
-                    let r = (base + n as f32).clamp(0.0, 255.0) as u8;
-                    let g = (base * 0.95 + n as f32).clamp(0.0, 255.0) as u8;
-                    let b = (base * 0.85 + n as f32).clamp(0.0, 255.0) as u8;
-                    buf.extend_from_slice(&[r, g, b, 255]);
-                }
-            }
-            buf
-        },
-        w,
-        h,
-    ));
-
-    // 8. horizontal alpha-fade banner
-    out.push((
-        "alpha_fade_banner".into(),
-        {
-            let mut buf = Vec::with_capacity((w * h * 4) as usize);
-            for y in 0..h {
-                for x in 0..w {
-                    let band = (y as i32 - 128).abs();
-                    let a = if band > 32 {
-                        0u8
-                    } else {
-                        ((32 - band) * 8).clamp(0, 255) as u8
-                    };
-                    let r = ((x * 200) / w) as u8;
-                    buf.extend_from_slice(&[r, 60, 240 - r, a]);
-                }
-            }
-            buf
-        },
-        w,
-        h,
-    ));
-
-    out
-}
-
-fn run_rgba_phase(cli: &Cli) {
-    let images = synthetic_rgba_set();
-    eprintln!("RGBA: synthesized {} images (256x256)", images.len());
-
-    if let Some(out_dir) = &cli.rgba_out_dir {
-        let _ = fs::create_dir_all(out_dir);
-        for (name, _, _, _) in &images {
-            // No PNG re-encoding — record names for traceability only.
-            let _ = std::fs::write(
-                out_dir.join(format!("{name}.txt")),
-                b"synth-rgba placeholder",
+/// Confirm the encoder cleanly refuses RGBA + target_zensim with the
+/// typed [`EncodeError::TargetZensimUnsupportedLayout`] error. This
+/// documents the current limitation in code: an earlier iteration of
+/// PR #48 silently dropped alpha into a transient RGB buffer for the
+/// iteration probes — that hid the unhonored-target footgun. The gate
+/// now refuses non-RGB8 inputs whenever target_zensim is set, leaving
+/// proper RGBA support as a separate follow-up.
+///
+/// Synthetic 32x32 RGBA image, single target. We're checking the
+/// gate, not convergence quality — a tiny image keeps the test fast
+/// even though it never actually reaches the iteration loop.
+fn run_rgba_unsupported_smoke() {
+    let w: u32 = 32;
+    let h: u32 = 32;
+    let mut rgba = Vec::with_capacity((w * h * 4) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let r = ((x * 255) / w) as u8;
+            let g = ((y * 255) / h) as u8;
+            let b = (((x + y) * 255) / (w + h)) as u8;
+            let a = if (x + y) & 1 == 0 { 255 } else { 128 };
+            rgba.extend_from_slice(&[r, g, b, a]);
+        }
+    }
+    let cfg = LossyConfig::new()
+        .with_method(4)
+        .with_target_zensim(ZensimTarget::new(80.0));
+    let r = EncodeRequest::lossy(&cfg, &rgba, PixelLayout::Rgba8, w, h).encode_with_metrics();
+    match r {
+        Ok((bytes, m)) => {
+            panic!(
+                "expected TargetZensimUnsupportedLayout error for RGBA + target_zensim, \
+                 got Ok({} bytes, achieved={:.2}, passes={})",
+                bytes.len(),
+                m.achieved_score,
+                m.passes_used,
             );
         }
-    }
-
-    use std::collections::BTreeMap;
-    let mut by_target: BTreeMap<u32, Agg> = BTreeMap::new();
-    let mut by_image: BTreeMap<String, Agg> = BTreeMap::new();
-    let mut overall = Agg::default();
-
-    for (name, rgba, w, h) in &images {
-        for &target in &cli.targets {
-            let cfg = LossyConfig::new()
-                .with_method(cli.method)
-                .with_target_zensim(
-                    ZensimTarget::new(target)
-                        .with_max_overshoot(Some(cli.max_overshoot))
-                        .with_max_passes(cli.max_passes),
-                );
-            // PixelLayout::Rgba8 — the encoder converts to YUVA
-            // internally. We just want to confirm the iteration loop
-            // works on RGBA inputs and converges.
-            let r =
-                EncodeRequest::lossy(&cfg, rgba, PixelLayout::Rgba8, *w, *h).encode_with_metrics();
-            match r {
-                Ok((b, m)) => {
-                    let a = agg_one(target, cli.max_overshoot, m, b.len());
-                    fold(&mut overall, &a);
-                    fold(by_target.entry((target * 100.0) as u32).or_default(), &a);
-                    fold(by_image.entry(name.clone()).or_default(), &a);
+        Err(at) => {
+            // Decompose to inspect the inner variant. Other variants
+            // would mean the gate is misbehaving.
+            let inner: EncodeError = at.into();
+            match inner {
+                EncodeError::TargetZensimUnsupportedLayout(layout) => {
                     eprintln!(
-                        "  rgba {name} target={target} achieved={:.2} passes={} bytes={} met={}",
-                        m.achieved_score,
-                        m.passes_used,
-                        b.len(),
-                        m.targets_met,
+                        "  ok: RGBA + target_zensim -> TargetZensimUnsupportedLayout({:?})",
+                        layout,
+                    );
+                    println!(
+                        "RGBA-smoke: PASS — target_zensim cleanly rejects PixelLayout::{:?}",
+                        layout,
                     );
                 }
-                Err(e) => eprintln!("RGBA ERROR {name} target={target}: {:?}", e),
+                other => {
+                    panic!(
+                        "expected TargetZensimUnsupportedLayout, got: {:?} ({})",
+                        other, other,
+                    );
+                }
             }
         }
     }
-    println!("--- RGBA by target ---");
-    for (t100, a) in &by_target {
-        print_summary("RGBA-synth", Some(*t100 as f32 / 100.0), a);
-    }
-    println!("--- RGBA by image (across all targets) ---");
-    for (name, a) in &by_image {
-        print_summary(name, None, a);
-    }
-    print_summary("RGBA-synth ALL", None, &overall);
 }
 
 // --------------------------------------------------------------------
@@ -624,6 +432,15 @@ fn run_anim_phase(cli: &Cli) {
             }
         };
         let (rgba_buf, w, h) = rgba;
+        // target_zensim is RGB8-only; explicitly drop alpha here at
+        // the test driver so the encoder gate doesn't refuse the
+        // input. Alpha-preserving target_zensim is a tracked
+        // follow-up; this test is purely about per-frame iteration
+        // convergence on the underlying RGB content.
+        let mut rgb_buf = Vec::with_capacity(rgba_buf.len() / 4 * 3);
+        for px in rgba_buf.chunks_exact(4) {
+            rgb_buf.extend_from_slice(&[px[0], px[1], px[2]]);
+        }
         let cfg = LossyConfig::new()
             .with_method(cli.method)
             .with_target_zensim(
@@ -631,8 +448,7 @@ fn run_anim_phase(cli: &Cli) {
                     .with_max_overshoot(Some(cli.max_overshoot))
                     .with_max_passes(max_passes),
             );
-        let r =
-            EncodeRequest::lossy(&cfg, &rgba_buf, PixelLayout::Rgba8, w, h).encode_with_metrics();
+        let r = EncodeRequest::lossy(&cfg, &rgb_buf, PixelLayout::Rgb8, w, h).encode_with_metrics();
         match r {
             Ok((b, m)) => {
                 let a = agg_one(target, cli.max_overshoot, m, b.len());

--- a/dev/zensim_extended_eval.rs
+++ b/dev/zensim_extended_eval.rs
@@ -1,0 +1,732 @@
+//! Extended convergence evaluation: CLIC2025 corpus, RGBA inputs, and
+//! per-frame convergence on an animated WebP. Companion to
+//! `dev/zensim_convergence_eval.rs` — that one stays focused on the
+//! standard 76-image RGB sweep; this one adds the broader sanity
+//! checks the user wants for PR #48 Task 3.
+//!
+//! Usage:
+//!   zensim_extended_eval [--clic /path/to/clic2025-1024]
+//!     [--rgba-out-dir /tmp/rgba-synth]
+//!     [--anim /path/to/anim.webp]
+//!     [--targets 75,80,85]
+//!     [--max-passes 2]
+//!     [--max-overshoot 1.5]
+//!     [--clic-limit 30]
+//!
+//! Defaults (when flags omitted):
+//!   --clic   $HOME/work/codec-corpus/clic2025-1024
+//!   --anim   $HOME/work/codec-corpus/webp-conformance/valid/anim.webp
+//!   --targets 75,80,85
+//!
+//! Reports aggregate stats per phase. Saves a CLIC TSV under
+//! /mnt/v/output/zenwebp/zensim-clic-eval/ for traceability (not
+//! committed). Synthetic RGBA images are generated in-memory; no
+//! filesystem I/O for them unless --rgba-out-dir is set.
+
+#![forbid(unsafe_code)]
+
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+use zenwebp::{EncodeRequest, LossyConfig, PixelLayout, ZensimTarget};
+
+#[derive(Clone)]
+struct Cli {
+    clic: PathBuf,
+    anim: PathBuf,
+    rgba_out_dir: Option<PathBuf>,
+    targets: Vec<f32>,
+    max_passes: u8,
+    max_overshoot: f32,
+    method: u8,
+    clic_limit: usize,
+}
+
+fn parse_args() -> Cli {
+    let home = env::var("HOME").expect("HOME not set");
+    let mut cli = Cli {
+        clic: PathBuf::from(format!("{home}/work/codec-corpus/clic2025-1024")),
+        anim: PathBuf::from(format!(
+            "{home}/work/codec-corpus/webp-conformance/valid/anim.webp"
+        )),
+        rgba_out_dir: None,
+        targets: vec![75.0, 80.0, 85.0],
+        max_passes: 2,
+        max_overshoot: 1.5,
+        method: 4,
+        clic_limit: 30,
+    };
+    let argv: Vec<String> = env::args().skip(1).collect();
+    let mut i = 0;
+    while i < argv.len() {
+        let a = &argv[i];
+        let next = || -> &str { argv.get(i + 1).map(|s| s.as_str()).unwrap_or("") };
+        match a.as_str() {
+            "--clic" => {
+                cli.clic = PathBuf::from(next());
+                i += 2;
+            }
+            "--anim" => {
+                cli.anim = PathBuf::from(next());
+                i += 2;
+            }
+            "--rgba-out-dir" => {
+                cli.rgba_out_dir = Some(PathBuf::from(next()));
+                i += 2;
+            }
+            "--targets" => {
+                cli.targets = next()
+                    .split(',')
+                    .map(|s| s.trim().parse::<f32>().expect("bad --targets"))
+                    .collect();
+                i += 2;
+            }
+            "--max-passes" => {
+                cli.max_passes = next().parse().unwrap();
+                i += 2;
+            }
+            "--max-overshoot" => {
+                cli.max_overshoot = next().parse().unwrap();
+                i += 2;
+            }
+            "--method" => {
+                cli.method = next().parse().unwrap();
+                i += 2;
+            }
+            "--clic-limit" => {
+                cli.clic_limit = next().parse().unwrap();
+                i += 2;
+            }
+            other => panic!("unknown arg: {other}"),
+        }
+    }
+    cli
+}
+
+#[derive(Default, Clone)]
+struct Agg {
+    n: u32,
+    passes_sum: u32,
+    passes_one: u32,
+    achieved_sum: f64,
+    targets_met: u32,
+    undershoot: u32,
+    overshoot: u32,
+    bytes: Vec<u64>,
+}
+
+fn fold(into: &mut Agg, src: &Agg) {
+    into.n += src.n;
+    into.passes_sum += src.passes_sum;
+    into.passes_one += src.passes_one;
+    into.achieved_sum += src.achieved_sum;
+    into.targets_met += src.targets_met;
+    into.undershoot += src.undershoot;
+    into.overshoot += src.overshoot;
+    into.bytes.extend(src.bytes.iter().copied());
+}
+
+fn agg_one(target: f32, max_overshoot: f32, m: zenwebp::ZensimEncodeMetrics, bytes: usize) -> Agg {
+    Agg {
+        n: 1,
+        passes_sum: u32::from(m.passes_used),
+        passes_one: u32::from(m.passes_used == 1),
+        achieved_sum: f64::from(m.achieved_score),
+        targets_met: u32::from(m.targets_met),
+        undershoot: u32::from(m.achieved_score < target),
+        overshoot: u32::from(m.achieved_score > target + max_overshoot),
+        bytes: vec![bytes as u64],
+    }
+}
+
+fn median_u64(v: &[u64]) -> u64 {
+    if v.is_empty() {
+        return 0;
+    }
+    let mut s = v.to_vec();
+    s.sort_unstable();
+    if s.len() % 2 == 1 {
+        s[s.len() / 2]
+    } else {
+        (s[s.len() / 2 - 1] + s[s.len() / 2]) / 2
+    }
+}
+
+fn print_summary(label: &str, target: Option<f32>, a: &Agg) {
+    if a.n == 0 {
+        return;
+    }
+    let n = a.n as f32;
+    let tgt = target.map(|t| format!("{t:.1}")).unwrap_or("ALL".into());
+    println!(
+        "{:24} target={:>5} n={:>4}  passes_avg={:.2}  pass1_share={:.0}%  achieved_avg={:.2}  met={}/{}  und={} ovs={}  med_bytes={}",
+        label,
+        tgt,
+        a.n,
+        a.passes_sum as f32 / n,
+        100.0 * a.passes_one as f32 / n,
+        a.achieved_sum / a.n as f64,
+        a.targets_met,
+        a.n,
+        a.undershoot,
+        a.overshoot,
+        median_u64(&a.bytes),
+    );
+}
+
+fn main() {
+    let cli = parse_args();
+    eprintln!(
+        "extended-eval: targets={:?} max_passes={} max_overshoot={} method={}",
+        cli.targets, cli.max_passes, cli.max_overshoot, cli.method
+    );
+
+    // ============================================================
+    // 3a — CLIC2025 1024px corpus (RGB)
+    // ============================================================
+    println!("\n========================================");
+    println!("=== Phase 3a: CLIC2025 1024px corpus ===");
+    println!("========================================");
+    run_clic_phase(&cli);
+
+    // ============================================================
+    // 3b — RGBA convergence
+    // ============================================================
+    println!("\n========================================");
+    println!("=== Phase 3b: RGBA convergence       ===");
+    println!("========================================");
+    run_rgba_phase(&cli);
+
+    // ============================================================
+    // 3c — Animation per-frame convergence
+    // ============================================================
+    println!("\n========================================");
+    println!("=== Phase 3c: animation per-frame    ===");
+    println!("========================================");
+    run_anim_phase(&cli);
+}
+
+// --------------------------------------------------------------------
+// 3a: CLIC2025
+// --------------------------------------------------------------------
+
+fn run_clic_phase(cli: &Cli) {
+    let mut paths: Vec<PathBuf> = match fs::read_dir(&cli.clic) {
+        Ok(it) => it
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.is_file() && p.extension().is_some_and(|e| e == "png" || e == "PNG"))
+            .collect(),
+        Err(e) => {
+            eprintln!(
+                "WARN: cannot read CLIC corpus at {}: {e:?}",
+                cli.clic.display()
+            );
+            return;
+        }
+    };
+    paths.sort();
+    let total_count = paths.len();
+    paths.truncate(cli.clic_limit);
+    eprintln!(
+        "CLIC: {} candidates at {}, limited to {}",
+        total_count,
+        cli.clic.display(),
+        paths.len()
+    );
+
+    // Persist per-image TSV.
+    let out_dir = PathBuf::from("/mnt/v/output/zenwebp/zensim-clic-eval");
+    let _ = fs::create_dir_all(&out_dir);
+    let out_path = out_dir.join("clic1024_2026-04-27.tsv");
+    let mut tsv = match fs::File::create(&out_path) {
+        Ok(f) => Some(std::io::BufWriter::new(f)),
+        Err(e) => {
+            eprintln!("warn: cannot create {} ({e:?})", out_path.display());
+            None
+        }
+    };
+    if let Some(w) = tsv.as_mut() {
+        let _ = writeln!(
+            w,
+            "image\twidth\theight\ttarget\tpasses\tachieved\tbytes\ttargets_met"
+        );
+    }
+
+    use std::collections::BTreeMap;
+    let mut by_target: BTreeMap<u32, Agg> = BTreeMap::new();
+    let mut overall = Agg::default();
+
+    for path in &paths {
+        let (rgb, w, h) = match decode_png_rgb(path) {
+            Some(t) => t,
+            None => {
+                eprintln!("skip: cannot decode {}", path.display());
+                continue;
+            }
+        };
+        if w < 32 || h < 32 {
+            continue;
+        }
+        let img_name = path.file_name().unwrap().to_string_lossy().to_string();
+        for &target in &cli.targets {
+            let cfg = LossyConfig::new()
+                .with_method(cli.method)
+                .with_target_zensim(
+                    ZensimTarget::new(target)
+                        .with_max_overshoot(Some(cli.max_overshoot))
+                        .with_max_passes(cli.max_passes),
+                );
+            let r = EncodeRequest::lossy(&cfg, &rgb, PixelLayout::Rgb8, w, h).encode_with_metrics();
+            match r {
+                Ok((b, m)) => {
+                    if let Some(out) = tsv.as_mut() {
+                        let _ = writeln!(
+                            out,
+                            "{}\t{}\t{}\t{:.2}\t{}\t{:.4}\t{}\t{}",
+                            img_name,
+                            w,
+                            h,
+                            target,
+                            m.passes_used,
+                            m.achieved_score,
+                            b.len(),
+                            u8::from(m.targets_met),
+                        );
+                    }
+                    let a = agg_one(target, cli.max_overshoot, m, b.len());
+                    fold(&mut overall, &a);
+                    fold(by_target.entry((target * 100.0) as u32).or_default(), &a);
+                }
+                Err(e) => eprintln!("CLIC ERROR {img_name} target={target}: {:?}", e),
+            }
+        }
+        eprint!(".");
+    }
+    eprintln!();
+    if let Some(mut w) = tsv {
+        let _ = w.flush();
+    }
+    println!("--- CLIC by target ---");
+    for (t100, a) in &by_target {
+        print_summary("CLIC1024", Some(*t100 as f32 / 100.0), a);
+    }
+    print_summary("CLIC1024 ALL", None, &overall);
+    eprintln!("CLIC TSV: {}", out_path.display());
+}
+
+// --------------------------------------------------------------------
+// 3b: RGBA synthesis + convergence
+// --------------------------------------------------------------------
+
+/// Build the canonical synthetic RGBA test set (8 images: smooth
+/// gradient + alpha gradient, photo-like (mixed sin), screen-content
+/// (sharp blocks), checkerboard alpha, semi-transparent overlay,
+/// translucent gradient corners, a noisy-photo facsimile, a
+/// horizontal alpha-fade banner).
+fn synthetic_rgba_set() -> Vec<(String, Vec<u8>, u32, u32)> {
+    let w: u32 = 256;
+    let h: u32 = 256;
+    let mut out = Vec::new();
+
+    // 1. smooth gradient + alpha gradient
+    out.push((
+        "smooth_grad_alpha_grad".into(),
+        {
+            let mut buf = Vec::with_capacity((w * h * 4) as usize);
+            for y in 0..h {
+                for x in 0..w {
+                    let r = ((x * 255) / w) as u8;
+                    let g = ((y * 255) / h) as u8;
+                    let b = (((x + y) * 255) / (w + h)) as u8;
+                    let a = ((x * 255) / w) as u8;
+                    buf.extend_from_slice(&[r, g, b, a]);
+                }
+            }
+            buf
+        },
+        w,
+        h,
+    ));
+
+    // 2. photo-like mixed content (full alpha)
+    out.push((
+        "photo_mixed_full_alpha".into(),
+        {
+            let mut buf = Vec::with_capacity((w * h * 4) as usize);
+            for y in 0..h {
+                for x in 0..w {
+                    let fx = x as f32 / w as f32;
+                    let fy = y as f32 / h as f32;
+                    let base_r = 80.0 + 100.0 * fx;
+                    let base_g = 100.0 + 80.0 * fy;
+                    let base_b = 90.0 + 80.0 * (1.0 - fx);
+                    let tex = 18.0
+                        * ((fx * 9.0).sin() * (fy * 7.0).cos()
+                            + 0.6 * (fx * 17.0 + fy * 11.0).sin());
+                    let r = (base_r + tex).clamp(0.0, 255.0) as u8;
+                    let g = (base_g + tex * 0.7).clamp(0.0, 255.0) as u8;
+                    let b = (base_b - tex * 0.5).clamp(0.0, 255.0) as u8;
+                    buf.extend_from_slice(&[r, g, b, 255]);
+                }
+            }
+            buf
+        },
+        w,
+        h,
+    ));
+
+    // 3. screen-content sharp blocks (alpha=255)
+    out.push((
+        "screen_content_blocks".into(),
+        {
+            let mut buf = Vec::with_capacity((w * h * 4) as usize);
+            for y in 0..h {
+                for x in 0..w {
+                    let qy = (y / 32) as u8;
+                    let qx = (x / 32) as u8;
+                    let id = (qy ^ qx) % 4;
+                    let (r, g, b) = match id {
+                        0 => (240, 240, 240),
+                        1 => (50, 50, 60),
+                        2 => (210, 60, 60),
+                        _ => (60, 130, 220),
+                    };
+                    buf.extend_from_slice(&[r, g, b, 255]);
+                }
+            }
+            buf
+        },
+        w,
+        h,
+    ));
+
+    // 4. checkerboard alpha (sharp transparency edges)
+    out.push((
+        "checkerboard_alpha".into(),
+        {
+            let mut buf = Vec::with_capacity((w * h * 4) as usize);
+            for y in 0..h {
+                for x in 0..w {
+                    let cell = ((x / 16) ^ (y / 16)) & 1;
+                    let a = if cell == 0 { 255u8 } else { 0u8 };
+                    buf.extend_from_slice(&[200, 80, 100, a]);
+                }
+            }
+            buf
+        },
+        w,
+        h,
+    ));
+
+    // 5. semi-transparent overlay (constant 128 alpha)
+    out.push((
+        "semi_transparent".into(),
+        {
+            let mut buf = Vec::with_capacity((w * h * 4) as usize);
+            for y in 0..h {
+                for x in 0..w {
+                    let r = ((x * 200) / w) as u8;
+                    let g = ((y * 200) / h) as u8;
+                    buf.extend_from_slice(&[r, g, 100, 128]);
+                }
+            }
+            buf
+        },
+        w,
+        h,
+    ));
+
+    // 6. translucent corners (radial alpha)
+    out.push((
+        "radial_alpha".into(),
+        {
+            let mut buf = Vec::with_capacity((w * h * 4) as usize);
+            let cx = (w / 2) as f32;
+            let cy = (h / 2) as f32;
+            let max_d = (cx.powi(2) + cy.powi(2)).sqrt();
+            for y in 0..h {
+                for x in 0..w {
+                    let dx = x as f32 - cx;
+                    let dy = y as f32 - cy;
+                    let d = (dx * dx + dy * dy).sqrt();
+                    let a = (255.0 * (1.0 - (d / max_d))).clamp(0.0, 255.0) as u8;
+                    buf.extend_from_slice(&[180, 90, 220, a]);
+                }
+            }
+            buf
+        },
+        w,
+        h,
+    ));
+
+    // 7. noisy-photo facsimile (small spatial noise added to a texture)
+    out.push((
+        "noisy_photo".into(),
+        {
+            let mut buf = Vec::with_capacity((w * h * 4) as usize);
+            for y in 0..h {
+                for x in 0..w {
+                    let fx = x as f32 / w as f32;
+                    let fy = y as f32 / h as f32;
+                    let base = 90.0 + 60.0 * fx + 40.0 * fy;
+                    // Cheap pseudorandom noise — don't import rand.
+                    let h = ((x.wrapping_mul(2654435761)) ^ y.wrapping_mul(40503)) as u8;
+                    let n = (h as i32 - 128) / 6;
+                    let r = (base + n as f32).clamp(0.0, 255.0) as u8;
+                    let g = (base * 0.95 + n as f32).clamp(0.0, 255.0) as u8;
+                    let b = (base * 0.85 + n as f32).clamp(0.0, 255.0) as u8;
+                    buf.extend_from_slice(&[r, g, b, 255]);
+                }
+            }
+            buf
+        },
+        w,
+        h,
+    ));
+
+    // 8. horizontal alpha-fade banner
+    out.push((
+        "alpha_fade_banner".into(),
+        {
+            let mut buf = Vec::with_capacity((w * h * 4) as usize);
+            for y in 0..h {
+                for x in 0..w {
+                    let band = (y as i32 - 128).abs();
+                    let a = if band > 32 {
+                        0u8
+                    } else {
+                        ((32 - band) * 8).clamp(0, 255) as u8
+                    };
+                    let r = ((x * 200) / w) as u8;
+                    buf.extend_from_slice(&[r, 60, 240 - r, a]);
+                }
+            }
+            buf
+        },
+        w,
+        h,
+    ));
+
+    out
+}
+
+fn run_rgba_phase(cli: &Cli) {
+    let images = synthetic_rgba_set();
+    eprintln!("RGBA: synthesized {} images (256x256)", images.len());
+
+    if let Some(out_dir) = &cli.rgba_out_dir {
+        let _ = fs::create_dir_all(out_dir);
+        for (name, _, _, _) in &images {
+            // No PNG re-encoding — record names for traceability only.
+            let _ = std::fs::write(
+                out_dir.join(format!("{name}.txt")),
+                b"synth-rgba placeholder",
+            );
+        }
+    }
+
+    use std::collections::BTreeMap;
+    let mut by_target: BTreeMap<u32, Agg> = BTreeMap::new();
+    let mut by_image: BTreeMap<String, Agg> = BTreeMap::new();
+    let mut overall = Agg::default();
+
+    for (name, rgba, w, h) in &images {
+        for &target in &cli.targets {
+            let cfg = LossyConfig::new()
+                .with_method(cli.method)
+                .with_target_zensim(
+                    ZensimTarget::new(target)
+                        .with_max_overshoot(Some(cli.max_overshoot))
+                        .with_max_passes(cli.max_passes),
+                );
+            // PixelLayout::Rgba8 — the encoder converts to YUVA
+            // internally. We just want to confirm the iteration loop
+            // works on RGBA inputs and converges.
+            let r =
+                EncodeRequest::lossy(&cfg, rgba, PixelLayout::Rgba8, *w, *h).encode_with_metrics();
+            match r {
+                Ok((b, m)) => {
+                    let a = agg_one(target, cli.max_overshoot, m, b.len());
+                    fold(&mut overall, &a);
+                    fold(by_target.entry((target * 100.0) as u32).or_default(), &a);
+                    fold(by_image.entry(name.clone()).or_default(), &a);
+                    eprintln!(
+                        "  rgba {name} target={target} achieved={:.2} passes={} bytes={} met={}",
+                        m.achieved_score,
+                        m.passes_used,
+                        b.len(),
+                        m.targets_met,
+                    );
+                }
+                Err(e) => eprintln!("RGBA ERROR {name} target={target}: {:?}", e),
+            }
+        }
+    }
+    println!("--- RGBA by target ---");
+    for (t100, a) in &by_target {
+        print_summary("RGBA-synth", Some(*t100 as f32 / 100.0), a);
+    }
+    println!("--- RGBA by image (across all targets) ---");
+    for (name, a) in &by_image {
+        print_summary(name, None, a);
+    }
+    print_summary("RGBA-synth ALL", None, &overall);
+}
+
+// --------------------------------------------------------------------
+// 3c: Animation per-frame
+// --------------------------------------------------------------------
+
+fn run_anim_phase(cli: &Cli) {
+    let bytes = match fs::read(&cli.anim) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("WARN: cannot read anim {}: {e:?}", cli.anim.display());
+            return;
+        }
+    };
+    let demuxer = match zenwebp::mux::WebPDemuxer::new(&bytes) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("WARN: demux failed: {:?}", e);
+            return;
+        }
+    };
+    eprintln!(
+        "anim: {}x{}, {} frames, animated={}",
+        demuxer.canvas_width(),
+        demuxer.canvas_height(),
+        demuxer.num_frames(),
+        demuxer.is_animated(),
+    );
+
+    let target: f32 = cli
+        .targets
+        .iter()
+        .copied()
+        .find(|&t| (t - 80.0).abs() < 0.01)
+        .unwrap_or(80.0);
+    let max_passes = cli.max_passes.max(2);
+
+    use std::collections::BTreeMap;
+    let mut by_frame: BTreeMap<u32, Agg> = BTreeMap::new();
+    let mut overall = Agg::default();
+
+    for n in 1..=demuxer.num_frames() {
+        // Re-decode the whole anim at frame n (compose-over canvas).
+        let rgba = match decode_anim_frame_rgba(&bytes, n) {
+            Some(t) => t,
+            None => {
+                eprintln!("anim: frame {n} decode failed");
+                continue;
+            }
+        };
+        let (rgba_buf, w, h) = rgba;
+        let cfg = LossyConfig::new()
+            .with_method(cli.method)
+            .with_target_zensim(
+                ZensimTarget::new(target)
+                    .with_max_overshoot(Some(cli.max_overshoot))
+                    .with_max_passes(max_passes),
+            );
+        let r =
+            EncodeRequest::lossy(&cfg, &rgba_buf, PixelLayout::Rgba8, w, h).encode_with_metrics();
+        match r {
+            Ok((b, m)) => {
+                let a = agg_one(target, cli.max_overshoot, m, b.len());
+                fold(&mut overall, &a);
+                fold(by_frame.entry(n).or_default(), &a);
+                eprintln!(
+                    "  frame {n}: {}x{} achieved={:.2} passes={} bytes={} met={}",
+                    w,
+                    h,
+                    m.achieved_score,
+                    m.passes_used,
+                    b.len(),
+                    m.targets_met,
+                );
+            }
+            Err(e) => eprintln!("anim frame {n} ERROR: {:?}", e),
+        }
+    }
+    println!("--- anim per-frame (target={target}, max_passes={max_passes}) ---");
+    for (n, a) in &by_frame {
+        print_summary(&format!("frame_{n}"), Some(target), a);
+    }
+    print_summary("anim ALL frames", Some(target), &overall);
+}
+
+/// Decode a single animation frame (1-based) of a WebP file to RGBA.
+/// Uses the zenwebp full-frame oneshot decoder against the per-frame
+/// bitstream extracted by the demuxer. This bypasses canvas
+/// composition (dispose/blend) — adequate for confirming the encoder
+/// loop converges; not a faithful playback.
+fn decode_anim_frame_rgba(data: &[u8], n: u32) -> Option<(Vec<u8>, u32, u32)> {
+    let demuxer = zenwebp::mux::WebPDemuxer::new(data).ok()?;
+    let frame = demuxer.frame(n)?;
+    // Extract per-frame WebP bitstream and decode standalone. We need
+    // a complete WebP (RIFF wrapper) — rebuild one around the VP8/VP8L
+    // bitstream so the standard decoder accepts it.
+    let mut webp = Vec::with_capacity(frame.bitstream.len() + 32);
+    webp.extend_from_slice(b"RIFF");
+    let body_size: u32 = 4 + 8 + frame.bitstream.len() as u32;
+    webp.extend_from_slice(&body_size.to_le_bytes());
+    webp.extend_from_slice(b"WEBP");
+    let chunk = if frame.is_lossy { *b"VP8 " } else { *b"VP8L" };
+    webp.extend_from_slice(&chunk);
+    webp.extend_from_slice(&(frame.bitstream.len() as u32).to_le_bytes());
+    webp.extend_from_slice(frame.bitstream);
+    if frame.bitstream.len() % 2 == 1 {
+        webp.push(0);
+    }
+    let (rgba, w, h) = zenwebp::oneshot::decode_rgba(&webp).ok()?;
+    Some((rgba, w, h))
+}
+
+fn decode_png_rgb(path: &PathBuf) -> Option<(Vec<u8>, u32, u32)> {
+    let bytes = fs::read(path).ok()?;
+    let cur = std::io::Cursor::new(bytes);
+    let mut decoder = png::Decoder::new(cur);
+    decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
+    let mut reader = decoder.read_info().ok()?;
+    let info = reader.info();
+    let w = info.width;
+    let h = info.height;
+    let color = info.color_type;
+    let bytes_per_pixel = match color {
+        png::ColorType::Rgb => 3,
+        png::ColorType::Rgba => 4,
+        png::ColorType::Grayscale => 1,
+        png::ColorType::GrayscaleAlpha => 2,
+        png::ColorType::Indexed => 3,
+    };
+    let mut buf = vec![0u8; (w as usize * h as usize) * bytes_per_pixel];
+    reader.next_frame(&mut buf).ok()?;
+    let rgb = match color {
+        png::ColorType::Rgb | png::ColorType::Indexed => buf,
+        png::ColorType::Rgba => {
+            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            for px in buf.chunks_exact(4) {
+                out.extend_from_slice(&[px[0], px[1], px[2]]);
+            }
+            out
+        }
+        png::ColorType::Grayscale => {
+            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            for &g in &buf {
+                out.extend_from_slice(&[g, g, g]);
+            }
+            out
+        }
+        png::ColorType::GrayscaleAlpha => {
+            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            for px in buf.chunks_exact(2) {
+                out.extend_from_slice(&[px[0], px[0], px[0]]);
+            }
+            out
+        }
+    };
+    Some((rgb, w, h))
+}

--- a/dev/zensim_phase3_trace.rs
+++ b/dev/zensim_phase3_trace.rs
@@ -167,7 +167,7 @@ fn main() {
             let cfg = LossyConfig::new()
                 .with_method(method)
                 .with_segments(4)
-                .with_target_zensim_target(
+                .with_target_zensim(
                     ZensimTarget::new(target)
                         .with_max_overshoot(Some(max_overshoot))
                         .with_max_passes(max_passes),

--- a/dev/zensim_phase3_trace.rs
+++ b/dev/zensim_phase3_trace.rs
@@ -20,7 +20,9 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
+use zenwebp::EncodeRequest;
 use zenwebp::LossyConfig;
+use zenwebp::PixelLayout;
 use zenwebp::ZensimTarget;
 
 mod env_set {
@@ -170,7 +172,9 @@ fn main() {
                         .with_max_overshoot(Some(max_overshoot))
                         .with_max_passes(max_passes),
                 );
-            let (b, m) = cfg.encode_rgb_with_metrics(&rgb, w, h).expect("encode");
+            let (b, m) = EncodeRequest::lossy(&cfg, &rgb, PixelLayout::Rgb8, w, h)
+                .encode_with_metrics()
+                .expect("encode");
             eprintln!(
                 "===RESULT=== variant={variant} img={} achieved={:.4} bytes={} passes={} met={}",
                 img_path.display(),

--- a/dev/zensim_phase3_trace.rs
+++ b/dev/zensim_phase3_trace.rs
@@ -129,16 +129,25 @@ fn main() {
             "--max-passes" => max_passes = args.next().unwrap().parse().unwrap(),
             "--method" => method = args.next().unwrap().parse().unwrap(),
             "--variants" => {
-                variants = args.next().unwrap().split(',').map(|s| s.to_string()).collect();
+                variants = args
+                    .next()
+                    .unwrap()
+                    .split(',')
+                    .map(|s| s.to_string())
+                    .collect();
             }
             other => panic!("unknown arg: {other}"),
         }
     }
     if images.is_empty() {
-        eprintln!("usage: --image <path> [--image ...] [--target 80] [--max-passes 3] [--variants baseline,noA]");
+        eprintln!(
+            "usage: --image <path> [--image ...] [--target 80] [--max-passes 3] [--variants baseline,noA]"
+        );
         std::process::exit(2);
     }
-    eprintln!("zensim_phase3_trace: target={target} max_overshoot={max_overshoot} max_passes={max_passes} method={method}");
+    eprintln!(
+        "zensim_phase3_trace: target={target} max_overshoot={max_overshoot} max_passes={max_passes} method={method}"
+    );
     eprintln!("variants: {:?}", variants);
 
     for variant in &variants {

--- a/dev/zensim_phase3_trace.rs
+++ b/dev/zensim_phase3_trace.rs
@@ -1,0 +1,175 @@
+//! Single-image Phase 3 tracer. Runs target_zensim on one (or a few)
+//! PNG files at a chosen target/max_overshoot/max_passes and prints the
+//! `PHASE3_TRACE` lines to stderr (the iteration-loop instrumentation
+//! is already gated by `ZENWEBP_PHASE3_TRACE=1`).
+//!
+//! Usage:
+//!   ZENWEBP_PHASE3_TRACE=1 zensim_phase3_trace --target 80 \
+//!     --max-passes 3 --max-overshoot 1.5 \
+//!     --variants baseline,noA \
+//!     --image /path/to/foo.png \
+//!     [--image /path/to/bar.png ...]
+//!
+//! For each (variant, image) the binary prints:
+//!   ===VARIANT===<variant>===
+//!   ===IMAGE===<path>===
+//!   <PHASE3_TRACE lines for this run>
+//!   ===RESULT=== achieved=... bytes=... passes=... met=...
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+use zenwebp::LossyConfig;
+use zenwebp::ZensimTarget;
+
+mod env_set {
+    pub fn set(key: &str, val: Option<&str>) {
+        // SAFETY: dev binary, single-threaded. Same pattern as zensim_ablation.
+        unsafe {
+            match val {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+}
+
+fn reset_env() {
+    let keys = [
+        "ZENWEBP_PHASE3_QUADRANT",
+        "ZENWEBP_ABLATE_NO_PHASE3",
+        "ZENWEBP_ABLATE_NAIVE_Q",
+        "ZENWEBP_ABLATE_NO_MULTI_PASS_STATS",
+        "ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS",
+        "ZENWEBP_ABLATE_NO_SECANT",
+        "ZENWEBP_PHASE3_FINE_GAP",
+    ];
+    for k in &keys {
+        env_set::set(k, None);
+    }
+}
+
+fn apply_variant(name: &str) {
+    reset_env();
+    for tok in name.split('_') {
+        match tok {
+            "baseline" => {}
+            "noA" => env_set::set("ZENWEBP_ABLATE_NO_PHASE3", Some("1")),
+            "noB" => env_set::set("ZENWEBP_PHASE3_QUADRANT", Some("1")),
+            "noC" => env_set::set("ZENWEBP_ABLATE_NAIVE_Q", Some("1")),
+            "noD" => env_set::set("ZENWEBP_ABLATE_NO_MULTI_PASS_STATS", Some("1")),
+            "noE" => env_set::set("ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS", Some("1")),
+            "noF" => env_set::set("ZENWEBP_ABLATE_NO_SECANT", Some("1")),
+            "alwaysOn" => env_set::set("ZENWEBP_PHASE3_FINE_GAP", Some("1000")),
+            other => panic!("unknown variant token: {other}"),
+        }
+    }
+}
+
+fn decode_png_rgb(path: &PathBuf) -> Option<(Vec<u8>, u32, u32)> {
+    let bytes = fs::read(path).ok()?;
+    let cur = std::io::Cursor::new(bytes);
+    let mut decoder = png::Decoder::new(cur);
+    decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
+    let mut reader = decoder.read_info().ok()?;
+    let info = reader.info();
+    let w = info.width;
+    let h = info.height;
+    let color = info.color_type;
+    let bytes_per_pixel = match color {
+        png::ColorType::Rgb => 3,
+        png::ColorType::Rgba => 4,
+        png::ColorType::Grayscale => 1,
+        png::ColorType::GrayscaleAlpha => 2,
+        png::ColorType::Indexed => 3,
+    };
+    let mut buf = vec![0u8; (w as usize * h as usize) * bytes_per_pixel];
+    reader.next_frame(&mut buf).ok()?;
+    let rgb = match color {
+        png::ColorType::Rgb | png::ColorType::Indexed => buf,
+        png::ColorType::Rgba => {
+            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            for px in buf.chunks_exact(4) {
+                out.extend_from_slice(&[px[0], px[1], px[2]]);
+            }
+            out
+        }
+        png::ColorType::Grayscale => {
+            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            for &g in &buf {
+                out.extend_from_slice(&[g, g, g]);
+            }
+            out
+        }
+        png::ColorType::GrayscaleAlpha => {
+            let mut out = Vec::with_capacity(w as usize * h as usize * 3);
+            for px in buf.chunks_exact(2) {
+                out.extend_from_slice(&[px[0], px[0], px[0]]);
+            }
+            out
+        }
+    };
+    Some((rgb, w, h))
+}
+
+fn main() {
+    let mut images: Vec<PathBuf> = Vec::new();
+    let mut target = 80.0f32;
+    let mut max_overshoot = 1.5f32;
+    let mut max_passes = 3u8;
+    let mut method = 4u8;
+    let mut variants: Vec<String> = vec!["baseline".into(), "noA".into()];
+    let mut args = env::args().skip(1).collect::<Vec<_>>().into_iter();
+    while let Some(a) = args.next() {
+        match a.as_str() {
+            "--image" => images.push(PathBuf::from(args.next().unwrap())),
+            "--target" => target = args.next().unwrap().parse().unwrap(),
+            "--max-overshoot" => max_overshoot = args.next().unwrap().parse().unwrap(),
+            "--max-passes" => max_passes = args.next().unwrap().parse().unwrap(),
+            "--method" => method = args.next().unwrap().parse().unwrap(),
+            "--variants" => {
+                variants = args.next().unwrap().split(',').map(|s| s.to_string()).collect();
+            }
+            other => panic!("unknown arg: {other}"),
+        }
+    }
+    if images.is_empty() {
+        eprintln!("usage: --image <path> [--image ...] [--target 80] [--max-passes 3] [--variants baseline,noA]");
+        std::process::exit(2);
+    }
+    eprintln!("zensim_phase3_trace: target={target} max_overshoot={max_overshoot} max_passes={max_passes} method={method}");
+    eprintln!("variants: {:?}", variants);
+
+    for variant in &variants {
+        eprintln!("\n===VARIANT==={variant}===");
+        for img_path in &images {
+            apply_variant(variant);
+            let (rgb, w, h) = match decode_png_rgb(img_path) {
+                Some(t) => t,
+                None => {
+                    eprintln!("skip: cannot decode {}", img_path.display());
+                    continue;
+                }
+            };
+            eprintln!("===IMAGE==={}===", img_path.display());
+            let cfg = LossyConfig::new()
+                .with_method(method)
+                .with_segments(4)
+                .with_target_zensim_target(
+                    ZensimTarget::new(target)
+                        .with_max_overshoot(Some(max_overshoot))
+                        .with_max_passes(max_passes),
+                );
+            let (b, m) = cfg.encode_rgb_with_metrics(&rgb, w, h).expect("encode");
+            eprintln!(
+                "===RESULT=== variant={variant} img={} achieved={:.4} bytes={} passes={} met={}",
+                img_path.display(),
+                m.achieved_score,
+                b.len(),
+                m.passes_used,
+                m.targets_met,
+            );
+        }
+    }
+}

--- a/dev/zensim_phase3_trace.rs
+++ b/dev/zensim_phase3_trace.rs
@@ -1,10 +1,10 @@
 //! Single-image Phase 3 tracer. Runs target_zensim on one (or a few)
 //! PNG files at a chosen target/max_overshoot/max_passes and prints the
 //! `PHASE3_TRACE` lines to stderr (the iteration-loop instrumentation
-//! is already gated by `ZENWEBP_PHASE3_TRACE=1`).
+//! is enabled here via [`zenwebp::AblationToggles::trace_phase3`]).
 //!
 //! Usage:
-//!   ZENWEBP_PHASE3_TRACE=1 zensim_phase3_trace --target 80 \
+//!   zensim_phase3_trace --target 80 \
 //!     --max-passes 3 --max-overshoot 1.5 \
 //!     --variants baseline,noA \
 //!     --image /path/to/foo.png \
@@ -20,53 +20,33 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
+use zenwebp::AblationToggles;
 use zenwebp::EncodeRequest;
 use zenwebp::LossyConfig;
 use zenwebp::PixelLayout;
 use zenwebp::ZensimTarget;
-
-mod env_set {
-    pub fn set(key: &str, val: Option<&str>) {
-        // SAFETY: dev binary, single-threaded. Same pattern as zensim_ablation.
-        unsafe {
-            match val {
-                Some(v) => std::env::set_var(key, v),
-                None => std::env::remove_var(key),
-            }
-        }
-    }
-}
-
-fn reset_env() {
-    let keys = [
-        "ZENWEBP_PHASE3_QUADRANT",
-        "ZENWEBP_ABLATE_NO_PHASE3",
-        "ZENWEBP_ABLATE_NAIVE_Q",
-        "ZENWEBP_ABLATE_NO_MULTI_PASS_STATS",
-        "ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS",
-        "ZENWEBP_ABLATE_NO_SECANT",
-        "ZENWEBP_PHASE3_FINE_GAP",
-    ];
-    for k in &keys {
-        env_set::set(k, None);
-    }
-}
+use zenwebp::set_ablation_toggles;
 
 fn apply_variant(name: &str) {
-    reset_env();
+    // Always force trace_phase3=true for this binary's purpose.
+    let mut t = AblationToggles {
+        trace_phase3: true,
+        ..AblationToggles::default()
+    };
     for tok in name.split('_') {
         match tok {
             "baseline" => {}
-            "noA" => env_set::set("ZENWEBP_ABLATE_NO_PHASE3", Some("1")),
-            "noB" => env_set::set("ZENWEBP_PHASE3_QUADRANT", Some("1")),
-            "noC" => env_set::set("ZENWEBP_ABLATE_NAIVE_Q", Some("1")),
-            "noD" => env_set::set("ZENWEBP_ABLATE_NO_MULTI_PASS_STATS", Some("1")),
-            "noE" => env_set::set("ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS", Some("1")),
-            "noF" => env_set::set("ZENWEBP_ABLATE_NO_SECANT", Some("1")),
-            "alwaysOn" => env_set::set("ZENWEBP_PHASE3_FINE_GAP", Some("1000")),
+            "noA" => t.disable_phase3 = true,
+            "noB" => t.use_quadrant_proxy = true,
+            "noC" => t.naive_starting_q = true,
+            "noD" => t.no_multi_pass_stats = true,
+            "noE" => t.pre_phase2_anchors = true,
+            "noF" => t.no_secant = true,
+            "alwaysOn" => t.phase3_fine_gap = Some(1000.0),
             other => panic!("unknown variant token: {other}"),
         }
     }
+    set_ablation_toggles(t);
 }
 
 fn decode_png_rgb(path: &PathBuf) -> Option<(Vec<u8>, u32, u32)> {

--- a/src/encoder/api.rs
+++ b/src/encoder/api.rs
@@ -1388,8 +1388,19 @@ impl<'a> EncodeRequest<'a> {
     }
 
     /// Encode to WebP bytes.
+    ///
+    /// When the lossy config has `target_zensim` set and the
+    /// `target-zensim` crate feature is enabled, the encoder runs a
+    /// closed-loop iteration (encode → decode → measure → adjust)
+    /// transparently and returns the converged bytes. Use
+    /// [`Self::encode_with_metrics`] if you also need the
+    /// [`ZensimEncodeMetrics`] (achieved score, passes used,
+    /// targets-met flag).
     #[track_caller]
     pub fn encode(self) -> EncodeResult<Vec<u8>> {
+        if let Some(bytes) = self.try_encode_target_zensim_bytes()? {
+            return Ok(bytes);
+        }
         let (output, _stats) = self.encode_inner()?;
         Ok(output)
     }
@@ -1406,6 +1417,89 @@ impl<'a> EncodeRequest<'a> {
     #[track_caller]
     pub fn encode_with_stats(self) -> EncodeResult<(Vec<u8>, EncodeStats)> {
         self.encode_inner()
+    }
+
+    /// Encode to WebP bytes alongside [`ZensimEncodeMetrics`].
+    ///
+    /// When the lossy config has `target_zensim` set and the
+    /// `target-zensim` crate feature is enabled (with RGB8 input), the
+    /// encoder runs a closed-loop iteration and reports the achieved
+    /// zensim score, passes used, and `targets_met` flag in the
+    /// returned metrics. In every other case (no target, feature
+    /// disabled, lossless, non-RGB8 layout), the metrics are filled
+    /// via [`ZensimEncodeMetrics::no_target`] — score `NaN`,
+    /// `passes_used=1`, `targets_met=true`.
+    ///
+    /// Mirrors the shape of zenjpeg's
+    /// `BytesEncoder::finish_with_metrics()`.
+    #[track_caller]
+    pub fn encode_with_metrics(
+        self,
+    ) -> EncodeResult<(Vec<u8>, super::zensim_target::ZensimEncodeMetrics)> {
+        if let Some(pair) = self.try_encode_target_zensim_with_metrics()? {
+            return Ok(pair);
+        }
+        let (output, _stats) = self.encode_inner()?;
+        let len = output.len();
+        Ok((
+            output,
+            super::zensim_target::ZensimEncodeMetrics::no_target(len),
+        ))
+    }
+
+    /// If this request targets a lossy config with `target_zensim`
+    /// set, RGB8 input, no stride override, and the `target-zensim`
+    /// feature is on, run the iteration loop and return the converged
+    /// bytes. Otherwise returns `Ok(None)` so the caller can fall
+    /// back to the normal single-pass path.
+    fn try_encode_target_zensim_bytes(&self) -> EncodeResult<Option<Vec<u8>>> {
+        match self.try_encode_target_zensim_with_metrics()? {
+            Some((bytes, _m)) => Ok(Some(bytes)),
+            None => Ok(None),
+        }
+    }
+
+    /// Same as [`Self::try_encode_target_zensim_bytes`] but also
+    /// returns the metrics. The iteration loop is always RGB8-only,
+    /// no stride, lossy config; the metadata fields (icc/exif/xmp) are
+    /// not currently honored on the iteration path — if any are set
+    /// we fall back to a single-pass encode and return `None` so the
+    /// caller can take the normal path. (TODO: thread metadata
+    /// through iteration once a user needs it.)
+    #[allow(clippy::unnecessary_wraps)] // signature aligns with feature-on counterpart
+    fn try_encode_target_zensim_with_metrics(
+        &self,
+    ) -> EncodeResult<Option<(Vec<u8>, super::zensim_target::ZensimEncodeMetrics)>> {
+        // Only RGB8 lossy configs with target_zensim set and no
+        // metadata/stride trigger the iteration path. Everything else
+        // returns None so the caller falls back to encode_inner.
+        let lossy = match &self.config {
+            ConfigKind::Lossy(cfg) => *cfg,
+            ConfigKind::Lossless(_) => return Ok(None),
+            ConfigKind::Enum(config::EncoderConfig::Lossy(cfg)) => cfg,
+            ConfigKind::Enum(config::EncoderConfig::Lossless(_)) => return Ok(None),
+        };
+        if lossy.target_zensim.is_none() {
+            return Ok(None);
+        }
+        if self.color_type != PixelLayout::Rgb8 {
+            return Ok(None);
+        }
+        if self.stride_pixels.is_some() {
+            return Ok(None);
+        }
+        if self.icc_profile.is_some()
+            || self.exif_metadata.is_some()
+            || self.xmp_metadata.is_some()
+        {
+            // Iteration loop currently doesn't thread metadata
+            // through. Take the safe path.
+            return Ok(None);
+        }
+        let pair = lossy
+            .encode_rgb_with_metrics(self.pixels, self.width, self.height)
+            .map_err(|e| at!(e))?;
+        Ok(Some(pair))
     }
 
     /// Encode to WebP, writing to an [`io::Write`](std::io::Write) implementor.

--- a/src/encoder/api.rs
+++ b/src/encoder/api.rs
@@ -661,16 +661,6 @@ pub struct EncodeStats {
     pub segment_quant: [u8; 4],
     /// Per-segment loop filter level.
     pub segment_level: [u8; 4],
-    /// Per-MB segment IDs (row-major, length = mb_w * mb_h). Empty when
-    /// segments are disabled (num_segments == 1) or for lossless
-    /// encodes. Surfaced for closed-loop callers (`target_zensim` per-
-    /// segment correction).
-    pub segment_map: alloc::vec::Vec<u8>,
-    /// Number of macroblock columns (width in MBs). Useful alongside
-    /// [`segment_map`](Self::segment_map) for spatial aggregation.
-    pub mb_width: u16,
-    /// Number of macroblock rows (height in MBs).
-    pub mb_height: u16,
     /// Size of alpha plane data in bytes.
     pub alpha_data_size: u32,
 

--- a/src/encoder/api.rs
+++ b/src/encoder/api.rs
@@ -580,6 +580,13 @@ pub struct EncoderParams {
     /// `target_size` / `target_zensim` search loops, or under
     /// `CostModel::StrictLibwebpParity`. Default `false`.
     pub(crate) multi_pass_stats: bool,
+    /// Per-segment additive offsets to the post-modulation quant_index
+    /// (applied AFTER `compute_segment_quant`'s SNS modulation). Crate-
+    /// internal hook for the `target_zensim` per-segment correction
+    /// pass. `None` (default) leaves segments untouched. Each delta is
+    /// applied per-segment via `(seg_quant_index as i32 + delta).clamp(0,
+    /// 127)` before `init_matrices`.
+    pub(crate) segment_quant_overrides: Option<[i8; 4]>,
 }
 
 impl Default for EncoderParams {
@@ -603,6 +610,7 @@ impl Default for EncoderParams {
             smooth_segment_map: false,
             cost_model: CostModel::ZenwebpDefault,
             multi_pass_stats: false,
+            segment_quant_overrides: None,
         }
     }
 }
@@ -653,6 +661,16 @@ pub struct EncodeStats {
     pub segment_quant: [u8; 4],
     /// Per-segment loop filter level.
     pub segment_level: [u8; 4],
+    /// Per-MB segment IDs (row-major, length = mb_w * mb_h). Empty when
+    /// segments are disabled (num_segments == 1) or for lossless
+    /// encodes. Surfaced for closed-loop callers (`target_zensim` per-
+    /// segment correction).
+    pub segment_map: alloc::vec::Vec<u8>,
+    /// Number of macroblock columns (width in MBs). Useful alongside
+    /// [`segment_map`](Self::segment_map) for spatial aggregation.
+    pub mb_width: u16,
+    /// Number of macroblock rows (height in MBs).
+    pub mb_height: u16,
     /// Size of alpha plane data in bytes.
     pub alpha_data_size: u32,
 
@@ -1011,6 +1029,7 @@ impl EncoderConfig {
             smooth_segment_map: self.smooth_segment_map,
             cost_model: self.cost_model,
             multi_pass_stats: self.multi_pass_stats,
+            segment_quant_overrides: None,
         }
     }
 

--- a/src/encoder/api.rs
+++ b/src/encoder/api.rs
@@ -683,6 +683,34 @@ pub struct EncodeStats {
     pub lossless_data_size: u32,
 }
 
+/// Internal-only encoder diagnostics, used by the closed-loop iteration in
+/// `zensim_target` to drive per-segment correction decisions from the real
+/// k-means `segment_map` rather than a spatial proxy.
+///
+/// **Not part of the public API.** Exposing the segment_map on
+/// [`EncodeStats`] would be a SemVer break (existing callers may have done
+/// `EncodeStats { ..fields }` literal construction); routing the data
+/// through this `pub(crate)` companion struct keeps the surface clean while
+/// giving the iteration loop the full per-MB segmentation it needs.
+///
+/// Populated only by [`encode_frame_lossy_with_diagnostics`](super::vp8::encode_frame_lossy_with_diagnostics).
+#[cfg(feature = "target-zensim")]
+#[derive(Debug, Clone, Default)]
+pub(crate) struct EncodeDiagnostics {
+    /// Per-macroblock segment id (0..num_segments). Length is
+    /// `mb_width * mb_height`, raster order. Empty when segmentation is
+    /// disabled (`num_segments == 1` or the encoder skipped the analysis
+    /// pass).
+    pub segment_map: alloc::vec::Vec<u8>,
+    /// Macroblock grid width (image_width rounded up by 16, divided by 16).
+    pub mb_width: u16,
+    /// Macroblock grid height.
+    pub mb_height: u16,
+    /// Effective number of segments after `simplify_segments` may have
+    /// merged duplicates. `1..=4`.
+    pub num_segments: u8,
+}
+
 // ============================================================================
 // Builder-style Encoder API (webpx-compatible)
 // ============================================================================
@@ -1389,6 +1417,71 @@ impl<'a> EncodeRequest<'a> {
             .write_all(&encoded)
             .map_err(|e| at!(EncodeError::IoError(e)))?;
         Ok(())
+    }
+
+    /// Internal-only: encode and also return the encoder's `segment_map`
+    /// + grid dimensions for the closed-loop `target-zensim` iteration.
+    ///
+    /// On-wire bytes are identical to [`Self::encode`].
+    #[cfg(feature = "target-zensim")]
+    pub(crate) fn encode_inner_with_diagnostics(
+        self,
+    ) -> EncodeResult<(Vec<u8>, EncodeStats, EncodeDiagnostics)> {
+        self.config
+            .get_limits()
+            .check_dimensions(self.width, self.height)
+            .map_err(|e| at!(EncodeError::InvalidBufferSize(format!("{}", e))))?;
+
+        let bpp = self.color_type.bytes_per_pixel();
+        let stride = self.stride_pixels.unwrap_or(self.width as usize);
+
+        if stride < self.width as usize {
+            return Err(at!(EncodeError::InvalidBufferSize(format!(
+                "stride_pixels {} < width {}",
+                stride, self.width
+            ))));
+        }
+
+        if self.color_type != PixelLayout::Yuv420 {
+            validate_buffer_size(
+                self.pixels.len(),
+                self.width,
+                self.height,
+                stride,
+                bpp as u32,
+            )?;
+        }
+
+        let mut output = Vec::new();
+        let stats;
+        let diag;
+        {
+            let mut encoder = WebPEncoder::new(&mut output);
+            encoder.set_params(self.config.to_params());
+            encoder.set_stop(self.stop);
+            encoder.set_progress(self.progress);
+            if let Some(icc) = self.icc_profile {
+                encoder.set_icc_profile(icc.to_vec());
+            }
+            if let Some(exif) = self.exif_metadata {
+                encoder.set_exif_metadata(exif.to_vec());
+            }
+            if let Some(xmp) = self.xmp_metadata {
+                encoder.set_xmp_metadata(xmp.to_vec());
+            }
+            let (s, d) = encoder
+                .encode_with_diagnostics(
+                    self.pixels,
+                    self.width,
+                    self.height,
+                    stride,
+                    self.color_type,
+                )
+                .map_err(|e| at!(e))?;
+            stats = s;
+            diag = d;
+        }
+        Ok((output, stats, diag))
     }
 
     fn encode_inner(self) -> EncodeResult<(Vec<u8>, EncodeStats)> {
@@ -2324,6 +2417,149 @@ impl<'a> WebPEncoder<'a> {
 
         stats.coded_size = self.writer.len() as u32;
         Ok(stats)
+    }
+
+    /// Same as [`Self::encode`], but routes through the lossy-with-
+    /// diagnostics path so the caller receives the encoder's per-MB
+    /// `segment_map` and grid dimensions alongside the standard
+    /// [`EncodeStats`]. The on-wire bytes are byte-identical to
+    /// `encode`'s output for the same inputs.
+    ///
+    /// This is the internal entry the `target-zensim` closed-loop
+    /// iteration uses for pass 1+ probes when per-segment correction is
+    /// active. Lossless and target_size/target_psnr search paths take the
+    /// regular `encode` route — the diagnostics are only meaningful for
+    /// single-pass lossy encodes.
+    ///
+    /// `target-zensim`-only — see [`EncodeDiagnostics`].
+    #[cfg(feature = "target-zensim")]
+    pub(crate) fn encode_with_diagnostics(
+        self,
+        data: &[u8],
+        width: u32,
+        height: u32,
+        stride: usize,
+        color: PixelLayout,
+    ) -> Result<(EncodeStats, EncodeDiagnostics), EncodeError> {
+        // Lossless and the no-target-zensim diagnostic path don't have
+        // segment_map. Emit an empty diagnostics struct in those cases —
+        // the iteration loop will fall back to global-q.
+        if !self.params.use_lossy {
+            let stats = self.encode(data, width, height, stride, color)?;
+            return Ok((stats, EncodeDiagnostics::default()));
+        }
+
+        let mut frame = Vec::new();
+        let lossy_with_alpha = self.params.use_lossy && color.has_alpha();
+        let alpha_quality = self.params.alpha_quality;
+        let mut stats;
+        let diagnostics;
+
+        // Diagnostics-collecting lossy frame encode.
+        let frame_chunk: &[u8; 4] = b"VP8 ";
+        {
+            let (s, d) = super::vp8::encode_frame_lossy_with_diagnostics(
+                &mut frame,
+                data,
+                width,
+                height,
+                stride,
+                color,
+                &self.params,
+                self.stop,
+                self.progress,
+            )?;
+            stats = s;
+            diagnostics = d;
+        }
+
+        // Identical container assembly to `Self::encode`.
+        let use_simple_container = self.icc_profile.is_empty()
+            && self.exif_metadata.is_empty()
+            && self.xmp_metadata.is_empty()
+            && !lossy_with_alpha;
+
+        if use_simple_container {
+            self.writer.write_all(b"RIFF");
+            self.writer.write_u32_le(chunk_size(frame.len()) + 4);
+            self.writer.write_all(b"WEBP");
+            write_chunk(self.writer, frame_chunk, &frame);
+        } else {
+            let mut total_bytes = 22 + chunk_size(frame.len());
+            if !self.icc_profile.is_empty() {
+                total_bytes += chunk_size(self.icc_profile.len());
+            }
+            if !self.exif_metadata.is_empty() {
+                total_bytes += chunk_size(self.exif_metadata.len());
+            }
+            if !self.xmp_metadata.is_empty() {
+                total_bytes += chunk_size(self.xmp_metadata.len());
+            }
+
+            let alpha_chunk_data = if lossy_with_alpha {
+                let mut alpha_chunk = Vec::new();
+                encode_alpha_lossless(
+                    &mut alpha_chunk,
+                    data,
+                    width,
+                    height,
+                    stride,
+                    color,
+                    alpha_quality,
+                    self.stop,
+                )?;
+                total_bytes += chunk_size(alpha_chunk.len());
+                Some(alpha_chunk)
+            } else {
+                None
+            };
+
+            let mut flags = 0u8;
+            if !self.xmp_metadata.is_empty() {
+                flags |= 1 << 2;
+            }
+            if !self.exif_metadata.is_empty() {
+                flags |= 1 << 3;
+            }
+            if color.has_alpha() {
+                flags |= 1 << 4;
+            }
+            if !self.icc_profile.is_empty() {
+                flags |= 1 << 5;
+            }
+
+            self.writer.write_all(b"RIFF");
+            self.writer.write_u32_le(total_bytes);
+            self.writer.write_all(b"WEBP");
+
+            let mut vp8x = Vec::new();
+            vp8x.push(flags);
+            vp8x.write_all(&[0; 3]);
+            vp8x.write_all(&(width - 1).to_le_bytes()[..3]);
+            vp8x.write_all(&(height - 1).to_le_bytes()[..3]);
+            write_chunk(self.writer, b"VP8X", &vp8x);
+
+            if !self.icc_profile.is_empty() {
+                write_chunk(self.writer, b"ICCP", &self.icc_profile);
+            }
+
+            if let Some(alpha_chunk) = alpha_chunk_data {
+                write_chunk(self.writer, b"ALPH", &alpha_chunk);
+            }
+
+            write_chunk(self.writer, frame_chunk, &frame);
+
+            if !self.exif_metadata.is_empty() {
+                write_chunk(self.writer, b"EXIF", &self.exif_metadata);
+            }
+
+            if !self.xmp_metadata.is_empty() {
+                write_chunk(self.writer, b"XMP ", &self.xmp_metadata);
+            }
+        }
+
+        stats.coded_size = self.writer.len() as u32;
+        Ok((stats, diagnostics))
     }
 }
 

--- a/src/encoder/api.rs
+++ b/src/encoder/api.rs
@@ -1488,9 +1488,7 @@ impl<'a> EncodeRequest<'a> {
         if self.stride_pixels.is_some() {
             return Ok(None);
         }
-        if self.icc_profile.is_some()
-            || self.exif_metadata.is_some()
-            || self.xmp_metadata.is_some()
+        if self.icc_profile.is_some() || self.exif_metadata.is_some() || self.xmp_metadata.is_some()
         {
             // Iteration loop currently doesn't thread metadata
             // through. Take the safe path.

--- a/src/encoder/api.rs
+++ b/src/encoder/api.rs
@@ -1460,18 +1460,21 @@ impl<'a> EncodeRequest<'a> {
     }
 
     /// Same as [`Self::try_encode_target_zensim_bytes`] but also
-    /// returns the metrics. The iteration loop is always RGB8-only,
-    /// no stride, lossy config; the metadata fields (icc/exif/xmp) are
-    /// not currently honored on the iteration path — if any are set
-    /// we fall back to a single-pass encode and return `None` so the
-    /// caller can take the normal path. (TODO: thread metadata
-    /// through iteration once a user needs it.)
+    /// returns the metrics. The iteration loop accepts RGB8 / RGBA8 /
+    /// BGR8 / BGRA8 inputs (alpha and BGR channels are stripped /
+    /// reordered to a transient RGB buffer used for iteration probes;
+    /// the final on-wire bytes are still RGB-only). No stride override,
+    /// lossy config; the metadata fields (icc/exif/xmp) are not
+    /// currently honored on the iteration path — if any are set we
+    /// fall back to a single-pass encode and return `None` so the
+    /// caller can take the normal path. (TODO: thread metadata and
+    /// preserve alpha through iteration once a user needs it.)
     #[allow(clippy::unnecessary_wraps)] // signature aligns with feature-on counterpart
     fn try_encode_target_zensim_with_metrics(
         &self,
     ) -> EncodeResult<Option<(Vec<u8>, super::zensim_target::ZensimEncodeMetrics)>> {
-        // Only RGB8 lossy configs with target_zensim set and no
-        // metadata/stride trigger the iteration path. Everything else
+        // Only lossy configs with target_zensim set and no stride/
+        // metadata trigger the iteration path. Everything else
         // returns None so the caller falls back to encode_inner.
         let lossy = match &self.config {
             ConfigKind::Lossy(cfg) => *cfg,
@@ -1480,9 +1483,6 @@ impl<'a> EncodeRequest<'a> {
             ConfigKind::Enum(config::EncoderConfig::Lossless(_)) => return Ok(None),
         };
         if lossy.target_zensim.is_none() {
-            return Ok(None);
-        }
-        if self.color_type != PixelLayout::Rgb8 {
             return Ok(None);
         }
         if self.stride_pixels.is_some() {
@@ -1494,8 +1494,71 @@ impl<'a> EncodeRequest<'a> {
             // through. Take the safe path.
             return Ok(None);
         }
+        // Convert input to a transient RGB buffer for the iteration
+        // probes. The iteration loop's encoder calls always use
+        // PixelLayout::Rgb8 internally (see
+        // `encode_at_with_diagnostics`), so the resulting on-wire
+        // bytes are RGB-only — alpha is dropped. RGBA / BGRA / BGR
+        // inputs are accepted to make the iteration loop fire on
+        // those formats, but callers who need alpha preserved should
+        // run the iteration on an RGB projection and then re-encode
+        // RGBA at the converged quality outside the loop.
+        let rgb_owned: alloc::vec::Vec<u8>;
+        let rgb_slice: &[u8] = match self.color_type {
+            PixelLayout::Rgb8 => self.pixels,
+            PixelLayout::Rgba8 => {
+                let n = (self.width as usize) * (self.height as usize);
+                if self.pixels.len() < n * 4 {
+                    return Ok(None);
+                }
+                rgb_owned = self
+                    .pixels
+                    .chunks_exact(4)
+                    .flat_map(|p| [p[0], p[1], p[2]])
+                    .collect();
+                &rgb_owned[..]
+            }
+            PixelLayout::Bgr8 => {
+                let n = (self.width as usize) * (self.height as usize);
+                if self.pixels.len() < n * 3 {
+                    return Ok(None);
+                }
+                rgb_owned = self
+                    .pixels
+                    .chunks_exact(3)
+                    .flat_map(|p| [p[2], p[1], p[0]])
+                    .collect();
+                &rgb_owned[..]
+            }
+            PixelLayout::Bgra8 => {
+                let n = (self.width as usize) * (self.height as usize);
+                if self.pixels.len() < n * 4 {
+                    return Ok(None);
+                }
+                rgb_owned = self
+                    .pixels
+                    .chunks_exact(4)
+                    .flat_map(|p| [p[2], p[1], p[0]])
+                    .collect();
+                &rgb_owned[..]
+            }
+            PixelLayout::Argb8 => {
+                let n = (self.width as usize) * (self.height as usize);
+                if self.pixels.len() < n * 4 {
+                    return Ok(None);
+                }
+                rgb_owned = self
+                    .pixels
+                    .chunks_exact(4)
+                    .flat_map(|p| [p[1], p[2], p[3]])
+                    .collect();
+                &rgb_owned[..]
+            }
+            // Other layouts (L8, LA8, YUV420) — fall back to single-pass.
+            _ => return Ok(None),
+        };
         let pair = lossy
-            .encode_rgb_with_metrics(self.pixels, self.width, self.height)
+            .encode_rgb_with_metrics(rgb_slice, self.width, self.height)
             .map_err(|e| at!(e))?;
         Ok(Some(pair))
     }

--- a/src/encoder/api.rs
+++ b/src/encoder/api.rs
@@ -74,19 +74,17 @@ pub enum EncodeError {
     /// `target_zensim` was set on the lossy config, but the input
     /// pixel layout is not supported by the iteration loop.
     ///
-    /// The closed-loop `target-zensim` encoder currently only supports
-    /// `PixelLayout::Rgb8` inputs — the iteration's decode-and-measure
-    /// step requires RGB pixels, and we deliberately refuse to silently
-    /// strip alpha or otherwise mutate the caller's input.
-    ///
-    /// To fix: convert the input to `PixelLayout::Rgb8` before calling
-    /// the encoder, or remove `target_zensim` from the config and use
-    /// the standard single-pass path. Tracked for follow-up RGBA
-    /// support (composite over a known background or use an
-    /// alpha-aware quality metric).
+    /// The closed-loop `target-zensim` encoder supports
+    /// [`PixelLayout::Rgb8`] and [`PixelLayout::Rgba8`] inputs; for
+    /// RGBA, the iteration measures encoded vs. source via zensim's
+    /// deterministic-noise compositing (well-defined because the same
+    /// composite is applied to source and reconstruction). Other
+    /// layouts (BGR/BGRA/ARGB/L8/LA8/YUV420) are not yet wired through
+    /// — convert to RGB8 or RGBA8 first, or remove `target_zensim`
+    /// from the config and use the standard single-pass path.
     #[error(
         "target_zensim does not yet support pixel layout {0:?}; convert to PixelLayout::Rgb8 \
-         first or remove target_zensim from the config"
+         or PixelLayout::Rgba8 first, or remove target_zensim from the config"
     )]
     TargetZensimUnsupportedLayout(PixelLayout),
 }
@@ -1441,21 +1439,23 @@ impl<'a> EncodeRequest<'a> {
     /// Encode to WebP bytes alongside [`ZensimEncodeMetrics`].
     ///
     /// When the lossy config has `target_zensim` set and the
-    /// `target-zensim` crate feature is enabled (with RGB8 input), the
-    /// encoder runs a closed-loop iteration and reports the achieved
-    /// zensim score, passes used, and `targets_met` flag in the
-    /// returned metrics. In every other case where iteration does not
-    /// run (no target, feature disabled, lossless), the metrics are
-    /// filled via [`ZensimEncodeMetrics::no_target`] — score `NaN`,
+    /// `target-zensim` crate feature is enabled (with [`PixelLayout::Rgb8`]
+    /// or [`PixelLayout::Rgba8`] input), the encoder runs a closed-loop
+    /// iteration and reports the achieved zensim score, passes used, and
+    /// `targets_met` flag in the returned metrics. In every other case
+    /// where iteration does not run (no target, feature disabled,
+    /// lossless), the metrics are filled via
+    /// [`ZensimEncodeMetrics::no_target`] — score `NaN`,
     /// `passes_used=1`, `targets_met=true`.
     ///
-    /// Pixel layout: `target_zensim` currently requires
-    /// [`PixelLayout::Rgb8`]. If `target_zensim` is set on the lossy
-    /// config but a different layout (RGBA, BGR, BGRA, ARGB, L8, LA8,
-    /// YUV420) is supplied, this method returns
-    /// [`EncodeError::TargetZensimUnsupportedLayout`]. RGBA support is
-    /// a tracked follow-up; until then convert to RGB or drop
-    /// `target_zensim` from the config.
+    /// Pixel layout: `target_zensim` supports [`PixelLayout::Rgb8`] and
+    /// [`PixelLayout::Rgba8`]. RGBA inputs are encoded as alpha-bearing
+    /// WebP and measured against the source via zensim's
+    /// deterministic-noise compositing (the same composite is applied
+    /// to source and reconstruction, so alpha quality is well-defined).
+    /// Other layouts (BGR, BGRA, ARGB, L8, LA8, YUV420) with
+    /// `target_zensim` set return
+    /// [`EncodeError::TargetZensimUnsupportedLayout`].
     ///
     /// Mirrors the shape of zenjpeg's
     /// `BytesEncoder::finish_with_metrics()`.
@@ -1475,13 +1475,13 @@ impl<'a> EncodeRequest<'a> {
     }
 
     /// If this request targets a lossy config with `target_zensim`
-    /// set, RGB8 input, no stride override, and the `target-zensim`
-    /// feature is on, run the iteration loop and return the converged
-    /// bytes. Returns
+    /// set, RGB8 or RGBA8 input, no stride override, and the
+    /// `target-zensim` feature is on, run the iteration loop and
+    /// return the converged bytes. Returns
     /// [`EncodeError::TargetZensimUnsupportedLayout`] when
-    /// `target_zensim` is set but the input layout is not `Rgb8`.
-    /// Otherwise returns `Ok(None)` so the caller can fall back to
-    /// the normal single-pass path.
+    /// `target_zensim` is set but the input layout is not `Rgb8` or
+    /// `Rgba8`. Otherwise returns `Ok(None)` so the caller can fall
+    /// back to the normal single-pass path.
     fn try_encode_target_zensim_bytes(&self) -> EncodeResult<Option<Vec<u8>>> {
         match self.try_encode_target_zensim_with_metrics()? {
             Some((bytes, _m)) => Ok(Some(bytes)),
@@ -1492,18 +1492,15 @@ impl<'a> EncodeRequest<'a> {
     /// Same as [`Self::try_encode_target_zensim_bytes`] but also
     /// returns the metrics.
     ///
-    /// `target_zensim` currently only supports `PixelLayout::Rgb8`
-    /// inputs. The iteration loop encodes, decodes, and measures the
-    /// resulting bytes against the source — that decode-and-measure
-    /// step needs RGB pixels, and we refuse to silently strip alpha
-    /// (or otherwise mutate the caller's input) just to make iteration
-    /// fire. Non-RGB8 inputs with `target_zensim` set return
-    /// [`EncodeError::TargetZensimUnsupportedLayout`]. RGBA support is
-    /// tracked as a follow-up; until then, callers who need
-    /// alpha-preserving target_zensim encoding should iterate on an
-    /// RGB projection and re-encode RGBA at the converged quality
-    /// outside the loop, or drop `target_zensim` and pick a fixed
-    /// quality.
+    /// `target_zensim` supports [`PixelLayout::Rgb8`] and
+    /// [`PixelLayout::Rgba8`] inputs. RGBA inputs are encoded as
+    /// alpha-bearing WebP and measured against the source via zensim's
+    /// deterministic-noise compositing — the same composite is applied
+    /// to source and reconstruction, so alpha quality is well-defined.
+    /// Other layouts (BGR/BGRA/ARGB/L8/LA8/YUV420) with `target_zensim`
+    /// set return [`EncodeError::TargetZensimUnsupportedLayout`]; no
+    /// silent fallback to single-pass — that would hide the unhonored
+    /// target.
     ///
     /// No stride override; the metadata fields (icc/exif/xmp) are not
     /// currently honored on the iteration path — if any are set we
@@ -1514,12 +1511,12 @@ impl<'a> EncodeRequest<'a> {
     fn try_encode_target_zensim_with_metrics(
         &self,
     ) -> EncodeResult<Option<(Vec<u8>, super::zensim_target::ZensimEncodeMetrics)>> {
-        // Only RGB8 lossy configs with target_zensim set and no
-        // metadata/stride trigger the iteration path. Non-RGB8 with
-        // target_zensim set returns a typed error (no silent fallback
-        // to single-pass — that would hide the unhonored target).
-        // Everything else returns Ok(None) so the caller falls back to
-        // encode_inner.
+        // Only Rgb8/Rgba8 lossy configs with target_zensim set and no
+        // metadata/stride trigger the iteration path. Other layouts
+        // with target_zensim set return a typed error (no silent
+        // fallback to single-pass — that would hide the unhonored
+        // target). Everything else returns Ok(None) so the caller
+        // falls back to encode_inner.
         let lossy = match &self.config {
             ConfigKind::Lossy(cfg) => *cfg,
             ConfigKind::Lossless(_) => return Ok(None),
@@ -1529,10 +1526,11 @@ impl<'a> EncodeRequest<'a> {
         if lossy.target_zensim.is_none() {
             return Ok(None);
         }
-        if self.color_type != PixelLayout::Rgb8 {
-            return Err(at!(EncodeError::TargetZensimUnsupportedLayout(
-                self.color_type
-            )));
+        match self.color_type {
+            PixelLayout::Rgb8 | PixelLayout::Rgba8 => {}
+            other => {
+                return Err(at!(EncodeError::TargetZensimUnsupportedLayout(other)));
+            }
         }
         if self.stride_pixels.is_some() {
             return Ok(None);
@@ -1544,7 +1542,7 @@ impl<'a> EncodeRequest<'a> {
             return Ok(None);
         }
         let pair = lossy
-            .encode_rgb_with_metrics(self.pixels, self.width, self.height)
+            .encode_pixels_with_metrics(self.pixels, self.color_type, self.width, self.height)
             .map_err(|e| at!(e))?;
         Ok(Some(pair))
     }

--- a/src/encoder/api.rs
+++ b/src/encoder/api.rs
@@ -70,6 +70,25 @@ pub enum EncodeError {
     #[cfg(feature = "zencodec")]
     #[error(transparent)]
     UnsupportedOperation(#[from] zencodec::UnsupportedOperation),
+
+    /// `target_zensim` was set on the lossy config, but the input
+    /// pixel layout is not supported by the iteration loop.
+    ///
+    /// The closed-loop `target-zensim` encoder currently only supports
+    /// `PixelLayout::Rgb8` inputs — the iteration's decode-and-measure
+    /// step requires RGB pixels, and we deliberately refuse to silently
+    /// strip alpha or otherwise mutate the caller's input.
+    ///
+    /// To fix: convert the input to `PixelLayout::Rgb8` before calling
+    /// the encoder, or remove `target_zensim` from the config and use
+    /// the standard single-pass path. Tracked for follow-up RGBA
+    /// support (composite over a known background or use an
+    /// alpha-aware quality metric).
+    #[error(
+        "target_zensim does not yet support pixel layout {0:?}; convert to PixelLayout::Rgb8 \
+         first or remove target_zensim from the config"
+    )]
+    TargetZensimUnsupportedLayout(PixelLayout),
 }
 
 /// Result type alias using `At<EncodeError>` for automatic location tracking.
@@ -1425,10 +1444,18 @@ impl<'a> EncodeRequest<'a> {
     /// `target-zensim` crate feature is enabled (with RGB8 input), the
     /// encoder runs a closed-loop iteration and reports the achieved
     /// zensim score, passes used, and `targets_met` flag in the
-    /// returned metrics. In every other case (no target, feature
-    /// disabled, lossless, non-RGB8 layout), the metrics are filled
-    /// via [`ZensimEncodeMetrics::no_target`] — score `NaN`,
+    /// returned metrics. In every other case where iteration does not
+    /// run (no target, feature disabled, lossless), the metrics are
+    /// filled via [`ZensimEncodeMetrics::no_target`] — score `NaN`,
     /// `passes_used=1`, `targets_met=true`.
+    ///
+    /// Pixel layout: `target_zensim` currently requires
+    /// [`PixelLayout::Rgb8`]. If `target_zensim` is set on the lossy
+    /// config but a different layout (RGBA, BGR, BGRA, ARGB, L8, LA8,
+    /// YUV420) is supplied, this method returns
+    /// [`EncodeError::TargetZensimUnsupportedLayout`]. RGBA support is
+    /// a tracked follow-up; until then convert to RGB or drop
+    /// `target_zensim` from the config.
     ///
     /// Mirrors the shape of zenjpeg's
     /// `BytesEncoder::finish_with_metrics()`.
@@ -1450,8 +1477,11 @@ impl<'a> EncodeRequest<'a> {
     /// If this request targets a lossy config with `target_zensim`
     /// set, RGB8 input, no stride override, and the `target-zensim`
     /// feature is on, run the iteration loop and return the converged
-    /// bytes. Otherwise returns `Ok(None)` so the caller can fall
-    /// back to the normal single-pass path.
+    /// bytes. Returns
+    /// [`EncodeError::TargetZensimUnsupportedLayout`] when
+    /// `target_zensim` is set but the input layout is not `Rgb8`.
+    /// Otherwise returns `Ok(None)` so the caller can fall back to
+    /// the normal single-pass path.
     fn try_encode_target_zensim_bytes(&self) -> EncodeResult<Option<Vec<u8>>> {
         match self.try_encode_target_zensim_with_metrics()? {
             Some((bytes, _m)) => Ok(Some(bytes)),
@@ -1460,22 +1490,36 @@ impl<'a> EncodeRequest<'a> {
     }
 
     /// Same as [`Self::try_encode_target_zensim_bytes`] but also
-    /// returns the metrics. The iteration loop accepts RGB8 / RGBA8 /
-    /// BGR8 / BGRA8 inputs (alpha and BGR channels are stripped /
-    /// reordered to a transient RGB buffer used for iteration probes;
-    /// the final on-wire bytes are still RGB-only). No stride override,
-    /// lossy config; the metadata fields (icc/exif/xmp) are not
+    /// returns the metrics.
+    ///
+    /// `target_zensim` currently only supports `PixelLayout::Rgb8`
+    /// inputs. The iteration loop encodes, decodes, and measures the
+    /// resulting bytes against the source — that decode-and-measure
+    /// step needs RGB pixels, and we refuse to silently strip alpha
+    /// (or otherwise mutate the caller's input) just to make iteration
+    /// fire. Non-RGB8 inputs with `target_zensim` set return
+    /// [`EncodeError::TargetZensimUnsupportedLayout`]. RGBA support is
+    /// tracked as a follow-up; until then, callers who need
+    /// alpha-preserving target_zensim encoding should iterate on an
+    /// RGB projection and re-encode RGBA at the converged quality
+    /// outside the loop, or drop `target_zensim` and pick a fixed
+    /// quality.
+    ///
+    /// No stride override; the metadata fields (icc/exif/xmp) are not
     /// currently honored on the iteration path — if any are set we
     /// fall back to a single-pass encode and return `None` so the
-    /// caller can take the normal path. (TODO: thread metadata and
-    /// preserve alpha through iteration once a user needs it.)
+    /// caller can take the normal path. (TODO: thread metadata
+    /// through iteration once a user needs it.)
     #[allow(clippy::unnecessary_wraps)] // signature aligns with feature-on counterpart
     fn try_encode_target_zensim_with_metrics(
         &self,
     ) -> EncodeResult<Option<(Vec<u8>, super::zensim_target::ZensimEncodeMetrics)>> {
-        // Only lossy configs with target_zensim set and no stride/
-        // metadata trigger the iteration path. Everything else
-        // returns None so the caller falls back to encode_inner.
+        // Only RGB8 lossy configs with target_zensim set and no
+        // metadata/stride trigger the iteration path. Non-RGB8 with
+        // target_zensim set returns a typed error (no silent fallback
+        // to single-pass — that would hide the unhonored target).
+        // Everything else returns Ok(None) so the caller falls back to
+        // encode_inner.
         let lossy = match &self.config {
             ConfigKind::Lossy(cfg) => *cfg,
             ConfigKind::Lossless(_) => return Ok(None),
@@ -1484,6 +1528,11 @@ impl<'a> EncodeRequest<'a> {
         };
         if lossy.target_zensim.is_none() {
             return Ok(None);
+        }
+        if self.color_type != PixelLayout::Rgb8 {
+            return Err(at!(EncodeError::TargetZensimUnsupportedLayout(
+                self.color_type
+            )));
         }
         if self.stride_pixels.is_some() {
             return Ok(None);
@@ -1494,71 +1543,8 @@ impl<'a> EncodeRequest<'a> {
             // through. Take the safe path.
             return Ok(None);
         }
-        // Convert input to a transient RGB buffer for the iteration
-        // probes. The iteration loop's encoder calls always use
-        // PixelLayout::Rgb8 internally (see
-        // `encode_at_with_diagnostics`), so the resulting on-wire
-        // bytes are RGB-only — alpha is dropped. RGBA / BGRA / BGR
-        // inputs are accepted to make the iteration loop fire on
-        // those formats, but callers who need alpha preserved should
-        // run the iteration on an RGB projection and then re-encode
-        // RGBA at the converged quality outside the loop.
-        let rgb_owned: alloc::vec::Vec<u8>;
-        let rgb_slice: &[u8] = match self.color_type {
-            PixelLayout::Rgb8 => self.pixels,
-            PixelLayout::Rgba8 => {
-                let n = (self.width as usize) * (self.height as usize);
-                if self.pixels.len() < n * 4 {
-                    return Ok(None);
-                }
-                rgb_owned = self
-                    .pixels
-                    .chunks_exact(4)
-                    .flat_map(|p| [p[0], p[1], p[2]])
-                    .collect();
-                &rgb_owned[..]
-            }
-            PixelLayout::Bgr8 => {
-                let n = (self.width as usize) * (self.height as usize);
-                if self.pixels.len() < n * 3 {
-                    return Ok(None);
-                }
-                rgb_owned = self
-                    .pixels
-                    .chunks_exact(3)
-                    .flat_map(|p| [p[2], p[1], p[0]])
-                    .collect();
-                &rgb_owned[..]
-            }
-            PixelLayout::Bgra8 => {
-                let n = (self.width as usize) * (self.height as usize);
-                if self.pixels.len() < n * 4 {
-                    return Ok(None);
-                }
-                rgb_owned = self
-                    .pixels
-                    .chunks_exact(4)
-                    .flat_map(|p| [p[2], p[1], p[0]])
-                    .collect();
-                &rgb_owned[..]
-            }
-            PixelLayout::Argb8 => {
-                let n = (self.width as usize) * (self.height as usize);
-                if self.pixels.len() < n * 4 {
-                    return Ok(None);
-                }
-                rgb_owned = self
-                    .pixels
-                    .chunks_exact(4)
-                    .flat_map(|p| [p[1], p[2], p[3]])
-                    .collect();
-                &rgb_owned[..]
-            }
-            // Other layouts (L8, LA8, YUV420) — fall back to single-pass.
-            _ => return Ok(None),
-        };
         let pair = lossy
-            .encode_rgb_with_metrics(rgb_slice, self.width, self.height)
+            .encode_rgb_with_metrics(self.pixels, self.width, self.height)
             .map_err(|e| at!(e))?;
         Ok(Some(pair))
     }

--- a/src/encoder/config.rs
+++ b/src/encoder/config.rs
@@ -101,6 +101,12 @@ pub struct LossyConfig {
     pub multi_pass_stats: bool,
     /// Resource limits for validation.
     pub limits: Limits,
+    /// Crate-internal: per-segment additive quant_index offsets applied
+    /// AFTER SNS modulation. Used by the `target_zensim` per-segment
+    /// correction pass. `None` (default) leaves segments untouched, so
+    /// public-API encodes never trigger this path.
+    #[doc(hidden)]
+    pub(crate) segment_quant_overrides: Option<[i8; 4]>,
 }
 
 impl Default for LossyConfig {
@@ -133,6 +139,7 @@ impl LossyConfig {
             cost_model: super::api::CostModel::ZenwebpDefault,
             multi_pass_stats: false,
             limits: Limits::none(),
+            segment_quant_overrides: None,
         }
     }
 
@@ -199,10 +206,7 @@ impl LossyConfig {
     /// Set the full [`ZensimTarget`](super::zensim_target::ZensimTarget)
     /// (target value plus tolerances and pass budget).
     #[must_use]
-    pub fn with_target_zensim_target(
-        mut self,
-        target: super::zensim_target::ZensimTarget,
-    ) -> Self {
+    pub fn with_target_zensim_target(mut self, target: super::zensim_target::ZensimTarget) -> Self {
         self.target_zensim = Some(target);
         self
     }
@@ -381,8 +385,13 @@ impl LossyConfig {
         rgb: &[u8],
         width: u32,
         height: u32,
-    ) -> Result<(alloc::vec::Vec<u8>, super::zensim_target::ZensimEncodeMetrics), super::api::EncodeError>
-    {
+    ) -> Result<
+        (
+            alloc::vec::Vec<u8>,
+            super::zensim_target::ZensimEncodeMetrics,
+        ),
+        super::api::EncodeError,
+    > {
         encode_rgb_with_metrics_impl(self, rgb, width, height)
     }
 
@@ -881,6 +890,7 @@ impl LossyConfig {
             smooth_segment_map: self.smooth_segment_map,
             cost_model: self.cost_model,
             multi_pass_stats: self.multi_pass_stats,
+            segment_quant_overrides: self.segment_quant_overrides,
         }
     }
 }
@@ -906,6 +916,7 @@ impl LosslessConfig {
             smooth_segment_map: false, // Not applicable to lossless
             cost_model: super::api::CostModel::ZenwebpDefault,
             multi_pass_stats: false, // Not applicable to lossless
+            segment_quant_overrides: None,
         }
     }
 }
@@ -954,7 +965,10 @@ fn encode_rgb_with_metrics_impl(
     width: u32,
     height: u32,
 ) -> Result<
-    (alloc::vec::Vec<u8>, super::zensim_target::ZensimEncodeMetrics),
+    (
+        alloc::vec::Vec<u8>,
+        super::zensim_target::ZensimEncodeMetrics,
+    ),
     super::api::EncodeError,
 > {
     if let Some(t) = cfg.target_zensim {
@@ -971,7 +985,10 @@ fn encode_rgb_with_metrics_impl(
     width: u32,
     height: u32,
 ) -> Result<
-    (alloc::vec::Vec<u8>, super::zensim_target::ZensimEncodeMetrics),
+    (
+        alloc::vec::Vec<u8>,
+        super::zensim_target::ZensimEncodeMetrics,
+    ),
     super::api::EncodeError,
 > {
     // Feature disabled — if target_zensim was set, fall back to a single
@@ -998,12 +1015,14 @@ fn encode_rgb_single_pass(
     width: u32,
     height: u32,
 ) -> Result<
-    (alloc::vec::Vec<u8>, super::zensim_target::ZensimEncodeMetrics),
+    (
+        alloc::vec::Vec<u8>,
+        super::zensim_target::ZensimEncodeMetrics,
+    ),
     super::api::EncodeError,
 > {
-    let req = super::api::EncodeRequest::lossy(
-        cfg, rgb, super::api::PixelLayout::Rgb8, width, height,
-    );
+    let req =
+        super::api::EncodeRequest::lossy(cfg, rgb, super::api::PixelLayout::Rgb8, width, height);
     match req.encode() {
         Ok(bytes) => {
             let len = bytes.len();

--- a/src/encoder/config.rs
+++ b/src/encoder/config.rs
@@ -55,6 +55,16 @@ pub struct LossyConfig {
     pub target_size: u32,
     /// Target PSNR in dB (0.0 = disabled). Default: 0.0.
     pub target_psnr: f32,
+    /// Target perceptual zensim score. `None` = disabled (default).
+    /// `Some(t)` enables a closed-loop encode → decode → measure → adjust
+    /// iteration that converges on `t`. See [`super::ZensimTarget`] for the
+    /// full knob set and `with_target_zensim` / `with_target_zensim_target`
+    /// for the builder methods.
+    ///
+    /// Requires the `target-zensim` crate feature to actually iterate;
+    /// otherwise the encoder falls back to the calibrated starting-q
+    /// estimate for the bucket and ships that single pass.
+    pub target_zensim: Option<super::zensim_target::ZensimTarget>,
     /// Content-aware preset (affects SNS, filter, sharpness). Default: None.
     pub preset: Option<Preset>,
     /// Sharp YUV configuration. `None` = disabled (standard chroma downsampling).
@@ -111,6 +121,7 @@ impl LossyConfig {
             alpha_quality: 100,
             target_size: 0,
             target_psnr: 0.0,
+            target_zensim: None,
             preset: None,
             sharp_yuv: None,
             sns_strength: None,
@@ -167,6 +178,32 @@ impl LossyConfig {
     #[must_use]
     pub fn with_target_psnr(mut self, psnr: f32) -> Self {
         self.target_psnr = psnr;
+        self
+    }
+
+    /// Target a perceptual zensim score (closed-loop adaptive encode).
+    ///
+    /// Sets `target_zensim` to `ZensimTarget::new(target)` (default
+    /// tolerances and pass budget). For full control over overshoot /
+    /// undershoot / passes, use [`with_target_zensim_target`](Self::with_target_zensim_target).
+    ///
+    /// Requires the `target-zensim` crate feature for the iteration to
+    /// actually run; without it, the encoder ships the calibrated
+    /// starting-q estimate as a single pass.
+    #[must_use]
+    pub fn with_target_zensim(mut self, target: f32) -> Self {
+        self.target_zensim = Some(super::zensim_target::ZensimTarget::new(target));
+        self
+    }
+
+    /// Set the full [`ZensimTarget`](super::zensim_target::ZensimTarget)
+    /// (target value plus tolerances and pass budget).
+    #[must_use]
+    pub fn with_target_zensim_target(
+        mut self,
+        target: super::zensim_target::ZensimTarget,
+    ) -> Self {
+        self.target_zensim = Some(target);
         self
     }
 
@@ -331,6 +368,34 @@ impl LossyConfig {
             &crate::EncoderConfig::Lossy(self.clone()),
         )
         .peak_memory_bytes_max
+    }
+
+    /// Encode an interleaved RGB8 buffer (`width * height * 3` bytes) and
+    /// return both the WebP bytes and any [`ZensimEncodeMetrics`] from a
+    /// `target_zensim` iteration. For non-target-zensim configs the
+    /// metrics struct is filled with the
+    /// [`ZensimEncodeMetrics::no_target`](super::zensim_target::ZensimEncodeMetrics::no_target)
+    /// variant — `targets_met=true`, `passes_used=1`, score `NaN`.
+    pub fn encode_rgb_with_metrics(
+        &self,
+        rgb: &[u8],
+        width: u32,
+        height: u32,
+    ) -> Result<(alloc::vec::Vec<u8>, super::zensim_target::ZensimEncodeMetrics), super::api::EncodeError>
+    {
+        encode_rgb_with_metrics_impl(self, rgb, width, height)
+    }
+
+    /// Encode an interleaved RGB8 buffer using `target_zensim` if set,
+    /// returning just the bytes. Convenience over
+    /// [`encode_rgb_with_metrics`](Self::encode_rgb_with_metrics).
+    pub fn encode_rgb(
+        &self,
+        rgb: &[u8],
+        width: u32,
+        height: u32,
+    ) -> Result<alloc::vec::Vec<u8>, super::api::EncodeError> {
+        Ok(self.encode_rgb_with_metrics(rgb, width, height)?.0)
     }
 }
 
@@ -875,5 +940,78 @@ impl EncoderConfig {
             Self::Lossy(cfg) => &cfg.limits,
             Self::Lossless(cfg) => &cfg.limits,
         }
+    }
+}
+
+// ============================================================================
+// target_zensim integration: convenience encoders on LossyConfig.
+// ============================================================================
+
+#[cfg(feature = "target-zensim")]
+fn encode_rgb_with_metrics_impl(
+    cfg: &LossyConfig,
+    rgb: &[u8],
+    width: u32,
+    height: u32,
+) -> Result<
+    (alloc::vec::Vec<u8>, super::zensim_target::ZensimEncodeMetrics),
+    super::api::EncodeError,
+> {
+    if let Some(t) = cfg.target_zensim {
+        return super::zensim_target::iteration::run(cfg, t, rgb, width, height);
+    }
+    // No target_zensim → straight single-pass encode.
+    encode_rgb_single_pass(cfg, rgb, width, height)
+}
+
+#[cfg(not(feature = "target-zensim"))]
+fn encode_rgb_with_metrics_impl(
+    cfg: &LossyConfig,
+    rgb: &[u8],
+    width: u32,
+    height: u32,
+) -> Result<
+    (alloc::vec::Vec<u8>, super::zensim_target::ZensimEncodeMetrics),
+    super::api::EncodeError,
+> {
+    // Feature disabled — if target_zensim was set, fall back to a single
+    // encode at the calibrated starting q for the (Photo) bucket. Match
+    // zenjpeg's behavior: don't error, just behave like a normal encode.
+    if let Some(t) = cfg.target_zensim {
+        let mut probe = cfg.clone();
+        probe.target_zensim = None;
+        probe.quality = super::zensim_target::zensim_to_starting_q_for_bucket(
+            t.target,
+            super::analysis::ImageContentType::Photo,
+        )
+        .clamp(0.0, 100.0);
+        return encode_rgb_single_pass(&probe, rgb, width, height);
+    }
+    encode_rgb_single_pass(cfg, rgb, width, height)
+}
+
+/// Single-pass RGB8 encode, no metrics. Plumb through `EncodeRequest`
+/// to reuse the existing entry point.
+fn encode_rgb_single_pass(
+    cfg: &LossyConfig,
+    rgb: &[u8],
+    width: u32,
+    height: u32,
+) -> Result<
+    (alloc::vec::Vec<u8>, super::zensim_target::ZensimEncodeMetrics),
+    super::api::EncodeError,
+> {
+    let req = super::api::EncodeRequest::lossy(
+        cfg, rgb, super::api::PixelLayout::Rgb8, width, height,
+    );
+    match req.encode() {
+        Ok(bytes) => {
+            let len = bytes.len();
+            Ok((
+                bytes,
+                super::zensim_target::ZensimEncodeMetrics::no_target(len),
+            ))
+        }
+        Err(at_err) => Err(at_err.decompose().0),
     }
 }

--- a/src/encoder/config.rs
+++ b/src/encoder/config.rs
@@ -57,9 +57,10 @@ pub struct LossyConfig {
     pub target_psnr: f32,
     /// Target perceptual zensim score. `None` = disabled (default).
     /// `Some(t)` enables a closed-loop encode → decode → measure → adjust
-    /// iteration that converges on `t`. See [`super::ZensimTarget`] for the
-    /// full knob set and `with_target_zensim` / `with_target_zensim_target`
-    /// for the builder methods.
+    /// iteration that converges on `t`. See [`super::ZensimTarget`] for
+    /// the full knob set and [`Self::with_target_zensim`] for the
+    /// builder method (it accepts either a bare `f32` or a fully-built
+    /// [`ZensimTarget`](super::ZensimTarget) via `Into`).
     ///
     /// Requires the `target-zensim` crate feature to actually iterate;
     /// otherwise the encoder falls back to the calibrated starting-q
@@ -190,24 +191,30 @@ impl LossyConfig {
 
     /// Target a perceptual zensim score (closed-loop adaptive encode).
     ///
-    /// Sets `target_zensim` to `ZensimTarget::new(target)` (default
-    /// tolerances and pass budget). For full control over overshoot /
-    /// undershoot / passes, use [`with_target_zensim_target`](Self::with_target_zensim_target).
+    /// Accepts either a bare `f32` (uses
+    /// [`ZensimTarget::new`](super::zensim_target::ZensimTarget::new)
+    /// defaults — overshoot=1.5, undershoot=None, max_passes=2) or a
+    /// fully-built [`ZensimTarget`](super::zensim_target::ZensimTarget)
+    /// via `Into`:
+    ///
+    /// ```ignore
+    /// use zenwebp::{LossyConfig, ZensimTarget};
+    /// // Bare f32 — default tolerances / passes:
+    /// let c = LossyConfig::new().with_target_zensim(80.0);
+    /// // Full struct — custom max_passes:
+    /// let c = LossyConfig::new()
+    ///     .with_target_zensim(ZensimTarget::new(80.0).with_max_passes(3));
+    /// ```
     ///
     /// Requires the `target-zensim` crate feature for the iteration to
     /// actually run; without it, the encoder ships the calibrated
     /// starting-q estimate as a single pass.
     #[must_use]
-    pub fn with_target_zensim(mut self, target: f32) -> Self {
-        self.target_zensim = Some(super::zensim_target::ZensimTarget::new(target));
-        self
-    }
-
-    /// Set the full [`ZensimTarget`](super::zensim_target::ZensimTarget)
-    /// (target value plus tolerances and pass budget).
-    #[must_use]
-    pub fn with_target_zensim_target(mut self, target: super::zensim_target::ZensimTarget) -> Self {
-        self.target_zensim = Some(target);
+    pub fn with_target_zensim<T: Into<super::zensim_target::ZensimTarget>>(
+        mut self,
+        target: T,
+    ) -> Self {
+        self.target_zensim = Some(target.into());
         self
     }
 
@@ -400,7 +407,6 @@ impl LossyConfig {
     > {
         encode_rgb_with_metrics_impl(self, rgb, width, height)
     }
-
 }
 
 /// Configuration for lossless (VP8L) encoding.

--- a/src/encoder/config.rs
+++ b/src/encoder/config.rs
@@ -374,13 +374,19 @@ impl LossyConfig {
         .peak_memory_bytes_max
     }
 
-    /// Encode an interleaved RGB8 buffer (`width * height * 3` bytes) and
-    /// return both the WebP bytes and any [`ZensimEncodeMetrics`] from a
-    /// `target_zensim` iteration. For non-target-zensim configs the
-    /// metrics struct is filled with the
+    /// Crate-internal: encode an interleaved RGB8 buffer
+    /// (`width * height * 3` bytes) and return both the WebP bytes and
+    /// any [`ZensimEncodeMetrics`] from a `target_zensim` iteration.
+    /// For non-target-zensim configs the metrics struct is filled with
+    /// the
     /// [`ZensimEncodeMetrics::no_target`](super::zensim_target::ZensimEncodeMetrics::no_target)
     /// variant — `targets_met=true`, `passes_used=1`, score `NaN`.
-    pub fn encode_rgb_with_metrics(
+    ///
+    /// This is the iteration loop's internal entry. Public callers
+    /// reach the same machinery via
+    /// [`EncodeRequest::encode_with_metrics`](super::api::EncodeRequest::encode_with_metrics)
+    /// or [`EncodeRequest::encode`](super::api::EncodeRequest::encode).
+    pub(crate) fn encode_rgb_with_metrics(
         &self,
         rgb: &[u8],
         width: u32,
@@ -395,17 +401,6 @@ impl LossyConfig {
         encode_rgb_with_metrics_impl(self, rgb, width, height)
     }
 
-    /// Encode an interleaved RGB8 buffer using `target_zensim` if set,
-    /// returning just the bytes. Convenience over
-    /// [`encode_rgb_with_metrics`](Self::encode_rgb_with_metrics).
-    pub fn encode_rgb(
-        &self,
-        rgb: &[u8],
-        width: u32,
-        height: u32,
-    ) -> Result<alloc::vec::Vec<u8>, super::api::EncodeError> {
-        Ok(self.encode_rgb_with_metrics(rgb, width, height)?.0)
-    }
 }
 
 /// Configuration for lossless (VP8L) encoding.

--- a/src/encoder/config.rs
+++ b/src/encoder/config.rs
@@ -209,6 +209,18 @@ impl LossyConfig {
     /// Requires the `target-zensim` crate feature for the iteration to
     /// actually run; without it, the encoder ships the calibrated
     /// starting-q estimate as a single pass.
+    ///
+    /// **Pixel layout: RGB8-only.** The closed-loop iteration only
+    /// supports `PixelLayout::Rgb8` inputs — encoding RGBA / BGRA /
+    /// BGR / ARGB / L8 / LA8 / YUV420 with `target_zensim` set returns
+    /// [`EncodeError::TargetZensimUnsupportedLayout`](super::api::EncodeError::TargetZensimUnsupportedLayout)
+    /// from the encoder. The iteration's decode-and-measure step
+    /// requires RGB pixels, and we deliberately refuse to silently
+    /// strip alpha to make iteration fire. RGBA support is tracked as
+    /// a follow-up; until then, callers who need alpha-preserving
+    /// `target_zensim` should iterate on an RGB projection of the
+    /// image and re-encode RGBA at the converged quality outside the
+    /// loop.
     #[must_use]
     pub fn with_target_zensim<T: Into<super::zensim_target::ZensimTarget>>(
         mut self,

--- a/src/encoder/config.rs
+++ b/src/encoder/config.rs
@@ -210,17 +210,14 @@ impl LossyConfig {
     /// actually run; without it, the encoder ships the calibrated
     /// starting-q estimate as a single pass.
     ///
-    /// **Pixel layout: RGB8-only.** The closed-loop iteration only
-    /// supports `PixelLayout::Rgb8` inputs — encoding RGBA / BGRA /
-    /// BGR / ARGB / L8 / LA8 / YUV420 with `target_zensim` set returns
-    /// [`EncodeError::TargetZensimUnsupportedLayout`](super::api::EncodeError::TargetZensimUnsupportedLayout)
-    /// from the encoder. The iteration's decode-and-measure step
-    /// requires RGB pixels, and we deliberately refuse to silently
-    /// strip alpha to make iteration fire. RGBA support is tracked as
-    /// a follow-up; until then, callers who need alpha-preserving
-    /// `target_zensim` should iterate on an RGB projection of the
-    /// image and re-encode RGBA at the converged quality outside the
-    /// loop.
+    /// **Supported pixel layouts:** `PixelLayout::Rgb8` and
+    /// `PixelLayout::Rgba8`. RGBA inputs are encoded as alpha-bearing
+    /// WebP and measured against the source via zensim's
+    /// deterministic-noise compositing — the same composite is applied
+    /// to source and reconstruction, so alpha quality is well-defined.
+    /// Other layouts (BGR, BGRA, ARGB, L8, LA8, YUV420) with
+    /// `target_zensim` set return
+    /// [`EncodeError::TargetZensimUnsupportedLayout`](super::api::EncodeError::TargetZensimUnsupportedLayout).
     #[must_use]
     pub fn with_target_zensim<T: Into<super::zensim_target::ZensimTarget>>(
         mut self,
@@ -393,21 +390,27 @@ impl LossyConfig {
         .peak_memory_bytes_max
     }
 
-    /// Crate-internal: encode an interleaved RGB8 buffer
-    /// (`width * height * 3` bytes) and return both the WebP bytes and
-    /// any [`ZensimEncodeMetrics`] from a `target_zensim` iteration.
-    /// For non-target-zensim configs the metrics struct is filled with
-    /// the
+    /// Crate-internal: encode an interleaved RGB8 or RGBA8 buffer
+    /// (`width * height * bpp` bytes, where `bpp` is 3 for RGB8 and
+    /// 4 for RGBA8) and return both the WebP bytes and any
+    /// [`ZensimEncodeMetrics`] from a `target_zensim` iteration. For
+    /// non-target-zensim configs the metrics struct is filled with the
     /// [`ZensimEncodeMetrics::no_target`](super::zensim_target::ZensimEncodeMetrics::no_target)
     /// variant — `targets_met=true`, `passes_used=1`, score `NaN`.
+    ///
+    /// `layout` must be either [`PixelLayout::Rgb8`] or
+    /// [`PixelLayout::Rgba8`]; the gate in
+    /// [`EncodeRequest::try_encode_target_zensim_with_metrics`] guards
+    /// other layouts before they reach this entry.
     ///
     /// This is the iteration loop's internal entry. Public callers
     /// reach the same machinery via
     /// [`EncodeRequest::encode_with_metrics`](super::api::EncodeRequest::encode_with_metrics)
     /// or [`EncodeRequest::encode`](super::api::EncodeRequest::encode).
-    pub(crate) fn encode_rgb_with_metrics(
+    pub(crate) fn encode_pixels_with_metrics(
         &self,
-        rgb: &[u8],
+        pixels: &[u8],
+        layout: super::api::PixelLayout,
         width: u32,
         height: u32,
     ) -> Result<
@@ -417,7 +420,7 @@ impl LossyConfig {
         ),
         super::api::EncodeError,
     > {
-        encode_rgb_with_metrics_impl(self, rgb, width, height)
+        encode_pixels_with_metrics_impl(self, pixels, layout, width, height)
     }
 }
 
@@ -972,9 +975,10 @@ impl EncoderConfig {
 // ============================================================================
 
 #[cfg(feature = "target-zensim")]
-fn encode_rgb_with_metrics_impl(
+fn encode_pixels_with_metrics_impl(
     cfg: &LossyConfig,
-    rgb: &[u8],
+    pixels: &[u8],
+    layout: super::api::PixelLayout,
     width: u32,
     height: u32,
 ) -> Result<
@@ -985,16 +989,17 @@ fn encode_rgb_with_metrics_impl(
     super::api::EncodeError,
 > {
     if let Some(t) = cfg.target_zensim {
-        return super::zensim_target::iteration::run(cfg, t, rgb, width, height);
+        return super::zensim_target::iteration::run(cfg, t, pixels, layout, width, height);
     }
     // No target_zensim → straight single-pass encode.
-    encode_rgb_single_pass(cfg, rgb, width, height)
+    encode_single_pass(cfg, pixels, layout, width, height)
 }
 
 #[cfg(not(feature = "target-zensim"))]
-fn encode_rgb_with_metrics_impl(
+fn encode_pixels_with_metrics_impl(
     cfg: &LossyConfig,
-    rgb: &[u8],
+    pixels: &[u8],
+    layout: super::api::PixelLayout,
     width: u32,
     height: u32,
 ) -> Result<
@@ -1015,16 +1020,17 @@ fn encode_rgb_with_metrics_impl(
             super::analysis::ImageContentType::Photo,
         )
         .clamp(0.0, 100.0);
-        return encode_rgb_single_pass(&probe, rgb, width, height);
+        return encode_single_pass(&probe, pixels, layout, width, height);
     }
-    encode_rgb_single_pass(cfg, rgb, width, height)
+    encode_single_pass(cfg, pixels, layout, width, height)
 }
 
-/// Single-pass RGB8 encode, no metrics. Plumb through `EncodeRequest`
-/// to reuse the existing entry point.
-fn encode_rgb_single_pass(
+/// Single-pass encode (Rgb8 or Rgba8), no metrics. Plumb through
+/// `EncodeRequest` to reuse the existing entry point.
+fn encode_single_pass(
     cfg: &LossyConfig,
-    rgb: &[u8],
+    pixels: &[u8],
+    layout: super::api::PixelLayout,
     width: u32,
     height: u32,
 ) -> Result<
@@ -1034,8 +1040,7 @@ fn encode_rgb_single_pass(
     ),
     super::api::EncodeError,
 > {
-    let req =
-        super::api::EncodeRequest::lossy(cfg, rgb, super::api::PixelLayout::Rgb8, width, height);
+    let req = super::api::EncodeRequest::lossy(cfg, pixels, layout, width, height);
     match req.encode() {
         Ok(bytes) => {
             let len = bytes.len();

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -48,6 +48,9 @@ pub mod tables;
 /// Trellis quantization for RD-optimized coefficient selection
 mod trellis;
 mod vec_writer;
+/// Closed-loop target-zensim adaptive encoder (perceptual quality search).
+#[doc(hidden)]
+pub mod zensim_target;
 /// VP8 lossy encoder implementation.
 #[doc(hidden)]
 pub mod vp8;
@@ -63,6 +66,7 @@ pub use api::{
     ImageMetadata, NoProgress, PixelLayout, Preset,
 };
 pub use config::{EncoderConfig, LosslessConfig, LossyConfig};
+pub use zensim_target::{ZensimEncodeMetrics, ZensimTarget};
 #[doc(hidden)]
 pub use vp8l::{Vp8lConfig, Vp8lQuality, encode_vp8l};
 

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -48,15 +48,15 @@ pub mod tables;
 /// Trellis quantization for RD-optimized coefficient selection
 mod trellis;
 mod vec_writer;
-/// Closed-loop target-zensim adaptive encoder (perceptual quality search).
-#[doc(hidden)]
-pub mod zensim_target;
 /// VP8 lossy encoder implementation.
 #[doc(hidden)]
 pub mod vp8;
 /// VP8L lossless encoder implementation.
 #[doc(hidden)]
 pub mod vp8l;
+/// Closed-loop target-zensim adaptive encoder (perceptual quality search).
+#[doc(hidden)]
+pub mod zensim_target;
 
 // Re-export public API
 pub use analysis::{ClassifierDiag, ImageContentType};
@@ -66,9 +66,9 @@ pub use api::{
     ImageMetadata, NoProgress, PixelLayout, Preset,
 };
 pub use config::{EncoderConfig, LosslessConfig, LossyConfig};
-pub use zensim_target::{ZensimEncodeMetrics, ZensimTarget};
 #[doc(hidden)]
 pub use vp8l::{Vp8lConfig, Vp8lQuality, encode_vp8l};
+pub use zensim_target::{ZensimEncodeMetrics, ZensimTarget};
 
 // Crate-internal re-exports for mux module
 pub(crate) use api::{chunk_size, encode_alpha_lossless, encode_frame_lossless, write_chunk};

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -68,6 +68,8 @@ pub use api::{
 pub use config::{EncoderConfig, LosslessConfig, LossyConfig};
 #[doc(hidden)]
 pub use vp8l::{Vp8lConfig, Vp8lQuality, encode_vp8l};
+#[cfg(feature = "ablation")]
+pub use zensim_target::{AblationToggles, set_toggles as set_ablation_toggles};
 pub use zensim_target::{ZensimEncodeMetrics, ZensimTarget};
 
 // Crate-internal re-exports for mux module

--- a/src/encoder/vp8/mod.rs
+++ b/src/encoder/vp8/mod.rs
@@ -1507,9 +1507,6 @@ impl<'a> Vp8Encoder<'a> {
             block_count_i4: final_block_count_i4,
             block_count_i16: final_block_count_i16,
             block_count_skip: final_skip_mb,
-            segment_map: self.segment_map.clone(),
-            mb_width: self.macroblock_width,
-            mb_height: self.macroblock_height,
             ..Default::default()
         };
 

--- a/src/encoder/vp8/mod.rs
+++ b/src/encoder/vp8/mod.rs
@@ -489,6 +489,11 @@ struct Vp8Encoder<'a> {
     /// Run a stat-collection pre-pass (m4 only — m5/m6 already saturate).
     /// Default `false`. Set via `LossyConfig::with_multi_pass_stats(true)`.
     multi_pass_stats: bool,
+    /// Per-segment additive quant_index offsets applied AFTER
+    /// `compute_segment_quant`'s SNS modulation. `None` (default) leaves
+    /// segments untouched. Crate-internal hook for `target_zensim`'s
+    /// per-segment correction pass.
+    segment_quant_overrides: Option<[i8; 4]>,
     /// Loop filter strength (0-100)
     filter_strength: u8,
     /// Loop filter sharpness (0-7)
@@ -598,6 +603,7 @@ impl<'a> Vp8Encoder<'a> {
             smooth_segment_map: false,
             cost_model: super::api::CostModel::ZenwebpDefault,
             multi_pass_stats: false,
+            segment_quant_overrides: None,
             filter_strength: 60,
             filter_sharpness: 0,
             num_segments: 4,
@@ -928,6 +934,7 @@ impl<'a> Vp8Encoder<'a> {
         self.smooth_segment_map = params.smooth_segment_map;
         self.cost_model = params.cost_model;
         self.multi_pass_stats = params.multi_pass_stats;
+        self.segment_quant_overrides = params.segment_quant_overrides;
         self.filter_strength = params.filter_strength.min(100);
         self.filter_sharpness = params.filter_sharpness.min(7);
         self.num_segments = params.num_segments.clamp(1, 4);
@@ -1500,6 +1507,9 @@ impl<'a> Vp8Encoder<'a> {
             block_count_i4: final_block_count_i4,
             block_count_i16: final_block_count_i16,
             block_count_skip: final_skip_mb,
+            segment_map: self.segment_map.clone(),
+            mb_width: self.macroblock_width,
+            mb_height: self.macroblock_height,
             ..Default::default()
         };
 
@@ -1728,7 +1738,16 @@ impl<'a> Vp8Encoder<'a> {
             let center = center as i32;
             let transformed_alpha = (255 * (center - mid_alpha) / effective_range).clamp(-127, 127);
             let beta = (255 * (center - min_center) / effective_range).clamp(0, 255) as u8;
-            let seg_quant_index = compute_segment_quant(quality, transformed_alpha, sns_strength);
+            let mut seg_quant_index =
+                compute_segment_quant(quality, transformed_alpha, sns_strength);
+            // target_zensim per-segment correction: apply additive
+            // override (clamped) AFTER SNS modulation. `None` (default)
+            // leaves the value untouched, so non-target-zensim encodes
+            // are bit-identical to before.
+            if let Some(deltas) = self.segment_quant_overrides {
+                let delta = deltas.get(seg_idx).copied().unwrap_or(0) as i32;
+                seg_quant_index = (i32::from(seg_quant_index) + delta).clamp(0, 127) as u8;
+            }
             let seg_filter = super::cost::compute_filter_level_with_beta(
                 seg_quant_index,
                 self.filter_sharpness,

--- a/src/encoder/vp8/mod.rs
+++ b/src/encoder/vp8/mod.rs
@@ -640,6 +640,21 @@ impl<'a> Vp8Encoder<'a> {
         }
     }
 
+    /// Take the encoder's segment_map and grid dimensions for diagnostics.
+    /// Used by the `target-zensim` closed-loop iteration to drive
+    /// per-segment correction from the encoder's actual k-means assignment
+    /// rather than a spatial proxy. Empty `segment_map` means segments
+    /// were disabled (`num_segments == 1`) or the analysis pass didn't run.
+    #[cfg(feature = "target-zensim")]
+    fn into_diagnostics(self) -> super::api::EncodeDiagnostics {
+        super::api::EncodeDiagnostics {
+            segment_map: self.segment_map,
+            mb_width: self.macroblock_width,
+            mb_height: self.macroblock_height,
+            num_segments: self.num_segments,
+        }
+    }
+
     /// Get the segment for a macroblock at (mbx, mby).
     ///
     /// When segments are enabled, looks up the segment ID from the segment map.
@@ -2085,6 +2100,90 @@ fn encode_with_partition_retry(
     }
 
     // All retry limits exhausted — return the last overflow error
+    Err(at!(last_overflow.unwrap_or(
+        EncodeError::Partition0Overflow {
+            size: 0,
+            max: (1 << 19) - 1,
+        }
+    )))
+}
+
+/// Encode a single lossy frame and return the resulting bytes alongside
+/// the encoder's per-MB segment_map and grid dimensions. Used by the
+/// `target-zensim` closed-loop iteration to make per-segment correction
+/// decisions against the encoder's real k-means assignment.
+///
+/// Mirrors [`encode_frame_lossy`] (with partition-retry) but routes through
+/// a path that retains access to the [`Vp8Encoder`] after `encode_image` so
+/// the segment_map can be taken out. The on-wire bytes are byte-identical
+/// to `encode_frame_lossy` for the same inputs.
+///
+/// Caller is responsible for skipping target_size / target_psnr / target_zensim
+/// recursion on the params (the iteration loop already does this).
+#[cfg(feature = "target-zensim")]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn encode_frame_lossy_with_diagnostics(
+    writer: &mut Vec<u8>,
+    data: &[u8],
+    width: u32,
+    height: u32,
+    stride: usize,
+    color: PixelLayout,
+    params: &super::api::EncoderParams,
+    stop: &dyn enough::Stop,
+    progress: &dyn super::api::EncodeProgress,
+) -> super::api::EncodeResult<(super::api::EncodeStats, super::api::EncodeDiagnostics)> {
+    let width = width
+        .try_into()
+        .map_err(|_| at!(EncodeError::InvalidDimensions))?;
+    let height = height
+        .try_into()
+        .map_err(|_| at!(EncodeError::InvalidDimensions))?;
+
+    // Same partition-retry semantics as `encode_with_partition_retry`,
+    // but we hold onto the Vp8Encoder so we can take its segment_map out
+    // after a successful encode.
+    if params.partition_limit.is_some() {
+        let mut vp8_encoder = Vp8Encoder::new(writer);
+        let stats =
+            vp8_encoder.encode_image(data, color, width, height, stride, params, stop, progress)?;
+        let diag = vp8_encoder.into_diagnostics();
+        return Ok((stats, diag));
+    }
+
+    const RETRY_LIMITS: [u8; 4] = [0, 40, 70, 100];
+    let mut last_overflow = None;
+    for &limit in &RETRY_LIMITS {
+        stop.check().map_err(|e| at!(EncodeError::from(e)))?;
+
+        let mut trial_buf = Vec::new();
+        let mut trial_params = params.clone();
+        trial_params.partition_limit = Some(limit);
+
+        let mut vp8_encoder = Vp8Encoder::new(&mut trial_buf);
+        match vp8_encoder.encode_image(
+            data,
+            color,
+            width,
+            height,
+            stride,
+            &trial_params,
+            stop,
+            progress,
+        ) {
+            Ok(stats) => {
+                let diag = vp8_encoder.into_diagnostics();
+                writer.extend_from_slice(&trial_buf);
+                return Ok((stats, diag));
+            }
+            Err(e @ EncodeError::Partition0Overflow { .. }) if limit < 100 => {
+                last_overflow = Some(e);
+                continue;
+            }
+            Err(e) => return Err(at!(e)),
+        }
+    }
+
     Err(at!(last_overflow.unwrap_or(
         EncodeError::Partition0Overflow {
             size: 0,

--- a/src/encoder/zensim_target.rs
+++ b/src/encoder/zensim_target.rs
@@ -591,10 +591,22 @@ pub(crate) mod iteration {
                         cum_before=[{},{},{},{}] cum_after=[{},{},{},{}] picked_seg={:?} dir={}",
                         pass,
                         target.target - last_score,
-                        dec.means[0], dec.means[1], dec.means[2], dec.means[3],
-                        dec.counts[0], dec.counts[1], dec.counts[2], dec.counts[3],
-                        cum_overrides[0], cum_overrides[1], cum_overrides[2], cum_overrides[3],
-                        dec.overrides[0], dec.overrides[1], dec.overrides[2], dec.overrides[3],
+                        dec.means[0],
+                        dec.means[1],
+                        dec.means[2],
+                        dec.means[3],
+                        dec.counts[0],
+                        dec.counts[1],
+                        dec.counts[2],
+                        dec.counts[3],
+                        cum_overrides[0],
+                        cum_overrides[1],
+                        cum_overrides[2],
+                        cum_overrides[3],
+                        dec.overrides[0],
+                        dec.overrides[1],
+                        dec.overrides[2],
+                        dec.overrides[3],
                         dec.picked_seg,
                         dec.direction,
                     );
@@ -984,9 +996,8 @@ pub(crate) mod iteration {
         #[cfg(not(feature = "std"))]
         let use_quadrant = false;
         if use_quadrant {
-            let q_overrides = next_segment_overrides_quadrant_proxy(
-                cum, diffmap, width, height, score, target,
-            );
+            let q_overrides =
+                next_segment_overrides_quadrant_proxy(cum, diffmap, width, height, score, target);
             return OverrideDecision {
                 overrides: q_overrides,
                 means: [0.0; 4],

--- a/src/encoder/zensim_target.rs
+++ b/src/encoder/zensim_target.rs
@@ -266,6 +266,125 @@ pub(crate) mod iteration {
     /// an error if a hard constraint was violated.
     pub(crate) type IterationResult = Result<(Vec<u8>, ZensimEncodeMetrics), EncodeError>;
 
+    // ============================================================================
+    // Ablation toggles (dev-only)
+    // ============================================================================
+    //
+    // The PR shipping target_zensim (Phases 1/2/3) is a stack of distinct
+    // mechanisms. We need to measure each chunk's individual contribution to
+    // convergence quality before un-drafting; this section wires per-chunk
+    // disable toggles read from environment variables. All toggles default
+    // to FALSE/OFF, so the production code path is unchanged when nothing
+    // is set.
+    //
+    // The `dev/zensim_ablation.rs` binary flips these between sweep legs.
+    // None of them touches the encoded bytestream — they only change the
+    // iteration loop's decisions (which q to start at, whether to take a
+    // per-segment vs global-q correction step, etc.).
+
+    /// Disable Phase 3 per-segment correction. When set, every pass after
+    /// pass 0 takes the global-q secant step (or fallback step) instead of
+    /// computing per-segment quant overrides from the diffmap. Equivalent
+    /// to "Phase 1 (+ Phase 2 anchors) only".
+    fn ablate_disable_phase3() -> bool {
+        std::env::var("ZENWEBP_ABLATE_NO_PHASE3")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+    }
+
+    /// Skip the bucket classifier and use a single naive starting-q anchor
+    /// table for all images regardless of content type. Disables Phase 1's
+    /// per-bucket calibration AND Phase 2's refit (since both Photo and
+    /// Drawing get replaced with the naive identity-ish ramp).
+    fn ablate_naive_starting_q() -> bool {
+        std::env::var("ZENWEBP_ABLATE_NAIVE_Q")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+    }
+
+    /// Don't force `multi_pass_stats=true` inside the iteration loop on
+    /// pass 1+. Leaves the user's `LossyConfig.multi_pass_stats` value
+    /// (typically `false`).
+    fn ablate_no_multi_pass_stats() -> bool {
+        std::env::var("ZENWEBP_ABLATE_NO_MULTI_PASS_STATS")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+    }
+
+    /// Restore the pre-Phase-2 hand-distilled anchors for Photo/Drawing
+    /// (Icon was hand-distilled in both versions and is unchanged). Tests
+    /// whether the Phase 2 calibration tool's refit is actually pulling
+    /// its weight vs the original judgement-based table.
+    fn ablate_pre_phase2_anchors() -> bool {
+        std::env::var("ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+    }
+
+    /// Use a fixed proportional Δq instead of the secant. Only meaningful
+    /// when Phase 3 is also disabled (the global-q fallback path).
+    fn ablate_no_secant() -> bool {
+        std::env::var("ZENWEBP_ABLATE_NO_SECANT")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+    }
+
+    /// Naive starting-q anchor table — single linear ramp (target, q) used
+    /// when the bucket classifier is bypassed. Shape mirrors zenjpeg's
+    /// `zq_to_starting_jpegli_q`: a gentle ramp that crosses target=q at
+    /// the high end and starts conservatively at the low end.
+    fn naive_starting_q(target: f32) -> f32 {
+        const NAIVE: &[(f32, f32)] = &[
+            (60.0, 50.0),
+            (70.0, 65.0),
+            (75.0, 75.0),
+            (80.0, 82.0),
+            (85.0, 90.0),
+            (90.0, 96.0),
+            (95.0, 100.0),
+        ];
+        interpolate_anchors(target, NAIVE)
+    }
+
+    /// Pre-Phase-2 hand-distilled Photo / Drawing anchors. Recovered from
+    /// commit `17b9c9a^:src/encoder/zensim_target.rs`. Used only when
+    /// `ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS=1` is set (chunk E ablation).
+    fn pre_phase2_starting_q(target: f32, bucket: ImageContentType) -> f32 {
+        const PHOTO_HAND: &[(f32, f32)] = &[
+            (60.0, 50.0),
+            (70.0, 65.0),
+            (75.0, 72.0),
+            (80.0, 80.0),
+            (85.0, 88.0),
+            (90.0, 94.0),
+            (95.0, 98.0),
+        ];
+        const DRAWING_HAND: &[(f32, f32)] = &[
+            (60.0, 55.0),
+            (70.0, 70.0),
+            (75.0, 78.0),
+            (80.0, 84.0),
+            (85.0, 90.0),
+            (90.0, 96.0),
+            (95.0, 100.0),
+        ];
+        const ICON_HAND: &[(f32, f32)] = &[
+            (60.0, 65.0),
+            (70.0, 78.0),
+            (75.0, 85.0),
+            (80.0, 90.0),
+            (85.0, 95.0),
+            (90.0, 98.0),
+            (95.0, 100.0),
+        ];
+        let anchors = match bucket {
+            ImageContentType::Photo => PHOTO_HAND,
+            ImageContentType::Drawing | ImageContentType::Text => DRAWING_HAND,
+            ImageContentType::Icon => ICON_HAND,
+        };
+        interpolate_anchors(target, anchors)
+    }
+
     /// Maximum |Δq| applied per secant step. Prevents oscillation when
     /// the metric is locally non-linear.
     const MAX_DELTA_Q: f32 = 10.0;
@@ -288,12 +407,28 @@ pub(crate) mod iteration {
         height: u32,
     ) -> IterationResult {
         // 1. Detect bucket from a quick classifier pass on the source.
-        let bucket = detect_bucket(rgb, width, height);
+        // Skipped entirely when the naive-starting-q ablation is on.
+        let bucket = if ablate_naive_starting_q() {
+            None
+        } else {
+            detect_bucket(rgb, width, height)
+        };
 
         // 2. Resolve the starting q.
-        let mut q = match bucket {
-            Some(b) => zensim_to_starting_q_for_bucket(target.target, b),
-            None => zensim_to_starting_q_for_bucket(target.target, ImageContentType::Photo),
+        let mut q = if ablate_naive_starting_q() {
+            // Chunk C ablation: skip per-bucket lookup, use a single ramp.
+            naive_starting_q(target.target)
+        } else if ablate_pre_phase2_anchors() {
+            // Chunk E ablation: pre-Phase-2 hand-distilled anchors.
+            match bucket {
+                Some(b) => pre_phase2_starting_q(target.target, b),
+                None => pre_phase2_starting_q(target.target, ImageContentType::Photo),
+            }
+        } else {
+            match bucket {
+                Some(b) => zensim_to_starting_q_for_bucket(target.target, b),
+                None => zensim_to_starting_q_for_bucket(target.target, ImageContentType::Photo),
+            }
         };
         q = q.clamp(0.0, 100.0);
 
@@ -345,7 +480,11 @@ pub(crate) mod iteration {
         // `num_segments == 1` (segmentation disabled or simplified down
         // to a single segment) or the segment_map is empty, we fall back
         // to global-q correction.
-        let per_segment_enabled = diag0.num_segments > 1
+        //
+        // Chunk A ablation: when ZENWEBP_ABLATE_NO_PHASE3=1, force the
+        // global-q fallback path even when segments are active.
+        let per_segment_enabled = !ablate_disable_phase3()
+            && diag0.num_segments > 1
             && !diag0.segment_map.is_empty()
             && diag0.mb_width > 0
             && diag0.mb_height > 0;
@@ -404,9 +543,11 @@ pub(crate) mod iteration {
             }
 
             // multi_pass_stats=true on probe encodes — small size win
-            // amortizes across passes.
+            // amortizes across passes. Chunk D ablation: leave it at the
+            // user's LossyConfig value when ZENWEBP_ABLATE_NO_MULTI_PASS_STATS=1.
+            let mps = !ablate_no_multi_pass_stats();
             let (bytes_n, diag_n) =
-                encode_at_with_diagnostics(cfg, next_q, true, next_overrides, rgb, width, height)?;
+                encode_at_with_diagnostics(cfg, next_q, mps, next_overrides, rgb, width, height)?;
             let (score_n, dm_n) = measure_score_and_diffmap(&z, &pre, &bytes_n, width, height)?;
             let passes_used = pass + 1;
 
@@ -490,7 +631,8 @@ pub(crate) mod iteration {
     }
 
     /// Compute next q via secant when we have a previous probe, fixed-
-    /// step otherwise.
+    /// step otherwise. Chunk F ablation: when ZENWEBP_ABLATE_NO_SECANT=1,
+    /// always use a fixed proportional step `(target - achieved) * 0.5`.
     fn compute_next_q(
         q: f32,
         last_score: f32,
@@ -498,6 +640,14 @@ pub(crate) mod iteration {
         target: &ZensimTarget,
     ) -> f32 {
         let gap = target.target - last_score;
+        if ablate_no_secant() {
+            let mut step = gap * 0.5;
+            step = step.clamp(-MAX_DELTA_Q, MAX_DELTA_Q);
+            if step.abs() < MIN_DELTA_Q {
+                step = MIN_DELTA_Q.copysign(if gap == 0.0 { 1.0 } else { gap });
+            }
+            return q + step;
+        }
         // Secant: estimate dscore/dq from the two most recent probes.
         // (Note: `q` and `last_score` are the SAME probe as the latest
         // one in `prev_probe` until we update. So the secant fits

--- a/src/encoder/zensim_target.rs
+++ b/src/encoder/zensim_target.rs
@@ -257,7 +257,7 @@ fn interpolate_anchors(target: f32, anchors: &[(f32, f32)]) -> f32 {
 pub(crate) mod iteration {
     use super::*;
     use crate::PixelLayout;
-    use crate::encoder::api::EncodeError;
+    use crate::encoder::api::{EncodeDiagnostics, EncodeError};
     use crate::encoder::config::LossyConfig;
     use alloc::format;
     use alloc::vec::Vec;
@@ -297,8 +297,11 @@ pub(crate) mod iteration {
         };
         q = q.clamp(0.0, 100.0);
 
-        // 3. Encode pass 0 (global-q, no per-segment overrides).
-        let bytes0 = encode_at(cfg, q, false, None, rgb, width, height)?;
+        // 3. Encode pass 0 (global-q, no per-segment overrides). Pass 0
+        // also captures the encoder's per-MB segment_map via the internal
+        // `EncodeDiagnostics` struct so Phase 3 can aggregate the diffmap
+        // per real k-means segment instead of a 2x2 spatial proxy.
+        let (bytes0, diag0) = encode_at_with_diagnostics(cfg, q, false, None, rgb, width, height)?;
         let max_passes = target.max_passes.max(1);
 
         if max_passes <= 1 {
@@ -335,18 +338,24 @@ pub(crate) mod iteration {
             return finalize(best, 1, &target);
         }
 
-        // Per-segment correction setup. We use a 2x2 spatial-quadrant
-        // PROXY for the encoder's segment_map rather than exposing it
-        // through the public API (would require a `#[non_exhaustive]`
-        // SemVer break on `EncodeStats`). For most natural images the
-        // k-means-on-alpha segment assignment correlates strongly with
-        // spatial regions, so the proxy gets us the same shape of
-        // adjustment without piercing public API. For images where it
-        // doesn't (deeply intermixed textures), the global-q fallback
-        // still kicks in via the secant once one quadrant adjustment
-        // doesn't move the dial.
-        let num_segments = cfg.segments.unwrap_or(4) as usize;
-        let per_segment_enabled = num_segments > 1 && width >= 32 && height >= 32;
+        // Per-segment correction setup. Phase 3 uses the encoder's actual
+        // k-means `segment_map` (one segment_id per macroblock, threaded
+        // through via `pub(crate) EncodeDiagnostics` — see
+        // `encode_inner_with_diagnostics`). When the encoder reported
+        // `num_segments == 1` (segmentation disabled or simplified down
+        // to a single segment) or the segment_map is empty, we fall back
+        // to global-q correction.
+        let per_segment_enabled = diag0.num_segments > 1
+            && !diag0.segment_map.is_empty()
+            && diag0.mb_width > 0
+            && diag0.mb_height > 0;
+        let num_segments = diag0.num_segments as usize;
+        // The active diagnostics — segment_map and grid — used for
+        // per-segment aggregation. Updated each pass with the most recent
+        // probe's actual segment assignment (which can shift slightly
+        // across passes since segments depend on quality-affected
+        // segmentation thresholds).
+        let mut last_diag = diag0;
 
         // prev_probe holds the SECOND-most-recent (q, score) so the
         // secant fits a slope between it and the current (q, last_score).
@@ -364,17 +373,18 @@ pub(crate) mod iteration {
             let use_per_segment = per_segment_enabled;
 
             let (next_q, next_overrides) = if use_per_segment {
-                // Phase 3: aggregate diffmap into 4 spatial quadrants;
-                // tighten the worst quadrant or loosen the best when in
-                // claw-back.
+                // Phase 3: aggregate the per-pixel diffmap into per-MB
+                // means, then accumulate per real k-means segment using
+                // `last_diag.segment_map`. Tighten the worst-mean segment
+                // or loosen the best-mean segment in the claw-back case.
                 let new_overrides = next_segment_overrides(
                     cum_overrides,
                     &last_dm,
                     width,
                     height,
+                    &last_diag,
                     last_score,
                     &target,
-                    num_segments.min(4),
                 );
                 // Keep q the same when doing per-segment correction.
                 (last_q, Some(new_overrides))
@@ -395,7 +405,8 @@ pub(crate) mod iteration {
 
             // multi_pass_stats=true on probe encodes — small size win
             // amortizes across passes.
-            let bytes_n = encode_at(cfg, next_q, true, next_overrides, rgb, width, height)?;
+            let (bytes_n, diag_n) =
+                encode_at_with_diagnostics(cfg, next_q, true, next_overrides, rgb, width, height)?;
             let (score_n, dm_n) = measure_score_and_diffmap(&z, &pre, &bytes_n, width, height)?;
             let passes_used = pass + 1;
 
@@ -422,6 +433,16 @@ pub(crate) mod iteration {
             last_q = next_q;
             last_score = score_n;
             last_dm = dm_n;
+            // The encoder may re-segment differently when overrides shift
+            // the per-segment quants — refresh from the latest probe.
+            // (Only meaningful for the diffmap aggregation loop; if the
+            // new diag has fewer segments we just operate on the smaller
+            // index range, no re-init needed.)
+            // Discard the old diag so the next aggregation uses the
+            // assignment that produced `dm_n`.
+            // (Per-segment fallback flag stays whatever pass 0 decided.)
+            let _ = num_segments; // keep the per-segment count from pass 0
+            last_diag = diag_n;
         }
 
         finalize(best, max_passes, &target)
@@ -538,9 +559,15 @@ pub(crate) mod iteration {
     }
 
     /// Encode RGB pixels at the given quality with optional per-segment
-    /// quant-index overrides. `enable_multi_pass` toggles
-    /// `multi_pass_stats` for inside-the-loop probes.
-    fn encode_at(
+    /// quant-index overrides, returning the WebP bytes alongside the
+    /// encoder's per-MB `segment_map` (via the internal
+    /// [`EncodeDiagnostics`] companion struct). On-wire bytes are
+    /// byte-identical to the regular [`crate::EncodeRequest::encode`]
+    /// path for the same inputs.
+    ///
+    /// `enable_multi_pass` toggles `multi_pass_stats` on the probe — a
+    /// small size-saving option that amortizes across passes.
+    fn encode_at_with_diagnostics(
         cfg: &LossyConfig,
         q: f32,
         enable_multi_pass: bool,
@@ -548,7 +575,7 @@ pub(crate) mod iteration {
         rgb: &[u8],
         width: u32,
         height: u32,
-    ) -> Result<Vec<u8>, EncodeError> {
+    ) -> Result<(Vec<u8>, EncodeDiagnostics), EncodeError> {
         let mut probe_cfg = cfg.clone();
         probe_cfg.quality = q.clamp(0.0, 100.0);
         probe_cfg.multi_pass_stats = enable_multi_pass;
@@ -566,8 +593,8 @@ pub(crate) mod iteration {
             width,
             height,
         );
-        match req.encode() {
-            Ok(bytes) => Ok(bytes),
+        match req.encode_inner_with_diagnostics() {
+            Ok((bytes, _stats, diag)) => Ok((bytes, diag)),
             Err(at_err) => Err(at_err.decompose().0),
         }
     }
@@ -631,58 +658,103 @@ pub(crate) mod iteration {
         Ok((score, dm.diffmap().to_vec()))
     }
 
-    /// Aggregate the per-pixel diffmap into 4 spatial quadrants
-    /// (top-left, top-right, bottom-left, bottom-right) → per-quadrant
-    /// mean → tighten the worst quadrant or loosen the best.
+    /// Aggregate the per-pixel diffmap into per-macroblock means, then
+    /// accumulate those into per-segment sums using the encoder's actual
+    /// k-means `segment_map`. Tightens the worst-mean segment or loosens
+    /// the best-mean segment in the claw-back case.
     ///
-    /// Why quadrants and not exact segments: the encoder's k-means
-    /// segment_map isn't exposed through the public API (adding it to
-    /// `EncodeStats` is a SemVer break). For most natural images,
-    /// k-means-on-alpha buckets correlate with spatial regions, so this
-    /// proxy gives roughly the same correction shape without piercing
-    /// public API.
+    /// Phase 3 used to do this against a 2x2 spatial quadrant proxy
+    /// because exposing the segment_map on `EncodeStats` would have been
+    /// a SemVer break. The real assignment is now threaded through the
+    /// `pub(crate) EncodeDiagnostics` companion struct
+    /// (`encode_inner_with_diagnostics`), so we operate on the encoder's
+    /// actual per-MB clustering — important because zenwebp's segments
+    /// are k-means in alpha-space, NOT spatial: an MB in the top-left
+    /// can share a segment with a same-alpha MB in the bottom-right and
+    /// the quadrant proxy would have lumped it elsewhere.
     ///
     /// Returns the NEW cumulative overrides (not deltas). Bounded to
-    /// `[-16, 16]` cumulatively to leave room for future passes and stay
-    /// in sensible VP8 quantizer range.
+    /// `[-16, 16]` cumulatively to stay in sensible VP8 quantizer range.
+    ///
+    /// MB-level aggregation: we walk the diffmap one MB at a time (16x16
+    /// pixel block) and add its mean to the appropriate segment's
+    /// accumulator. Edge MBs that overlap the right/bottom image border
+    /// are handled by clipping the read region.
     fn next_segment_overrides(
         cum: [i8; 4],
         diffmap: &[f32],
         width: u32,
         height: u32,
+        diag: &EncodeDiagnostics,
         score: f32,
         target: &ZensimTarget,
-        num_segments: usize,
     ) -> [i8; 4] {
-        let n = num_segments.clamp(2, 4);
-        let mut sum = [0.0f64; 4];
-        let mut count = [0u64; 4];
+        // A/B testing hatch: when the env var ZENWEBP_PHASE3_QUADRANT=1
+        // is set, fall back to the previous 2x2 spatial-quadrant proxy.
+        // Used by `dev/zensim_ab_quadrant_vs_segmap.rs` to compare the
+        // two aggregators side-by-side. Production never sets this.
+        // std-only since core::env doesn't expose `var`.
+        #[cfg(feature = "std")]
+        let use_quadrant = std::env::var("ZENWEBP_PHASE3_QUADRANT")
+            .map(|v| v == "1")
+            .unwrap_or(false);
+        #[cfg(not(feature = "std"))]
+        let use_quadrant = false;
+        if use_quadrant {
+            return next_segment_overrides_quadrant_proxy(
+                cum, diffmap, width, height, score, target,
+            );
+        }
+
+        let n = (diag.num_segments as usize).clamp(2, 4);
         let w = width as usize;
         let h = height as usize;
-        // Quadrant layout for n=4: TL=0, TR=1, BL=2, BR=3. For n=2,
-        // halve horizontally: L=0, R=1. For n=3, drop BR (treat it as
-        // BL).
-        let half_w = w / 2;
-        let half_h = h / 2;
-        for y in 0..h {
-            let row = &diffmap[y * w..y * w + w];
-            for (x, &v) in row.iter().enumerate() {
-                let q = match n {
-                    2 => usize::from(x >= half_w),
-                    _ => {
-                        let qx = usize::from(x >= half_w);
-                        let qy = usize::from(y >= half_h);
-                        let q4 = qy * 2 + qx;
-                        // For n=3, treat quadrant 3 as 2 (merge BL+BR).
-                        if n == 3 && q4 == 3 { 2 } else { q4 }
+        let mb_w = diag.mb_width as usize;
+        let mb_h = diag.mb_height as usize;
+        let expected = mb_w.saturating_mul(mb_h);
+        // Defensive: if the segment_map shape doesn't match the encoder
+        // grid (shouldn't happen, but the diag is plumbed through enough
+        // layers that it's worth guarding), fall back to no-op overrides.
+        if diag.segment_map.len() != expected || expected == 0 {
+            return cum;
+        }
+
+        let mut sum = [0.0f64; 4];
+        let mut count = [0u64; 4];
+
+        // Per-MB diffmap mean → accumulate into the MB's segment.
+        for mb_y in 0..mb_h {
+            let py0 = mb_y * 16;
+            let py1 = (py0 + 16).min(h);
+            if py0 >= h {
+                break;
+            }
+            for mb_x in 0..mb_w {
+                let px0 = mb_x * 16;
+                let px1 = (px0 + 16).min(w);
+                if px0 >= w {
+                    continue;
+                }
+                let seg = diag.segment_map[mb_y * mb_w + mb_x] as usize;
+                if seg >= n {
+                    continue;
+                }
+                let mut block_sum = 0.0f64;
+                let mut block_count = 0u64;
+                for py in py0..py1 {
+                    let row = &diffmap[py * w + px0..py * w + px1];
+                    for &v in row {
+                        block_sum += v as f64;
+                        block_count += 1;
                     }
-                };
-                if q < 4 {
-                    sum[q] += v as f64;
-                    count[q] += 1;
+                }
+                if block_count > 0 {
+                    sum[seg] += block_sum;
+                    count[seg] += block_count;
                 }
             }
         }
+
         let mut means = [0.0f32; 4];
         for s in 0..n {
             if count[s] > 0 {
@@ -690,7 +762,9 @@ pub(crate) mod iteration {
             }
         }
 
-        // Find worst (highest mean) and best (lowest mean) quadrants.
+        // Find worst (highest mean diffmap = most distorted) and best
+        // (lowest mean diffmap = highest fidelity headroom) segments,
+        // ignoring segments with no MB assignments.
         let mut worst = 0usize;
         let mut best = 0usize;
         let mut found_worst = false;
@@ -708,7 +782,86 @@ pub(crate) mod iteration {
                 found_best = true;
             }
         }
+        if !found_worst {
+            return cum;
+        }
 
+        let mut out = cum;
+        let gap = target.target - score;
+        if gap > 0.0 {
+            let step = if gap > 4.0 {
+                -3
+            } else if gap > 2.0 {
+                -2
+            } else {
+                -1
+            };
+            out[worst] = (i32::from(out[worst]) + step).clamp(-16, 16) as i8;
+        } else if let Some(t) = target.max_overshoot
+            && (score - target.target) > t
+        {
+            let overshoot = score - target.target - t;
+            let step = if overshoot > 4.0 {
+                3
+            } else if overshoot > 2.0 {
+                2
+            } else {
+                1
+            };
+            out[best] = (i32::from(out[best]) + step).clamp(-16, 16) as i8;
+        }
+        out
+    }
+
+    /// Pre-deviation aggregation: 2x2 spatial-quadrant proxy. Kept for
+    /// A/B comparison via `ZENWEBP_PHASE3_QUADRANT=1`. Production code
+    /// uses the real `segment_map` via [`next_segment_overrides`].
+    fn next_segment_overrides_quadrant_proxy(
+        cum: [i8; 4],
+        diffmap: &[f32],
+        width: u32,
+        height: u32,
+        score: f32,
+        target: &ZensimTarget,
+    ) -> [i8; 4] {
+        let n: usize = 4;
+        let mut sum = [0.0f64; 4];
+        let mut count = [0u64; 4];
+        let w = width as usize;
+        let h = height as usize;
+        let half_w = w / 2;
+        let half_h = h / 2;
+        for y in 0..h {
+            let row = &diffmap[y * w..y * w + w];
+            for (x, &v) in row.iter().enumerate() {
+                let qx = usize::from(x >= half_w);
+                let qy = usize::from(y >= half_h);
+                let q = qy * 2 + qx;
+                sum[q] += v as f64;
+                count[q] += 1;
+            }
+        }
+        let mut means = [0.0f32; 4];
+        for s in 0..n {
+            if count[s] > 0 {
+                means[s] = (sum[s] / count[s] as f64) as f32;
+            }
+        }
+        let mut worst = 0usize;
+        let mut best = 0usize;
+        let mut found = false;
+        for s in 0..n {
+            if count[s] == 0 {
+                continue;
+            }
+            if !found || means[s] > means[worst] {
+                worst = s;
+            }
+            if !found || means[s] < means[best] {
+                best = s;
+            }
+            found = true;
+        }
         let mut out = cum;
         let gap = target.target - score;
         if gap > 0.0 {

--- a/src/encoder/zensim_target.rs
+++ b/src/encoder/zensim_target.rs
@@ -26,7 +26,9 @@
 //! The per-bucket anchors below come from `dev/zensim_calibrate.rs`. To
 //! re-fit (e.g. after touching the encoder's RD path or upgrading zensim):
 //!
-//!     cargo run --release --features target-zensim --example zensim_calibrate -- <corpus>
+//! ```text
+//! cargo run --release --features target-zensim --example zensim_calibrate -- <corpus>
+//! ```
 //!
 //! The tool emits a TSV plus a Rust-formatted const block. Replace the
 //! `PHOTO`, `DRAWING`, `ICON` arrays below with the harness output. Anchors
@@ -172,37 +174,40 @@ impl ZensimEncodeMetrics {
 ///
 /// # Anchor table source
 ///
-/// Initial values were hand-distilled from a CID22 sweep at q ∈ {30, 50,
-/// 70, 80, 85, 90, 95}. They were then refit by `dev/zensim_calibrate.rs`
-/// against a 20-image subset of CID22 validation; the fit results are
-/// pasted in below. To re-fit, see this module's top-level comment.
+/// PHOTO and DRAWING are fitted by `dev/zensim_calibrate.rs` against
+/// 20 images of CID22 validation (median smallest-q-meeting-target per
+/// content bucket). ICON is hand-distilled and conservative — re-fit
+/// when an icon corpus is added (the CID22 subset has no ≤128px
+/// images). To re-fit, see this module's top-level comment.
+///
+/// Fit data (CID22 validation, 20 images, 2026-04-26):
+///   Photo   n=12, p25/p75 spread ≤ 7q across all 7 anchors.
+///   Drawing n=8,  p25/p75 spread ≤ 5q across all 7 anchors.
 #[must_use]
 pub(crate) fn zensim_to_starting_q_for_bucket(target: f32, bucket: ImageContentType) -> f32 {
-    // Photo bucket: natural photographs. Calibrated against CID22
-    // validation images that classify as Photo. Streaming CSF is most
-    // forgiving here — q ≈ target in the photo range.
+    // Photo bucket: natural photographs from CID22.
     const PHOTO: &[(f32, f32)] = &[
-        (60.0, 50.0),
-        (70.0, 65.0),
-        (75.0, 72.0),
-        (80.0, 80.0),
-        (85.0, 88.0),
-        (90.0, 94.0),
-        (95.0, 98.0),
-    ];
-    // Drawing bucket: screenshots, line art, mixed UI. Sharper edges, less
-    // headroom — same target needs slightly higher q than photos.
-    const DRAWING: &[(f32, f32)] = &[
-        (60.0, 55.0),
-        (70.0, 70.0),
-        (75.0, 78.0),
-        (80.0, 84.0),
+        (60.0, 30.0),
+        (70.0, 60.0),
+        (75.0, 75.0),
+        (80.0, 85.0),
         (85.0, 90.0),
-        (90.0, 96.0),
+        (90.0, 98.0),
+        (95.0, 100.0),
+    ];
+    // Drawing bucket: low-uniformity / complex texture content from
+    // CID22 (the classifier puts mixed photo+UI here).
+    const DRAWING: &[(f32, f32)] = &[
+        (60.0, 30.0),
+        (70.0, 60.0),
+        (75.0, 72.5),
+        (80.0, 85.0),
+        (85.0, 90.0),
+        (90.0, 100.0),
         (95.0, 100.0),
     ];
     // Icon bucket: ≤128px. Tiny images — every coefficient counts. Push
-    // q higher to preserve detail.
+    // q higher to preserve detail. Hand-distilled (no fit corpus yet).
     const ICON: &[(f32, f32)] = &[
         (60.0, 65.0),
         (70.0, 78.0),
@@ -251,9 +256,9 @@ fn interpolate_anchors(target: f32, anchors: &[(f32, f32)]) -> f32 {
 #[cfg(feature = "target-zensim")]
 pub(crate) mod iteration {
     use super::*;
+    use crate::PixelLayout;
     use crate::encoder::api::EncodeError;
     use crate::encoder::config::LossyConfig;
-    use crate::PixelLayout;
     use alloc::format;
     use alloc::vec::Vec;
 
@@ -271,8 +276,10 @@ pub(crate) mod iteration {
     /// gap rounds to ~0).
     const MIN_DELTA_Q: f32 = 0.5;
 
-    /// Run the global-q closed loop. Returns either the final bytes +
-    /// metrics or a strict-mode `EncodeError`.
+    /// Run the closed loop. Pass 0 is global-q at the calibrated start;
+    /// pass 1+ uses per-segment diffmap-driven correction when segments
+    /// are active (Phase 3), falling back to a global-q secant step when
+    /// segments are disabled (`num_segments == 1`) or unavailable.
     pub(crate) fn run(
         cfg: &LossyConfig,
         target: ZensimTarget,
@@ -290,8 +297,8 @@ pub(crate) mod iteration {
         };
         q = q.clamp(0.0, 100.0);
 
-        // 3. Encode pass 0.
-        let bytes0 = encode_at(cfg, q, false, rgb, width, height)?;
+        // 3. Encode pass 0 (global-q, no per-segment overrides).
+        let (bytes0, stats0) = encode_at(cfg, q, false, None, rgb, width, height)?;
         let max_passes = target.max_passes.max(1);
 
         if max_passes <= 1 {
@@ -306,21 +313,21 @@ pub(crate) mod iteration {
             ));
         }
 
-        // 4. Measure pass 0.
+        // 4. Measure pass 0 with per-pixel diffmap (used by Phase 3 if
+        // segments are active).
         let z = zensim::Zensim::new(zensim::ZensimProfile::latest());
-        let pre = build_source_reference(&z, rgb, width, height)
-            .ok_or_else(|| EncodeError::InvalidBufferSize(
+        let pre = build_source_reference(&z, rgb, width, height).ok_or_else(|| {
+            EncodeError::InvalidBufferSize(
                 "zensim precompute_reference failed (image too small?)".into(),
-            ))?;
-        let score0 = match measure_score(&z, &pre, &bytes0, width, height) {
-            Ok(s) => s,
-            Err(e) => return Err(e),
-        };
+            )
+        })?;
+        let (score0, dm0) = measure_score_and_diffmap(&z, &pre, &bytes0, width, height)?;
 
         let mut best = Candidate {
             bytes: bytes0,
             score: score0,
             q,
+            seg_overrides: None,
         };
 
         // Already in band? Ship pass 0.
@@ -328,33 +335,84 @@ pub(crate) mod iteration {
             return finalize(best, 1, &target);
         }
 
+        // Per-segment correction setup. Available iff segments are
+        // active AND the encoder produced a segment_map.
+        let seg_map = stats0.segment_map.clone();
+        let mb_w = stats0.mb_width as usize;
+        let mb_h = stats0.mb_height as usize;
+        // Number of distinct segment IDs in the map. After
+        // simplify_segments() this may be fewer than 4.
+        let num_segments = seg_map
+            .iter()
+            .copied()
+            .max()
+            .map(|m| (m as usize) + 1)
+            .unwrap_or(1);
+        let per_segment_enabled =
+            num_segments > 1 && seg_map.len() == mb_w * mb_h && !seg_map.is_empty();
+
         // prev_probe holds the SECOND-most-recent (q, score) so the
         // secant fits a slope between it and the current (q, last_score).
         let mut prev_probe: Option<(f32, f32)> = None;
         let mut last_q = q;
         let mut last_score = score0;
+        let mut last_dm = dm0;
+        // Cumulative per-segment overrides (applied across passes).
+        let mut cum_overrides: [i8; 4] = [0; 4];
 
         // 5. Iterate.
         for pass in 1..max_passes {
-            let next_q = compute_next_q(last_q, last_score, prev_probe, &target);
-            let q_clamped = next_q.clamp(0.0, 100.0);
-            // If clamping made it equal-ish to the previous q, bail (we'd
-            // just probe the same point).
-            if (q_clamped - last_q).abs() < 0.05 {
+            // Decide whether this pass uses per-segment correction or
+            // a global-q step. Per-segment is preferred when active.
+            let use_per_segment = per_segment_enabled;
+
+            let (next_q, next_overrides) = if use_per_segment {
+                // Phase 3: aggregate diffmap → per-segment mean → tighten
+                // the worst segment / loosen the best when in claw-back.
+                let new_overrides = next_segment_overrides(
+                    cum_overrides,
+                    &seg_map,
+                    mb_w,
+                    mb_h,
+                    &last_dm,
+                    width,
+                    height,
+                    last_score,
+                    &target,
+                    num_segments,
+                );
+                // Keep q the same when doing per-segment correction.
+                (last_q, Some(new_overrides))
+            } else {
+                let nq = compute_next_q(last_q, last_score, prev_probe, &target);
+                (nq.clamp(0.0, 100.0), None)
+            };
+
+            // If neither q changed nor overrides moved, bail.
+            let q_moved = (next_q - last_q).abs() >= 0.05;
+            let overrides_moved = match next_overrides {
+                Some(o) => o != cum_overrides,
+                None => false,
+            };
+            if !q_moved && !overrides_moved {
                 break;
             }
 
             // multi_pass_stats=true on probe encodes — small size win
             // amortizes across passes.
-            let bytes_n = encode_at(cfg, q_clamped, true, rgb, width, height)?;
-            let score_n = measure_score(&z, &pre, &bytes_n, width, height)?;
+            let (bytes_n, stats_n) =
+                encode_at(cfg, next_q, true, next_overrides, rgb, width, height)?;
+            let (score_n, dm_n) = measure_score_and_diffmap(&z, &pre, &bytes_n, width, height)?;
             let passes_used = pass + 1;
 
-            // Track the best candidate that is "feasible" (>= target) by
-            // smallest bytes; otherwise the highest-score one.
             best = pick_best(
                 best,
-                Candidate { bytes: bytes_n, score: score_n, q: q_clamped },
+                Candidate {
+                    bytes: bytes_n,
+                    score: score_n,
+                    q: next_q,
+                    seg_overrides: next_overrides,
+                },
                 &target,
             );
 
@@ -362,9 +420,15 @@ pub(crate) mod iteration {
                 return finalize(best, passes_used, &target);
             }
 
+            // Update state for next iteration.
+            if let Some(ov) = next_overrides {
+                cum_overrides = ov;
+            }
             prev_probe = Some((last_q, last_score));
-            last_q = q_clamped;
+            last_q = next_q;
             last_score = score_n;
+            last_dm = dm_n;
+            let _ = stats_n; // segment_map is stable across passes by design.
         }
 
         finalize(best, max_passes, &target)
@@ -374,6 +438,7 @@ pub(crate) mod iteration {
         bytes: Vec<u8>,
         score: f32,
         q: f32,
+        seg_overrides: Option<[i8; 4]>,
     }
 
     fn pick_best(prev: Candidate, cand: Candidate, target: &ZensimTarget) -> Candidate {
@@ -385,7 +450,11 @@ pub(crate) mod iteration {
             (true, true) => {
                 // Both meet target → pick the one with fewer bytes (best
                 // bytes-recovery outcome).
-                if cand.bytes.len() < prev.bytes.len() { cand } else { prev }
+                if cand.bytes.len() < prev.bytes.len() {
+                    cand
+                } else {
+                    prev
+                }
             }
             (false, false) => {
                 // Neither meets target → pick the higher score.
@@ -448,28 +517,21 @@ pub(crate) mod iteration {
         step
     }
 
-    fn finalize(
-        best: Candidate,
-        passes_used: u8,
-        target: &ZensimTarget,
-    ) -> IterationResult {
+    fn finalize(best: Candidate, passes_used: u8, target: &ZensimTarget) -> IterationResult {
         // Strict-mode failure check: if max_undershoot is set and we
         // missed by more than that, return an error.
-        if let Some(slack) = target.max_undershoot {
-            if best.score < target.target - slack {
-                return Err(EncodeError::InvalidBufferSize(format!(
-                    "target_zensim: achieved {:.3} below floor {:.3} (max_undershoot {:.3}) after {} passes",
-                    best.score,
-                    target.target,
-                    slack,
-                    passes_used,
-                )));
-            }
+        if let Some(slack) = target.max_undershoot
+            && best.score < target.target - slack
+        {
+            return Err(EncodeError::InvalidBufferSize(format!(
+                "target_zensim: achieved {:.3} below floor {:.3} (max_undershoot {:.3}) after {} passes",
+                best.score, target.target, slack, passes_used,
+            )));
         }
         let targets_met = best.score >= target.target
-            || target.max_undershoot.map_or(true, |t| {
-                (target.target - best.score) <= t
-            });
+            || target
+                .max_undershoot
+                .is_none_or(|t| (target.target - best.score) <= t);
         let bytes_len = best.bytes.len();
         Ok((
             best.bytes,
@@ -482,16 +544,20 @@ pub(crate) mod iteration {
         ))
     }
 
-    /// Encode RGB pixels at the given quality. `enable_multi_pass` toggles
+    /// Encode RGB pixels at the given quality with optional per-segment
+    /// quant-index overrides. `enable_multi_pass` toggles
     /// `multi_pass_stats` for inside-the-loop probes (small size win).
+    /// Returns bytes plus the encoder's `EncodeStats` (carrying the
+    /// segment_map needed for Phase 3 aggregation).
     fn encode_at(
         cfg: &LossyConfig,
         q: f32,
         enable_multi_pass: bool,
+        seg_overrides: Option<[i8; 4]>,
         rgb: &[u8],
         width: u32,
         height: u32,
-    ) -> Result<Vec<u8>, EncodeError> {
+    ) -> Result<(Vec<u8>, crate::encoder::api::EncodeStats), EncodeError> {
         let mut probe_cfg = cfg.clone();
         probe_cfg.quality = q.clamp(0.0, 100.0);
         // Force multi_pass_stats on/off as requested (always enabled for
@@ -503,12 +569,17 @@ pub(crate) mod iteration {
         probe_cfg.target_size = 0;
         probe_cfg.target_psnr = 0.0;
         probe_cfg.target_zensim = None;
+        probe_cfg.segment_quant_overrides = seg_overrides;
 
         let req = crate::encoder::api::EncodeRequest::lossy(
-            &probe_cfg, rgb, PixelLayout::Rgb8, width, height,
+            &probe_cfg,
+            rgb,
+            PixelLayout::Rgb8,
+            width,
+            height,
         );
-        match req.encode() {
-            Ok(bytes) => Ok(bytes),
+        match req.encode_with_stats() {
+            Ok((bytes, stats)) => Ok((bytes, stats)),
             Err(at_err) => Err(at_err.decompose().0),
         }
     }
@@ -530,19 +601,22 @@ pub(crate) mod iteration {
         z.precompute_reference(&slice).ok()
     }
 
-    /// Decode `webp` bytes back to RGB and compute the zensim score.
-    fn measure_score(
+    /// Decode `webp` and compute zensim score + per-pixel diffmap. The
+    /// diffmap is `Vec<f32>` of length `width * height` in row-major
+    /// order — used by Phase 3 per-segment aggregation.
+    fn measure_score_and_diffmap(
         z: &zensim::Zensim,
         pre: &zensim::PrecomputedReference,
         webp: &[u8],
         width: u32,
         height: u32,
-    ) -> Result<f32, EncodeError> {
-        let (rgb, w, h) = crate::oneshot::decode_rgb(webp)
-            .map_err(|e| EncodeError::InvalidBufferSize(format!(
+    ) -> Result<(f32, Vec<f32>), EncodeError> {
+        let (rgb, w, h) = crate::oneshot::decode_rgb(webp).map_err(|e| {
+            EncodeError::InvalidBufferSize(format!(
                 "target_zensim: decode for measurement failed: {:?}",
                 e.decompose().0,
-            )))?;
+            ))
+        })?;
         if w != width || h != height {
             return Err(EncodeError::InvalidBufferSize(format!(
                 "target_zensim: decoded dims {}x{} != source {}x{}",
@@ -557,10 +631,129 @@ pub(crate) mod iteration {
         }
         let chunks: &[[u8; 3]] = bytemuck::cast_slice(&rgb[..n]);
         let slice = zensim::RgbSlice::new(chunks, w as usize, h as usize);
-        let res = z.compute_with_ref(pre, &slice).map_err(|e| {
-            EncodeError::InvalidBufferSize(format!("zensim compute_with_ref failed: {:?}", e))
-        })?;
-        Ok(res.score() as f32)
+        let dm = z
+            .compute_with_ref_and_diffmap(pre, &slice, zensim::DiffmapWeighting::Trained)
+            .map_err(|e| {
+                EncodeError::InvalidBufferSize(format!(
+                    "zensim compute_with_ref_and_diffmap failed: {:?}",
+                    e
+                ))
+            })?;
+        let score = dm.score() as f32;
+        Ok((score, dm.diffmap().to_vec()))
+    }
+
+    /// Aggregate the per-pixel diffmap into per-segment means, then
+    /// compute the next per-segment quant_index override. The policy:
+    ///
+    /// - If overall score < target: tighten the segment with the highest
+    ///   mean diffmap (reduce its quant by 1–3 depending on gap).
+    /// - If achieved > target + max_overshoot: loosen the segment with
+    ///   the lowest mean diffmap.
+    ///
+    /// Returns the NEW cumulative overrides (not deltas). Bounded so
+    /// `seg_quant + override` stays in `[-32, 32]` cumulatively (the
+    /// `compute_segment_quant` clamp handles the absolute [0, 127]
+    /// range; the soft cap here prevents oscillation).
+    #[allow(clippy::too_many_arguments)]
+    fn next_segment_overrides(
+        cum: [i8; 4],
+        seg_map: &[u8],
+        mb_w: usize,
+        mb_h: usize,
+        diffmap: &[f32],
+        width: u32,
+        height: u32,
+        score: f32,
+        target: &ZensimTarget,
+        num_segments: usize,
+    ) -> [i8; 4] {
+        let mut sum = [0.0f64; 4];
+        let mut count = [0u32; 4];
+        let w = width as usize;
+        let h = height as usize;
+        // For each MB (16x16 region), accumulate the mean diffmap for
+        // that MB into its segment's running totals.
+        for my in 0..mb_h {
+            for mx in 0..mb_w {
+                let seg = seg_map.get(my * mb_w + mx).copied().unwrap_or(0) as usize;
+                if seg >= 4 {
+                    continue;
+                }
+                let y0 = my * 16;
+                let x0 = mx * 16;
+                let y1 = (y0 + 16).min(h);
+                let x1 = (x0 + 16).min(w);
+                if y1 == y0 || x1 == x0 {
+                    continue;
+                }
+                let mut s = 0.0f64;
+                let mut n = 0u32;
+                for y in y0..y1 {
+                    let row = &diffmap[y * w..y * w + w];
+                    for &v in &row[x0..x1] {
+                        s += v as f64;
+                        n += 1;
+                    }
+                }
+                if n > 0 {
+                    sum[seg] += s / n as f64;
+                    count[seg] += 1;
+                }
+            }
+        }
+        let mut means = [0.0f32; 4];
+        for s in 0..num_segments.min(4) {
+            if count[s] > 0 {
+                means[s] = (sum[s] / count[s] as f64) as f32;
+            }
+        }
+        // Find worst (highest mean) and best (lowest mean) active
+        // segments.
+        let mut worst = 0usize;
+        let mut best = 0usize;
+        for s in 0..num_segments.min(4) {
+            if count[s] == 0 {
+                continue;
+            }
+            if means[s] > means[worst] || count[worst] == 0 {
+                worst = s;
+            }
+            if means[s] < means[best] || count[best] == 0 {
+                best = s;
+            }
+        }
+
+        let mut out = cum;
+        let gap = target.target - score;
+        if gap > 0.0 {
+            // Score below target — tighten worst segment.
+            // Step magnitude scaled to gap: small gap → -1, larger → up to -3.
+            let step = if gap > 4.0 {
+                -3
+            } else if gap > 2.0 {
+                -2
+            } else {
+                -1
+            };
+            // Soft cap accumulated tightening at -16 to leave room for
+            // future passes and stay within sensible quant range.
+            out[worst] = (i32::from(out[worst]) + step).clamp(-16, 16) as i8;
+        } else if let Some(t) = target.max_overshoot
+            && (score - target.target) > t
+        {
+            // Above the comfort band — loosen the best segment.
+            let overshoot = score - target.target - t;
+            let step = if overshoot > 4.0 {
+                3
+            } else if overshoot > 2.0 {
+                2
+            } else {
+                1
+            };
+            out[best] = (i32::from(out[best]) + step).clamp(-16, 16) as i8;
+        }
+        out
     }
 
     /// Run the bucket classifier on the RGB source. We need a Y plane —
@@ -581,14 +774,12 @@ pub(crate) mod iteration {
         // primarily uses bimodality + edge density + uniformity, all of
         // which are tolerant of histogram shape.
         for px in rgb.chunks_exact(3) {
-            let y = ((u32::from(px[0]) * 76 + u32::from(px[1]) * 150 + u32::from(px[2]) * 30)
-                >> 8) as u8;
+            let y = ((u32::from(px[0]) * 76 + u32::from(px[1]) * 150 + u32::from(px[2]) * 30) >> 8)
+                as u8;
             y_plane.push(y);
             alpha_hist[y as usize] += 1;
         }
-        let bucket = crate::encoder::analysis::classify_image_type(
-            &y_plane, w, h, w, &alpha_hist,
-        );
+        let bucket = crate::encoder::analysis::classify_image_type(&y_plane, w, h, w, &alpha_hist);
         Some(bucket)
     }
 }
@@ -637,7 +828,10 @@ mod tests {
             let mut prev = 0.0f32;
             for t in (60..=95).step_by(5) {
                 let q = zensim_to_starting_q_for_bucket(t as f32, b);
-                assert!(q >= prev, "non-monotonic at {b:?} target {t}: {prev} -> {q}");
+                assert!(
+                    q >= prev,
+                    "non-monotonic at {b:?} target {t}: {prev} -> {q}"
+                );
                 assert!((1.0..=100.0).contains(&q), "{b:?} target {t} q={q}");
                 prev = q;
             }
@@ -648,9 +842,9 @@ mod tests {
     fn calibration_clamps_at_endpoints() {
         // Below the lowest anchor: clamp to lowest q.
         let q_low = zensim_to_starting_q_for_bucket(40.0, ImageContentType::Photo);
-        assert_eq!(q_low, 50.0);
+        assert_eq!(q_low, 30.0);
         // Above the highest anchor: clamp to highest q.
         let q_high = zensim_to_starting_q_for_bucket(99.0, ImageContentType::Photo);
-        assert_eq!(q_high, 98.0);
+        assert_eq!(q_high, 100.0);
     }
 }

--- a/src/encoder/zensim_target.rs
+++ b/src/encoder/zensim_target.rs
@@ -1,0 +1,656 @@
+//! Closed-loop target-zensim adaptive encoder.
+//!
+//! Mirrors the design of zenjpeg's `target_zq` module (`src/encode/zq.rs`):
+//! the encoder iteratively encodes the image, decodes it, measures the
+//! resulting zensim score against the source, and either ships the result
+//! (within the tolerance band) or adjusts global VP8 quality and tries again.
+//!
+//! # Convergence
+//!
+//! Three mechanisms keep most encodes to one or two passes:
+//!
+//! 1. **Per-bucket starting-q calibration** — the first-pass quality is
+//!    chosen by interpolating in a per-content-type anchor table. Photo,
+//!    Drawing, and Icon get their own tables (3 buckets vs zenjpeg's 5);
+//!    these mirror zenjpeg's PHOTO_DETAILED / SCREEN_CONTENT shapes.
+//! 2. **Asymmetric tolerance band** — `max_overshoot=Some(t)` means we ship
+//!    if achieved is in `[target, target+t]` even when more passes are
+//!    available. `max_undershoot=None` (default) is best-effort; setting
+//!    `Some(t)` makes a final achieved < target-t a hard error.
+//! 3. **Secant step** — when off-band, the next q is computed via a
+//!    one-pair secant fitted to the most recent two (q, achieved) probes.
+//!    Falls back to a fixed step on the first iteration.
+//!
+//! # Calibration recipe
+//!
+//! The per-bucket anchors below come from `dev/zensim_calibrate.rs`. To
+//! re-fit (e.g. after touching the encoder's RD path or upgrading zensim):
+//!
+//!     cargo run --release --features target-zensim --example zensim_calibrate -- <corpus>
+//!
+//! The tool emits a TSV plus a Rust-formatted const block. Replace the
+//! `PHOTO`, `DRAWING`, `ICON` arrays below with the harness output. Anchors
+//! are `(target_zensim, starting_q)` pairs ordered by ascending target.
+
+#![allow(dead_code)] // Phase 1: types are wired but not yet exposed via LossyConfig
+
+use super::analysis::ImageContentType;
+
+/// Explicit target-perceptual-quality specification.
+///
+/// Default: target=80, max_overshoot=Some(1.5), max_undershoot=None,
+/// max_passes=2 — best-effort behavior tuned to land in band on pass 1
+/// for typical photo content and never iterate more than once.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ZensimTarget {
+    /// Ideal zensim score. The encoder iterates to reach or exceed this
+    /// within the [`Self::max_passes`] budget.
+    pub target: f32,
+
+    /// Distance ABOVE target the encoder will accept without further
+    /// iteration. `None` = ship the first feasible result (single pass
+    /// once target is met). `Some(t)` = if `achieved > target + t`,
+    /// claw back bytes by loosening quality.
+    ///
+    /// Default: `Some(1.5)`.
+    pub max_overshoot: Option<f32>,
+
+    /// Distance BELOW target the encoder will accept as a SUCCESSFUL
+    /// encode. `None` = best-effort, never error (default; encoder ships
+    /// whatever it managed within `max_passes`). `Some(t)` = if final
+    /// `achieved < target - t` after exhausting `max_passes`, the encoder
+    /// returns `Err`.
+    ///
+    /// Set this when you NEED a strictness guarantee (archival, SLA-bound
+    /// serving). Permissive callers leave it `None` and inspect
+    /// [`ZensimEncodeMetrics::achieved_score`] themselves.
+    ///
+    /// Default: `None`.
+    pub max_undershoot: Option<f32>,
+
+    /// Iteration budget. `1` = single-pass (no correction; behaves like a
+    /// regular encode at the calibrated starting q). `2` = default; one
+    /// initial encode plus one correction pass.
+    pub max_passes: u8,
+}
+
+impl Default for ZensimTarget {
+    fn default() -> Self {
+        Self {
+            target: 80.0,
+            max_overshoot: Some(1.5),
+            max_undershoot: None,
+            max_passes: 2,
+        }
+    }
+}
+
+impl ZensimTarget {
+    /// Construct a `ZensimTarget` with the given target and default
+    /// tolerances / passes. Equivalent to `ZensimTarget { target,
+    /// ..Default::default() }`.
+    #[must_use]
+    pub fn new(target: f32) -> Self {
+        Self {
+            target,
+            ..Default::default()
+        }
+    }
+
+    /// Builder-style override of [`Self::max_overshoot`].
+    #[must_use]
+    pub fn with_max_overshoot(mut self, v: Option<f32>) -> Self {
+        self.max_overshoot = v;
+        self
+    }
+
+    /// Builder-style override of [`Self::max_undershoot`].
+    #[must_use]
+    pub fn with_max_undershoot(mut self, v: Option<f32>) -> Self {
+        self.max_undershoot = v;
+        self
+    }
+
+    /// Builder-style override of [`Self::max_passes`].
+    #[must_use]
+    pub fn with_max_passes(mut self, n: u8) -> Self {
+        self.max_passes = n;
+        self
+    }
+}
+
+/// Outcome of a target-zensim encode, returned alongside the WebP bytes
+/// from `LossyConfig::encode_rgb_with_metrics` and friends.
+///
+/// `targets_met` is `false` when:
+/// - the iteration ran (target_zensim was set with the feature enabled), AND
+/// - `achieved_score < target.target`, AND
+/// - `max_undershoot.is_some()` AND `target - achieved > max_undershoot.unwrap()`
+///
+/// In all other cases — including configs without `target_zensim`, configs
+/// where the feature is compiled out, and best-effort runs that landed
+/// below target — `targets_met` is `true`.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ZensimEncodeMetrics {
+    /// Final achieved zensim score. `f32::NAN` for non-target-zensim
+    /// configs or when the feature is disabled (no measurement done).
+    pub achieved_score: f32,
+
+    /// Number of encode passes performed (including the initial pass).
+    /// `1` for non-target-zensim configs.
+    pub passes_used: u8,
+
+    /// Encoded WebP byte count.
+    pub bytes: usize,
+
+    /// Whether the strictness contract was honored. See struct docs.
+    pub targets_met: bool,
+}
+
+impl ZensimEncodeMetrics {
+    /// Construct metrics for a non-target-zensim encode. `bytes` is the
+    /// final output size.
+    pub(crate) fn no_target(bytes: usize) -> Self {
+        Self {
+            achieved_score: f32::NAN,
+            passes_used: 1,
+            bytes,
+            targets_met: true,
+        }
+    }
+}
+
+/// Per-bucket starting-q calibration. Maps a target zensim score to the
+/// VP8 quality value that landed at-or-just-above the target on the
+/// calibration corpus for `bucket`.
+///
+/// Anchors are `(target_zensim, starting_q)`. Linear interpolation between
+/// adjacent anchors; clamped to the lowest/highest quality at the
+/// endpoints.
+///
+/// # Anchor table source
+///
+/// Initial values were hand-distilled from a CID22 sweep at q ∈ {30, 50,
+/// 70, 80, 85, 90, 95}. They were then refit by `dev/zensim_calibrate.rs`
+/// against a 20-image subset of CID22 validation; the fit results are
+/// pasted in below. To re-fit, see this module's top-level comment.
+#[must_use]
+pub(crate) fn zensim_to_starting_q_for_bucket(target: f32, bucket: ImageContentType) -> f32 {
+    // Photo bucket: natural photographs. Calibrated against CID22
+    // validation images that classify as Photo. Streaming CSF is most
+    // forgiving here — q ≈ target in the photo range.
+    const PHOTO: &[(f32, f32)] = &[
+        (60.0, 50.0),
+        (70.0, 65.0),
+        (75.0, 72.0),
+        (80.0, 80.0),
+        (85.0, 88.0),
+        (90.0, 94.0),
+        (95.0, 98.0),
+    ];
+    // Drawing bucket: screenshots, line art, mixed UI. Sharper edges, less
+    // headroom — same target needs slightly higher q than photos.
+    const DRAWING: &[(f32, f32)] = &[
+        (60.0, 55.0),
+        (70.0, 70.0),
+        (75.0, 78.0),
+        (80.0, 84.0),
+        (85.0, 90.0),
+        (90.0, 96.0),
+        (95.0, 100.0),
+    ];
+    // Icon bucket: ≤128px. Tiny images — every coefficient counts. Push
+    // q higher to preserve detail.
+    const ICON: &[(f32, f32)] = &[
+        (60.0, 65.0),
+        (70.0, 78.0),
+        (75.0, 85.0),
+        (80.0, 90.0),
+        (85.0, 95.0),
+        (90.0, 98.0),
+        (95.0, 100.0),
+    ];
+    let anchors = match bucket {
+        ImageContentType::Photo => PHOTO,
+        ImageContentType::Drawing | ImageContentType::Text => DRAWING,
+        ImageContentType::Icon => ICON,
+    };
+    interpolate_anchors(target, anchors)
+}
+
+/// Linear interpolation over a sorted (target, q) anchor table. Clamps
+/// to the endpoints' q values outside the bracketed range. Returns
+/// `target` itself if the table is empty.
+fn interpolate_anchors(target: f32, anchors: &[(f32, f32)]) -> f32 {
+    if anchors.is_empty() {
+        return target;
+    }
+    if target <= anchors[0].0 {
+        return anchors[0].1;
+    }
+    let last = anchors[anchors.len() - 1];
+    if target >= last.0 {
+        return last.1.min(100.0);
+    }
+    for w in anchors.windows(2) {
+        let (lo, hi) = (w[0], w[1]);
+        if target >= lo.0 && target <= hi.0 {
+            let t = (target - lo.0) / (hi.0 - lo.0);
+            return lo.1 + t * (hi.1 - lo.1);
+        }
+    }
+    target
+}
+
+// ============================================================================
+// Iteration loop (gated on the `target-zensim` feature)
+// ============================================================================
+
+#[cfg(feature = "target-zensim")]
+pub(crate) mod iteration {
+    use super::*;
+    use crate::encoder::api::EncodeError;
+    use crate::encoder::config::LossyConfig;
+    use crate::PixelLayout;
+    use alloc::format;
+    use alloc::vec::Vec;
+
+    /// Result of running the closed-loop iteration: bytes + metrics, or
+    /// an error if a hard constraint was violated.
+    pub(crate) type IterationResult = Result<(Vec<u8>, ZensimEncodeMetrics), EncodeError>;
+
+    /// Maximum |Δq| applied per secant step. Prevents oscillation when
+    /// the metric is locally non-linear.
+    const MAX_DELTA_Q: f32 = 10.0;
+    /// Default sensitivity (Δq per zensim-unit gap) for the FIRST step,
+    /// before we have a (q, score) pair to fit a secant against.
+    const DEFAULT_SENSITIVITY: f32 = 1.5;
+    /// Minimum |Δq| applied per step (avoids no-op when sensitivity ×
+    /// gap rounds to ~0).
+    const MIN_DELTA_Q: f32 = 0.5;
+
+    /// Run the global-q closed loop. Returns either the final bytes +
+    /// metrics or a strict-mode `EncodeError`.
+    pub(crate) fn run(
+        cfg: &LossyConfig,
+        target: ZensimTarget,
+        rgb: &[u8],
+        width: u32,
+        height: u32,
+    ) -> IterationResult {
+        // 1. Detect bucket from a quick classifier pass on the source.
+        let bucket = detect_bucket(rgb, width, height);
+
+        // 2. Resolve the starting q.
+        let mut q = match bucket {
+            Some(b) => zensim_to_starting_q_for_bucket(target.target, b),
+            None => zensim_to_starting_q_for_bucket(target.target, ImageContentType::Photo),
+        };
+        q = q.clamp(0.0, 100.0);
+
+        // 3. Encode pass 0.
+        let bytes0 = encode_at(cfg, q, false, rgb, width, height)?;
+        let max_passes = target.max_passes.max(1);
+
+        if max_passes <= 1 {
+            return Ok((
+                bytes0.clone(),
+                ZensimEncodeMetrics {
+                    achieved_score: f32::NAN,
+                    passes_used: 1,
+                    bytes: bytes0.len(),
+                    targets_met: true,
+                },
+            ));
+        }
+
+        // 4. Measure pass 0.
+        let z = zensim::Zensim::new(zensim::ZensimProfile::latest());
+        let pre = build_source_reference(&z, rgb, width, height)
+            .ok_or_else(|| EncodeError::InvalidBufferSize(
+                "zensim precompute_reference failed (image too small?)".into(),
+            ))?;
+        let score0 = match measure_score(&z, &pre, &bytes0, width, height) {
+            Ok(s) => s,
+            Err(e) => return Err(e),
+        };
+
+        let mut best = Candidate {
+            bytes: bytes0,
+            score: score0,
+            q,
+        };
+
+        // Already in band? Ship pass 0.
+        if in_band(score0, &target) {
+            return finalize(best, 1, &target);
+        }
+
+        // prev_probe holds the SECOND-most-recent (q, score) so the
+        // secant fits a slope between it and the current (q, last_score).
+        let mut prev_probe: Option<(f32, f32)> = None;
+        let mut last_q = q;
+        let mut last_score = score0;
+
+        // 5. Iterate.
+        for pass in 1..max_passes {
+            let next_q = compute_next_q(last_q, last_score, prev_probe, &target);
+            let q_clamped = next_q.clamp(0.0, 100.0);
+            // If clamping made it equal-ish to the previous q, bail (we'd
+            // just probe the same point).
+            if (q_clamped - last_q).abs() < 0.05 {
+                break;
+            }
+
+            // multi_pass_stats=true on probe encodes — small size win
+            // amortizes across passes.
+            let bytes_n = encode_at(cfg, q_clamped, true, rgb, width, height)?;
+            let score_n = measure_score(&z, &pre, &bytes_n, width, height)?;
+            let passes_used = pass + 1;
+
+            // Track the best candidate that is "feasible" (>= target) by
+            // smallest bytes; otherwise the highest-score one.
+            best = pick_best(
+                best,
+                Candidate { bytes: bytes_n, score: score_n, q: q_clamped },
+                &target,
+            );
+
+            if in_band(score_n, &target) {
+                return finalize(best, passes_used, &target);
+            }
+
+            prev_probe = Some((last_q, last_score));
+            last_q = q_clamped;
+            last_score = score_n;
+        }
+
+        finalize(best, max_passes, &target)
+    }
+
+    struct Candidate {
+        bytes: Vec<u8>,
+        score: f32,
+        q: f32,
+    }
+
+    fn pick_best(prev: Candidate, cand: Candidate, target: &ZensimTarget) -> Candidate {
+        let prev_feas = prev.score >= target.target;
+        let cand_feas = cand.score >= target.target;
+        match (prev_feas, cand_feas) {
+            (false, true) => cand,
+            (true, false) => prev,
+            (true, true) => {
+                // Both meet target → pick the one with fewer bytes (best
+                // bytes-recovery outcome).
+                if cand.bytes.len() < prev.bytes.len() { cand } else { prev }
+            }
+            (false, false) => {
+                // Neither meets target → pick the higher score.
+                if cand.score > prev.score { cand } else { prev }
+            }
+        }
+    }
+
+    /// Returns true if `score` is in the comfort band — i.e. >= target
+    /// AND (no overshoot configured OR overshoot within budget).
+    fn in_band(score: f32, target: &ZensimTarget) -> bool {
+        if score < target.target {
+            return false;
+        }
+        match target.max_overshoot {
+            Some(t) => (score - target.target) <= t,
+            None => true, // No claw-back wanted; first feasible ships.
+        }
+    }
+
+    /// Compute next q via secant when we have a previous probe, fixed-
+    /// step otherwise.
+    fn compute_next_q(
+        q: f32,
+        last_score: f32,
+        prev: Option<(f32, f32)>,
+        target: &ZensimTarget,
+    ) -> f32 {
+        let gap = target.target - last_score;
+        // Secant: estimate dscore/dq from the two most recent probes.
+        // (Note: `q` and `last_score` are the SAME probe as the latest
+        // one in `prev_probe` until we update. So the secant fits
+        // against the second-most-recent point.)
+        let delta = if let Some((q_prev, s_prev)) = prev {
+            let dq = q - q_prev;
+            let ds = last_score - s_prev;
+            if dq.abs() > 0.1 && ds.abs() > 0.05 {
+                let slope = ds / dq; // zensim units per q point
+                let mut step = gap / slope.max(0.05);
+                step = step.clamp(-MAX_DELTA_Q, MAX_DELTA_Q);
+                if step.abs() < MIN_DELTA_Q {
+                    step = MIN_DELTA_Q.copysign(step);
+                }
+                step
+            } else {
+                fallback_step(gap)
+            }
+        } else {
+            fallback_step(gap)
+        };
+        q + delta
+    }
+
+    fn fallback_step(gap: f32) -> f32 {
+        let mut step = gap * DEFAULT_SENSITIVITY;
+        step = step.clamp(-MAX_DELTA_Q, MAX_DELTA_Q);
+        if step.abs() < MIN_DELTA_Q {
+            step = MIN_DELTA_Q.copysign(if gap == 0.0 { 1.0 } else { gap });
+        }
+        step
+    }
+
+    fn finalize(
+        best: Candidate,
+        passes_used: u8,
+        target: &ZensimTarget,
+    ) -> IterationResult {
+        // Strict-mode failure check: if max_undershoot is set and we
+        // missed by more than that, return an error.
+        if let Some(slack) = target.max_undershoot {
+            if best.score < target.target - slack {
+                return Err(EncodeError::InvalidBufferSize(format!(
+                    "target_zensim: achieved {:.3} below floor {:.3} (max_undershoot {:.3}) after {} passes",
+                    best.score,
+                    target.target,
+                    slack,
+                    passes_used,
+                )));
+            }
+        }
+        let targets_met = best.score >= target.target
+            || target.max_undershoot.map_or(true, |t| {
+                (target.target - best.score) <= t
+            });
+        let bytes_len = best.bytes.len();
+        Ok((
+            best.bytes,
+            ZensimEncodeMetrics {
+                achieved_score: best.score,
+                passes_used,
+                bytes: bytes_len,
+                targets_met,
+            },
+        ))
+    }
+
+    /// Encode RGB pixels at the given quality. `enable_multi_pass` toggles
+    /// `multi_pass_stats` for inside-the-loop probes (small size win).
+    fn encode_at(
+        cfg: &LossyConfig,
+        q: f32,
+        enable_multi_pass: bool,
+        rgb: &[u8],
+        width: u32,
+        height: u32,
+    ) -> Result<Vec<u8>, EncodeError> {
+        let mut probe_cfg = cfg.clone();
+        probe_cfg.quality = q.clamp(0.0, 100.0);
+        // Force multi_pass_stats on/off as requested (always enabled for
+        // pass 1+ to amortize the marginal cost across the search).
+        probe_cfg.multi_pass_stats = enable_multi_pass;
+        // Iteration must NOT recurse — disable target_zensim/target_psnr/
+        // target_size on the probe config. Only target_zensim is plumbed
+        // here; existing target_size/target_psnr semantics stay independent.
+        probe_cfg.target_size = 0;
+        probe_cfg.target_psnr = 0.0;
+        probe_cfg.target_zensim = None;
+
+        let req = crate::encoder::api::EncodeRequest::lossy(
+            &probe_cfg, rgb, PixelLayout::Rgb8, width, height,
+        );
+        match req.encode() {
+            Ok(bytes) => Ok(bytes),
+            Err(at_err) => Err(at_err.decompose().0),
+        }
+    }
+
+    /// Build a precomputed zensim reference from RGB bytes.
+    fn build_source_reference(
+        z: &zensim::Zensim,
+        rgb: &[u8],
+        width: u32,
+        height: u32,
+    ) -> Option<zensim::PrecomputedReference> {
+        let w = width as usize;
+        let h = height as usize;
+        if rgb.len() < w * h * 3 {
+            return None;
+        }
+        let pixels: &[[u8; 3]] = bytemuck::cast_slice(&rgb[..w * h * 3]);
+        let slice = zensim::RgbSlice::new(pixels, w, h);
+        z.precompute_reference(&slice).ok()
+    }
+
+    /// Decode `webp` bytes back to RGB and compute the zensim score.
+    fn measure_score(
+        z: &zensim::Zensim,
+        pre: &zensim::PrecomputedReference,
+        webp: &[u8],
+        width: u32,
+        height: u32,
+    ) -> Result<f32, EncodeError> {
+        let (rgb, w, h) = crate::oneshot::decode_rgb(webp)
+            .map_err(|e| EncodeError::InvalidBufferSize(format!(
+                "target_zensim: decode for measurement failed: {:?}",
+                e.decompose().0,
+            )))?;
+        if w != width || h != height {
+            return Err(EncodeError::InvalidBufferSize(format!(
+                "target_zensim: decoded dims {}x{} != source {}x{}",
+                w, h, width, height,
+            )));
+        }
+        let n = (w as usize) * (h as usize) * 3;
+        if rgb.len() < n {
+            return Err(EncodeError::InvalidBufferSize(
+                "target_zensim: short decoded buffer".into(),
+            ));
+        }
+        let chunks: &[[u8; 3]] = bytemuck::cast_slice(&rgb[..n]);
+        let slice = zensim::RgbSlice::new(chunks, w as usize, h as usize);
+        let res = z.compute_with_ref(pre, &slice).map_err(|e| {
+            EncodeError::InvalidBufferSize(format!("zensim compute_with_ref failed: {:?}", e))
+        })?;
+        Ok(res.score() as f32)
+    }
+
+    /// Run the bucket classifier on the RGB source. We need a Y plane —
+    /// derive a quick luma approximation from RGB rather than running the
+    /// full encoder analyzer (which would re-encode an extra time).
+    fn detect_bucket(rgb: &[u8], width: u32, height: u32) -> Option<ImageContentType> {
+        let w = width as usize;
+        let h = height as usize;
+        if w < 8 || h < 8 || rgb.len() < w * h * 3 {
+            return None;
+        }
+        // BT.601 Y = 0.299R + 0.587G + 0.114B.
+        let mut y_plane: Vec<u8> = Vec::with_capacity(w * h);
+        let mut alpha_hist = [0u32; 256];
+        // Use the high-byte of (Y-difference between neighbors) as a stand-in
+        // for the encoder's alpha histogram. We don't have a real alpha plane
+        // here so populate it with Y values themselves — the classifier
+        // primarily uses bimodality + edge density + uniformity, all of
+        // which are tolerant of histogram shape.
+        for px in rgb.chunks_exact(3) {
+            let y = ((u32::from(px[0]) * 76 + u32::from(px[1]) * 150 + u32::from(px[2]) * 30)
+                >> 8) as u8;
+            y_plane.push(y);
+            alpha_hist[y as usize] += 1;
+        }
+        let bucket = crate::encoder::analysis::classify_image_type(
+            &y_plane, w, h, w, &alpha_hist,
+        );
+        Some(bucket)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_default() {
+        let t = ZensimTarget::default();
+        assert_eq!(t.target, 80.0);
+        assert_eq!(t.max_overshoot, Some(1.5));
+        assert_eq!(t.max_undershoot, None);
+        assert_eq!(t.max_passes, 2);
+    }
+
+    #[test]
+    fn target_builder() {
+        let t = ZensimTarget::new(85.0)
+            .with_max_overshoot(Some(0.5))
+            .with_max_undershoot(Some(2.0))
+            .with_max_passes(3);
+        assert_eq!(t.target, 85.0);
+        assert_eq!(t.max_overshoot, Some(0.5));
+        assert_eq!(t.max_undershoot, Some(2.0));
+        assert_eq!(t.max_passes, 3);
+    }
+
+    #[test]
+    fn metrics_no_target() {
+        let m = ZensimEncodeMetrics::no_target(1234);
+        assert!(m.achieved_score.is_nan());
+        assert_eq!(m.passes_used, 1);
+        assert_eq!(m.bytes, 1234);
+        assert!(m.targets_met);
+    }
+
+    #[test]
+    fn calibration_monotonic_per_bucket() {
+        for &b in &[
+            ImageContentType::Photo,
+            ImageContentType::Drawing,
+            ImageContentType::Icon,
+        ] {
+            let mut prev = 0.0f32;
+            for t in (60..=95).step_by(5) {
+                let q = zensim_to_starting_q_for_bucket(t as f32, b);
+                assert!(q >= prev, "non-monotonic at {b:?} target {t}: {prev} -> {q}");
+                assert!((1.0..=100.0).contains(&q), "{b:?} target {t} q={q}");
+                prev = q;
+            }
+        }
+    }
+
+    #[test]
+    fn calibration_clamps_at_endpoints() {
+        // Below the lowest anchor: clamp to lowest q.
+        let q_low = zensim_to_starting_q_for_bucket(40.0, ImageContentType::Photo);
+        assert_eq!(q_low, 50.0);
+        // Above the highest anchor: clamp to highest q.
+        let q_high = zensim_to_starting_q_for_bucket(99.0, ImageContentType::Photo);
+        assert_eq!(q_high, 98.0);
+    }
+}

--- a/src/encoder/zensim_target.rs
+++ b/src/encoder/zensim_target.rs
@@ -689,10 +689,31 @@ pub(crate) mod iteration {
         score: f32,
         target: &ZensimTarget,
     ) -> [i8; 4] {
-        // A/B testing hatch: when the env var ZENWEBP_PHASE3_QUADRANT=1
-        // is set, fall back to the previous 2x2 spatial-quadrant proxy.
-        // Used by `dev/zensim_ab_quadrant_vs_segmap.rs` to compare the
-        // two aggregators side-by-side. Production never sets this.
+        // Content-type-dependent fallback hatch: when the env var
+        // ZENWEBP_PHASE3_QUADRANT=1 is set, fall back to the 2x2
+        // spatial-quadrant proxy that this code shipped with originally.
+        //
+        // A/B run (CID22 + gb82 + gb82-sc, 76 images x 3 targets =
+        // 228 cells, target ∈ {75, 80, 85}, max_overshoot=1.5,
+        // max_passes=3, m4) shows mixed behavior:
+        //   - gb82-sc (screen content): real segment_map slightly
+        //     tighter (avg |achieved-target| 5.678 vs 5.754 for quad
+        //     across all 30 cells; -0.134 across the 17 divergent
+        //     cells). Hypothesis directionally validated.
+        //   - CID22 + gb82 (photos): quadrant proxy slightly tighter
+        //     (avg |achieved-target| +0.02 to +0.04 for seg across
+        //     ~114 divergent photo cells).
+        // Both legs hit targets_met = 228/228; seg has 6 fewer
+        // undershoots overall (54 vs 60). Median bytes within ~2% of
+        // each other.
+        //
+        // The default (real `segment_map`) is correct in spirit —
+        // it operates on the encoder's actual k-means assignment —
+        // but on photo content the quadrant proxy occasionally lands
+        // closer to target. Callers running large photo-only batches
+        // who care about |achieved - target| may want to set this env
+        // var. Used by `dev/zensim_ab_quadrant_vs_segmap.rs` to
+        // re-run the comparison.
         // std-only since core::env doesn't expose `var`.
         #[cfg(feature = "std")]
         let use_quadrant = std::env::var("ZENWEBP_PHASE3_QUADRANT")

--- a/src/encoder/zensim_target.rs
+++ b/src/encoder/zensim_target.rs
@@ -34,8 +34,6 @@
 //! `PHOTO`, `DRAWING`, `ICON` arrays below with the harness output. Anchors
 //! are `(target_zensim, starting_q)` pairs ordered by ascending target.
 
-#![allow(dead_code)] // Phase 1: types are wired but not yet exposed via LossyConfig
-
 use super::analysis::ImageContentType;
 
 /// Explicit target-perceptual-quality specification.
@@ -267,29 +265,34 @@ pub(crate) mod iteration {
     pub(crate) type IterationResult = Result<(Vec<u8>, ZensimEncodeMetrics), EncodeError>;
 
     // ============================================================================
-    // Ablation toggles (dev-only)
+    // Ablation toggles (dev-only, gated on `ablation` feature)
     // ============================================================================
     //
     // The PR shipping target_zensim (Phases 1/2/3) is a stack of distinct
-    // mechanisms. We need to measure each chunk's individual contribution to
-    // convergence quality before un-drafting; this section wires per-chunk
-    // disable toggles read from environment variables. All toggles default
-    // to FALSE/OFF, so the production code path is unchanged when nothing
-    // is set.
+    // mechanisms. The `ablation` feature wires per-chunk disable toggles
+    // read from environment variables so `dev/zensim_*.rs` measurement
+    // binaries can re-run leg-by-leg comparisons. Production builds (the
+    // `target-zensim` feature alone, no `ablation`) get const `false` for
+    // every toggle and the compiler elides them entirely — zero
+    // `std::env::var` calls on the iteration hot path.
     //
-    // The `dev/zensim_ablation.rs` binary flips these between sweep legs.
-    // None of them touches the encoded bytestream — they only change the
-    // iteration loop's decisions (which q to start at, whether to take a
-    // per-segment vs global-q correction step, etc.).
+    // None of these toggles touches the encoded bytestream — they only
+    // change the iteration loop's decisions (which q to start at, whether
+    // to take a per-segment vs global-q correction step, etc.).
 
     /// Disable Phase 3 per-segment correction. When set, every pass after
     /// pass 0 takes the global-q secant step (or fallback step) instead of
     /// computing per-segment quant overrides from the diffmap. Equivalent
     /// to "Phase 1 (+ Phase 2 anchors) only".
+    #[cfg(feature = "ablation")]
     fn ablate_disable_phase3() -> bool {
         std::env::var("ZENWEBP_ABLATE_NO_PHASE3")
             .map(|v| v == "1")
             .unwrap_or(false)
+    }
+    #[cfg(not(feature = "ablation"))]
+    const fn ablate_disable_phase3() -> bool {
+        false
     }
 
     /// Emit a per-pass investigation trace to stderr when set. Format
@@ -298,53 +301,80 @@ pub(crate) mod iteration {
     ///     achieved=<f> bytes=<u> num_segs=<n>
     ///     means=[s0,s1,s2,s3] counts=[n0,n1,n2,n3]
     ///     cum_overrides=[d0,d1,d2,d3] decision=<reason>
+    #[cfg(feature = "ablation")]
     fn trace_phase3() -> bool {
         std::env::var("ZENWEBP_PHASE3_TRACE")
             .map(|v| v == "1")
             .unwrap_or(false)
+    }
+    #[cfg(not(feature = "ablation"))]
+    const fn trace_phase3() -> bool {
+        false
     }
 
     /// Skip the bucket classifier and use a single naive starting-q anchor
     /// table for all images regardless of content type. Disables Phase 1's
     /// per-bucket calibration AND Phase 2's refit (since both Photo and
     /// Drawing get replaced with the naive identity-ish ramp).
+    #[cfg(feature = "ablation")]
     fn ablate_naive_starting_q() -> bool {
         std::env::var("ZENWEBP_ABLATE_NAIVE_Q")
             .map(|v| v == "1")
             .unwrap_or(false)
     }
+    #[cfg(not(feature = "ablation"))]
+    const fn ablate_naive_starting_q() -> bool {
+        false
+    }
 
     /// Don't force `multi_pass_stats=true` inside the iteration loop on
     /// pass 1+. Leaves the user's `LossyConfig.multi_pass_stats` value
     /// (typically `false`).
+    #[cfg(feature = "ablation")]
     fn ablate_no_multi_pass_stats() -> bool {
         std::env::var("ZENWEBP_ABLATE_NO_MULTI_PASS_STATS")
             .map(|v| v == "1")
             .unwrap_or(false)
+    }
+    #[cfg(not(feature = "ablation"))]
+    const fn ablate_no_multi_pass_stats() -> bool {
+        false
     }
 
     /// Restore the pre-Phase-2 hand-distilled anchors for Photo/Drawing
     /// (Icon was hand-distilled in both versions and is unchanged). Tests
     /// whether the Phase 2 calibration tool's refit is actually pulling
     /// its weight vs the original judgement-based table.
+    #[cfg(feature = "ablation")]
     fn ablate_pre_phase2_anchors() -> bool {
         std::env::var("ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS")
             .map(|v| v == "1")
             .unwrap_or(false)
     }
+    #[cfg(not(feature = "ablation"))]
+    const fn ablate_pre_phase2_anchors() -> bool {
+        false
+    }
 
     /// Use a fixed proportional Δq instead of the secant. Only meaningful
     /// when Phase 3 is also disabled (the global-q fallback path).
+    #[cfg(feature = "ablation")]
     fn ablate_no_secant() -> bool {
         std::env::var("ZENWEBP_ABLATE_NO_SECANT")
             .map(|v| v == "1")
             .unwrap_or(false)
     }
+    #[cfg(not(feature = "ablation"))]
+    const fn ablate_no_secant() -> bool {
+        false
+    }
 
     /// Naive starting-q anchor table — single linear ramp (target, q) used
     /// when the bucket classifier is bypassed. Shape mirrors zenjpeg's
     /// `zq_to_starting_jpegli_q`: a gentle ramp that crosses target=q at
-    /// the high end and starts conservatively at the low end.
+    /// the high end and starts conservatively at the low end. Only reached
+    /// under the `ablation` feature when `ZENWEBP_ABLATE_NAIVE_Q=1`.
+    #[cfg_attr(not(feature = "ablation"), allow(dead_code))]
     fn naive_starting_q(target: f32) -> f32 {
         const NAIVE: &[(f32, f32)] = &[
             (60.0, 50.0),
@@ -360,7 +390,9 @@ pub(crate) mod iteration {
 
     /// Pre-Phase-2 hand-distilled Photo / Drawing anchors. Recovered from
     /// commit `17b9c9a^:src/encoder/zensim_target.rs`. Used only when
-    /// `ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS=1` is set (chunk E ablation).
+    /// the `ablation` feature is on AND `ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS=1`
+    /// is set (chunk E ablation).
+    #[cfg_attr(not(feature = "ablation"), allow(dead_code))]
     fn pre_phase2_starting_q(target: f32, bucket: ImageContentType) -> f32 {
         const PHOTO_HAND: &[(f32, f32)] = &[
             (60.0, 50.0),
@@ -557,14 +589,18 @@ pub(crate) mod iteration {
         // per-segment ever could; switching mid-trajectory throws away
         // that information and tends to produce out-of-band finals.
         //
-        // The `ZENWEBP_PHASE3_FINE_GAP` env var (float, default 0.5)
-        // overrides the threshold for tuning experiments. Set it to a
-        // very large value (e.g. 1000) to recover the pre-fix always-on
-        // Phase 3 behavior for A/B testing.
+        // Under the `ablation` feature the `ZENWEBP_PHASE3_FINE_GAP` env
+        // var (float, default 0.5) overrides the threshold for tuning
+        // experiments. Set it to a very large value (e.g. 1000) to
+        // recover the pre-fix always-on Phase 3 behavior for A/B testing.
+        // Production builds use the constant 0.5.
+        #[cfg(feature = "ablation")]
         let phase3_fine_gap: f32 = std::env::var("ZENWEBP_PHASE3_FINE_GAP")
             .ok()
             .and_then(|s| s.parse::<f32>().ok())
             .unwrap_or(0.5);
+        #[cfg(not(feature = "ablation"))]
+        let phase3_fine_gap: f32 = 0.5;
         for pass in 1..max_passes {
             let abs_gap = (target.target - last_score).abs();
             let use_per_segment =
@@ -704,7 +740,12 @@ pub(crate) mod iteration {
     struct Candidate {
         bytes: Vec<u8>,
         score: f32,
+        // q and seg_overrides are populated for diagnostic tracing /
+        // debugging (the trace lines reference them). pick_best only
+        // reads bytes/score, so these are otherwise unread.
+        #[allow(dead_code)]
         q: f32,
+        #[allow(dead_code)]
         seg_overrides: Option<[i8; 4]>,
     }
 
@@ -984,16 +1025,15 @@ pub(crate) mod iteration {
         // The default (real `segment_map`) is correct in spirit —
         // it operates on the encoder's actual k-means assignment —
         // but on photo content the quadrant proxy occasionally lands
-        // closer to target. Callers running large photo-only batches
-        // who care about |achieved - target| may want to set this env
-        // var. Used by `dev/zensim_ab_quadrant_vs_segmap.rs` to
-        // re-run the comparison.
-        // std-only since core::env doesn't expose `var`.
-        #[cfg(feature = "std")]
+        // closer to target. Under the `ablation` feature the
+        // `dev/zensim_ab_quadrant_vs_segmap.rs` binary toggles this
+        // var to re-run the comparison. Production builds always use
+        // the real segment_map.
+        #[cfg(feature = "ablation")]
         let use_quadrant = std::env::var("ZENWEBP_PHASE3_QUADRANT")
             .map(|v| v == "1")
             .unwrap_or(false);
-        #[cfg(not(feature = "std"))]
+        #[cfg(not(feature = "ablation"))]
         let use_quadrant = false;
         if use_quadrant {
             let q_overrides =
@@ -1139,8 +1179,10 @@ pub(crate) mod iteration {
     }
 
     /// Pre-deviation aggregation: 2x2 spatial-quadrant proxy. Kept for
-    /// A/B comparison via `ZENWEBP_PHASE3_QUADRANT=1`. Production code
-    /// uses the real `segment_map` via [`next_segment_overrides`].
+    /// A/B comparison under the `ablation` feature via
+    /// `ZENWEBP_PHASE3_QUADRANT=1`. Production code uses the real
+    /// `segment_map` via [`next_segment_overrides`].
+    #[cfg_attr(not(feature = "ablation"), allow(dead_code))]
     fn next_segment_overrides_quadrant_proxy(
         cum: [i8; 4],
         diffmap: &[f32],

--- a/src/encoder/zensim_target.rs
+++ b/src/encoder/zensim_target.rs
@@ -292,6 +292,18 @@ pub(crate) mod iteration {
             .unwrap_or(false)
     }
 
+    /// Emit a per-pass investigation trace to stderr when set. Format
+    /// (one line per pass, prefix `PHASE3_TRACE`):
+    ///   PHASE3_TRACE pass=<n> target=<t> q=<q> mps=<bool>
+    ///     achieved=<f> bytes=<u> num_segs=<n>
+    ///     means=[s0,s1,s2,s3] counts=[n0,n1,n2,n3]
+    ///     cum_overrides=[d0,d1,d2,d3] decision=<reason>
+    fn trace_phase3() -> bool {
+        std::env::var("ZENWEBP_PHASE3_TRACE")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+    }
+
     /// Skip the bucket classifier and use a single naive starting-q anchor
     /// table for all images regardless of content type. Disables Phase 1's
     /// per-bucket calibration AND Phase 2's refit (since both Photo and
@@ -439,6 +451,18 @@ pub(crate) mod iteration {
         let (bytes0, diag0) = encode_at_with_diagnostics(cfg, q, false, None, rgb, width, height)?;
         let max_passes = target.max_passes.max(1);
 
+        if trace_phase3() {
+            eprintln!(
+                "PHASE3_TRACE pass=0 target={:.3} q={:.3} mps=false bytes={} num_segs={} mb={}x{}",
+                target.target,
+                q,
+                bytes0.len(),
+                diag0.num_segments,
+                diag0.mb_width,
+                diag0.mb_height
+            );
+        }
+
         if max_passes <= 1 {
             return Ok((
                 bytes0.clone(),
@@ -460,6 +484,17 @@ pub(crate) mod iteration {
             )
         })?;
         let (score0, dm0) = measure_score_and_diffmap(&z, &pre, &bytes0, width, height)?;
+
+        if trace_phase3() {
+            eprintln!(
+                "PHASE3_TRACE pass=0_measured target={:.3} q={:.3} achieved={:.4} bytes={} gap={:.4}",
+                target.target,
+                q,
+                score0,
+                bytes0.len(),
+                target.target - score0
+            );
+        }
 
         let mut best = Candidate {
             bytes: bytes0,
@@ -506,17 +541,41 @@ pub(crate) mod iteration {
         let mut cum_overrides: [i8; 4] = [0; 4];
 
         // 5. Iterate.
+        //
+        // Phase 3 dispatch policy (fix for the previously net-negative
+        // always-on per-segment correction; see traces in
+        // `/mnt/v/output/zenwebp/zensim-investigate/`):
+        //
+        // Per-segment override moves global zensim by ~0.1-0.4 per pass
+        // (one segment, small MB fraction). The global-q secant moves it
+        // by 2-4 per pass. When `|gap| > PHASE3_FINE_GAP`, the global-q
+        // secant is the right tool; per-segment only fires when:
+        //   (a) we're already close to band ("final mile"), AND
+        //   (b) we haven't started a global-q secant trajectory yet
+        //       (`prev_probe.is_none()`).
+        // Once a secant has two anchor points it converges faster than
+        // per-segment ever could; switching mid-trajectory throws away
+        // that information and tends to produce out-of-band finals.
+        //
+        // The `ZENWEBP_PHASE3_FINE_GAP` env var (float, default 0.5)
+        // overrides the threshold for tuning experiments. Set it to a
+        // very large value (e.g. 1000) to recover the pre-fix always-on
+        // Phase 3 behavior for A/B testing.
+        let phase3_fine_gap: f32 = std::env::var("ZENWEBP_PHASE3_FINE_GAP")
+            .ok()
+            .and_then(|s| s.parse::<f32>().ok())
+            .unwrap_or(0.5);
         for pass in 1..max_passes {
-            // Decide whether this pass uses per-segment correction or
-            // a global-q step. Per-segment is preferred when active.
-            let use_per_segment = per_segment_enabled;
+            let abs_gap = (target.target - last_score).abs();
+            let use_per_segment =
+                per_segment_enabled && abs_gap <= phase3_fine_gap && prev_probe.is_none();
 
             let (next_q, next_overrides) = if use_per_segment {
                 // Phase 3: aggregate the per-pixel diffmap into per-MB
                 // means, then accumulate per real k-means segment using
                 // `last_diag.segment_map`. Tighten the worst-mean segment
                 // or loosen the best-mean segment in the claw-back case.
-                let new_overrides = next_segment_overrides(
+                let dec = next_segment_overrides(
                     cum_overrides,
                     &last_dm,
                     width,
@@ -525,10 +584,36 @@ pub(crate) mod iteration {
                     last_score,
                     &target,
                 );
+                if trace_phase3() {
+                    eprintln!(
+                        "PHASE3_TRACE pass={}_decide use_per_segment=true gap={:.4} \
+                        means=[{:.4},{:.4},{:.4},{:.4}] counts=[{},{},{},{}] \
+                        cum_before=[{},{},{},{}] cum_after=[{},{},{},{}] picked_seg={:?} dir={}",
+                        pass,
+                        target.target - last_score,
+                        dec.means[0], dec.means[1], dec.means[2], dec.means[3],
+                        dec.counts[0], dec.counts[1], dec.counts[2], dec.counts[3],
+                        cum_overrides[0], cum_overrides[1], cum_overrides[2], cum_overrides[3],
+                        dec.overrides[0], dec.overrides[1], dec.overrides[2], dec.overrides[3],
+                        dec.picked_seg,
+                        dec.direction,
+                    );
+                }
                 // Keep q the same when doing per-segment correction.
-                (last_q, Some(new_overrides))
+                (last_q, Some(dec.overrides))
             } else {
                 let nq = compute_next_q(last_q, last_score, prev_probe, &target);
+                if trace_phase3() {
+                    eprintln!(
+                        "PHASE3_TRACE pass={}_decide use_per_segment=false gap={:.4} \
+                        last_q={:.3} next_q={:.3} prev_probe={:?}",
+                        pass,
+                        target.target - last_score,
+                        last_q,
+                        nq.clamp(0.0, 100.0),
+                        prev_probe,
+                    );
+                }
                 (nq.clamp(0.0, 100.0), None)
             };
 
@@ -550,6 +635,21 @@ pub(crate) mod iteration {
                 encode_at_with_diagnostics(cfg, next_q, mps, next_overrides, rgb, width, height)?;
             let (score_n, dm_n) = measure_score_and_diffmap(&z, &pre, &bytes_n, width, height)?;
             let passes_used = pass + 1;
+
+            if trace_phase3() {
+                eprintln!(
+                    "PHASE3_TRACE pass={}_measured target={:.3} q={:.3} achieved={:.4} bytes={} \
+                    overrides={:?} num_segs={} delta_score={:.4}",
+                    pass,
+                    target.target,
+                    next_q,
+                    score_n,
+                    bytes_n.len(),
+                    next_overrides,
+                    diag_n.num_segments,
+                    score_n - last_score,
+                );
+            }
 
             best = pick_best(
                 best,
@@ -830,6 +930,18 @@ pub(crate) mod iteration {
     /// pixel block) and add its mean to the appropriate segment's
     /// accumulator. Edge MBs that overlap the right/bottom image border
     /// are handled by clipping the read region.
+    /// Return value carries the new cumulative override AND the per-segment
+    /// diagnostic stats (mean diffmap + MB count per segment) so the trace
+    /// can show what the policy saw. `picked_seg` is the segment index that
+    /// was tightened/loosened (or `None` if nothing was changed).
+    pub(crate) struct OverrideDecision {
+        pub overrides: [i8; 4],
+        pub means: [f32; 4],
+        pub counts: [u64; 4],
+        pub picked_seg: Option<usize>,
+        pub direction: i8, // -1 tightened worst, +1 loosened best, 0 no-op
+    }
+
     fn next_segment_overrides(
         cum: [i8; 4],
         diffmap: &[f32],
@@ -838,7 +950,7 @@ pub(crate) mod iteration {
         diag: &EncodeDiagnostics,
         score: f32,
         target: &ZensimTarget,
-    ) -> [i8; 4] {
+    ) -> OverrideDecision {
         // Content-type-dependent fallback hatch: when the env var
         // ZENWEBP_PHASE3_QUADRANT=1 is set, fall back to the 2x2
         // spatial-quadrant proxy that this code shipped with originally.
@@ -872,9 +984,16 @@ pub(crate) mod iteration {
         #[cfg(not(feature = "std"))]
         let use_quadrant = false;
         if use_quadrant {
-            return next_segment_overrides_quadrant_proxy(
+            let q_overrides = next_segment_overrides_quadrant_proxy(
                 cum, diffmap, width, height, score, target,
             );
+            return OverrideDecision {
+                overrides: q_overrides,
+                means: [0.0; 4],
+                counts: [0; 4],
+                picked_seg: None,
+                direction: 0,
+            };
         }
 
         let n = (diag.num_segments as usize).clamp(2, 4);
@@ -887,11 +1006,17 @@ pub(crate) mod iteration {
         // grid (shouldn't happen, but the diag is plumbed through enough
         // layers that it's worth guarding), fall back to no-op overrides.
         if diag.segment_map.len() != expected || expected == 0 {
-            return cum;
+            return OverrideDecision {
+                overrides: cum,
+                means: [0.0; 4],
+                counts: [0; 4],
+                picked_seg: None,
+                direction: 0,
+            };
         }
 
         let mut sum = [0.0f64; 4];
-        let mut count = [0u64; 4];
+        let mut counts = [0u64; 4];
 
         // Per-MB diffmap mean → accumulate into the MB's segment.
         for mb_y in 0..mb_h {
@@ -921,15 +1046,15 @@ pub(crate) mod iteration {
                 }
                 if block_count > 0 {
                     sum[seg] += block_sum;
-                    count[seg] += block_count;
+                    counts[seg] += block_count;
                 }
             }
         }
 
         let mut means = [0.0f32; 4];
         for s in 0..n {
-            if count[s] > 0 {
-                means[s] = (sum[s] / count[s] as f64) as f32;
+            if counts[s] > 0 {
+                means[s] = (sum[s] / counts[s] as f64) as f32;
             }
         }
 
@@ -941,7 +1066,7 @@ pub(crate) mod iteration {
         let mut found_worst = false;
         let mut found_best = false;
         for s in 0..n {
-            if count[s] == 0 {
+            if counts[s] == 0 {
                 continue;
             }
             if !found_worst || means[s] > means[worst] {
@@ -954,11 +1079,19 @@ pub(crate) mod iteration {
             }
         }
         if !found_worst {
-            return cum;
+            return OverrideDecision {
+                overrides: cum,
+                means,
+                counts,
+                picked_seg: None,
+                direction: 0,
+            };
         }
 
         let mut out = cum;
         let gap = target.target - score;
+        let mut picked: Option<usize> = None;
+        let mut direction: i8 = 0;
         if gap > 0.0 {
             let step = if gap > 4.0 {
                 -3
@@ -968,6 +1101,8 @@ pub(crate) mod iteration {
                 -1
             };
             out[worst] = (i32::from(out[worst]) + step).clamp(-16, 16) as i8;
+            picked = Some(worst);
+            direction = -1;
         } else if let Some(t) = target.max_overshoot
             && (score - target.target) > t
         {
@@ -980,8 +1115,16 @@ pub(crate) mod iteration {
                 1
             };
             out[best] = (i32::from(out[best]) + step).clamp(-16, 16) as i8;
+            picked = Some(best);
+            direction = 1;
         }
-        out
+        OverrideDecision {
+            overrides: out,
+            means,
+            counts,
+            picked_seg: picked,
+            direction,
+        }
     }
 
     /// Pre-deviation aggregation: 2x2 spatial-quadrant proxy. Kept for

--- a/src/encoder/zensim_target.rs
+++ b/src/encoder/zensim_target.rs
@@ -298,7 +298,7 @@ pub(crate) mod iteration {
         q = q.clamp(0.0, 100.0);
 
         // 3. Encode pass 0 (global-q, no per-segment overrides).
-        let (bytes0, stats0) = encode_at(cfg, q, false, None, rgb, width, height)?;
+        let bytes0 = encode_at(cfg, q, false, None, rgb, width, height)?;
         let max_passes = target.max_passes.max(1);
 
         if max_passes <= 1 {
@@ -335,21 +335,18 @@ pub(crate) mod iteration {
             return finalize(best, 1, &target);
         }
 
-        // Per-segment correction setup. Available iff segments are
-        // active AND the encoder produced a segment_map.
-        let seg_map = stats0.segment_map.clone();
-        let mb_w = stats0.mb_width as usize;
-        let mb_h = stats0.mb_height as usize;
-        // Number of distinct segment IDs in the map. After
-        // simplify_segments() this may be fewer than 4.
-        let num_segments = seg_map
-            .iter()
-            .copied()
-            .max()
-            .map(|m| (m as usize) + 1)
-            .unwrap_or(1);
-        let per_segment_enabled =
-            num_segments > 1 && seg_map.len() == mb_w * mb_h && !seg_map.is_empty();
+        // Per-segment correction setup. We use a 2x2 spatial-quadrant
+        // PROXY for the encoder's segment_map rather than exposing it
+        // through the public API (would require a `#[non_exhaustive]`
+        // SemVer break on `EncodeStats`). For most natural images the
+        // k-means-on-alpha segment assignment correlates strongly with
+        // spatial regions, so the proxy gets us the same shape of
+        // adjustment without piercing public API. For images where it
+        // doesn't (deeply intermixed textures), the global-q fallback
+        // still kicks in via the secant once one quadrant adjustment
+        // doesn't move the dial.
+        let num_segments = cfg.segments.unwrap_or(4) as usize;
+        let per_segment_enabled = num_segments > 1 && width >= 32 && height >= 32;
 
         // prev_probe holds the SECOND-most-recent (q, score) so the
         // secant fits a slope between it and the current (q, last_score).
@@ -367,19 +364,17 @@ pub(crate) mod iteration {
             let use_per_segment = per_segment_enabled;
 
             let (next_q, next_overrides) = if use_per_segment {
-                // Phase 3: aggregate diffmap → per-segment mean → tighten
-                // the worst segment / loosen the best when in claw-back.
+                // Phase 3: aggregate diffmap into 4 spatial quadrants;
+                // tighten the worst quadrant or loosen the best when in
+                // claw-back.
                 let new_overrides = next_segment_overrides(
                     cum_overrides,
-                    &seg_map,
-                    mb_w,
-                    mb_h,
                     &last_dm,
                     width,
                     height,
                     last_score,
                     &target,
-                    num_segments,
+                    num_segments.min(4),
                 );
                 // Keep q the same when doing per-segment correction.
                 (last_q, Some(new_overrides))
@@ -400,8 +395,7 @@ pub(crate) mod iteration {
 
             // multi_pass_stats=true on probe encodes — small size win
             // amortizes across passes.
-            let (bytes_n, stats_n) =
-                encode_at(cfg, next_q, true, next_overrides, rgb, width, height)?;
+            let bytes_n = encode_at(cfg, next_q, true, next_overrides, rgb, width, height)?;
             let (score_n, dm_n) = measure_score_and_diffmap(&z, &pre, &bytes_n, width, height)?;
             let passes_used = pass + 1;
 
@@ -428,7 +422,6 @@ pub(crate) mod iteration {
             last_q = next_q;
             last_score = score_n;
             last_dm = dm_n;
-            let _ = stats_n; // segment_map is stable across passes by design.
         }
 
         finalize(best, max_passes, &target)
@@ -546,9 +539,7 @@ pub(crate) mod iteration {
 
     /// Encode RGB pixels at the given quality with optional per-segment
     /// quant-index overrides. `enable_multi_pass` toggles
-    /// `multi_pass_stats` for inside-the-loop probes (small size win).
-    /// Returns bytes plus the encoder's `EncodeStats` (carrying the
-    /// segment_map needed for Phase 3 aggregation).
+    /// `multi_pass_stats` for inside-the-loop probes.
     fn encode_at(
         cfg: &LossyConfig,
         q: f32,
@@ -557,15 +548,12 @@ pub(crate) mod iteration {
         rgb: &[u8],
         width: u32,
         height: u32,
-    ) -> Result<(Vec<u8>, crate::encoder::api::EncodeStats), EncodeError> {
+    ) -> Result<Vec<u8>, EncodeError> {
         let mut probe_cfg = cfg.clone();
         probe_cfg.quality = q.clamp(0.0, 100.0);
-        // Force multi_pass_stats on/off as requested (always enabled for
-        // pass 1+ to amortize the marginal cost across the search).
         probe_cfg.multi_pass_stats = enable_multi_pass;
         // Iteration must NOT recurse — disable target_zensim/target_psnr/
-        // target_size on the probe config. Only target_zensim is plumbed
-        // here; existing target_size/target_psnr semantics stay independent.
+        // target_size on the probe config.
         probe_cfg.target_size = 0;
         probe_cfg.target_psnr = 0.0;
         probe_cfg.target_zensim = None;
@@ -578,8 +566,8 @@ pub(crate) mod iteration {
             width,
             height,
         );
-        match req.encode_with_stats() {
-            Ok((bytes, stats)) => Ok((bytes, stats)),
+        match req.encode() {
+            Ok(bytes) => Ok(bytes),
             Err(at_err) => Err(at_err.decompose().0),
         }
     }
@@ -643,24 +631,22 @@ pub(crate) mod iteration {
         Ok((score, dm.diffmap().to_vec()))
     }
 
-    /// Aggregate the per-pixel diffmap into per-segment means, then
-    /// compute the next per-segment quant_index override. The policy:
+    /// Aggregate the per-pixel diffmap into 4 spatial quadrants
+    /// (top-left, top-right, bottom-left, bottom-right) → per-quadrant
+    /// mean → tighten the worst quadrant or loosen the best.
     ///
-    /// - If overall score < target: tighten the segment with the highest
-    ///   mean diffmap (reduce its quant by 1–3 depending on gap).
-    /// - If achieved > target + max_overshoot: loosen the segment with
-    ///   the lowest mean diffmap.
+    /// Why quadrants and not exact segments: the encoder's k-means
+    /// segment_map isn't exposed through the public API (adding it to
+    /// `EncodeStats` is a SemVer break). For most natural images,
+    /// k-means-on-alpha buckets correlate with spatial regions, so this
+    /// proxy gives roughly the same correction shape without piercing
+    /// public API.
     ///
-    /// Returns the NEW cumulative overrides (not deltas). Bounded so
-    /// `seg_quant + override` stays in `[-32, 32]` cumulatively (the
-    /// `compute_segment_quant` clamp handles the absolute [0, 127]
-    /// range; the soft cap here prevents oscillation).
-    #[allow(clippy::too_many_arguments)]
+    /// Returns the NEW cumulative overrides (not deltas). Bounded to
+    /// `[-16, 16]` cumulatively to leave room for future passes and stay
+    /// in sensible VP8 quantizer range.
     fn next_segment_overrides(
         cum: [i8; 4],
-        seg_map: &[u8],
-        mb_w: usize,
-        mb_h: usize,
         diffmap: &[f32],
         width: u32,
         height: u32,
@@ -668,67 +654,64 @@ pub(crate) mod iteration {
         target: &ZensimTarget,
         num_segments: usize,
     ) -> [i8; 4] {
+        let n = num_segments.clamp(2, 4);
         let mut sum = [0.0f64; 4];
-        let mut count = [0u32; 4];
+        let mut count = [0u64; 4];
         let w = width as usize;
         let h = height as usize;
-        // For each MB (16x16 region), accumulate the mean diffmap for
-        // that MB into its segment's running totals.
-        for my in 0..mb_h {
-            for mx in 0..mb_w {
-                let seg = seg_map.get(my * mb_w + mx).copied().unwrap_or(0) as usize;
-                if seg >= 4 {
-                    continue;
-                }
-                let y0 = my * 16;
-                let x0 = mx * 16;
-                let y1 = (y0 + 16).min(h);
-                let x1 = (x0 + 16).min(w);
-                if y1 == y0 || x1 == x0 {
-                    continue;
-                }
-                let mut s = 0.0f64;
-                let mut n = 0u32;
-                for y in y0..y1 {
-                    let row = &diffmap[y * w..y * w + w];
-                    for &v in &row[x0..x1] {
-                        s += v as f64;
-                        n += 1;
+        // Quadrant layout for n=4: TL=0, TR=1, BL=2, BR=3. For n=2,
+        // halve horizontally: L=0, R=1. For n=3, drop BR (treat it as
+        // BL).
+        let half_w = w / 2;
+        let half_h = h / 2;
+        for y in 0..h {
+            let row = &diffmap[y * w..y * w + w];
+            for (x, &v) in row.iter().enumerate() {
+                let q = match n {
+                    2 => usize::from(x >= half_w),
+                    _ => {
+                        let qx = usize::from(x >= half_w);
+                        let qy = usize::from(y >= half_h);
+                        let q4 = qy * 2 + qx;
+                        // For n=3, treat quadrant 3 as 2 (merge BL+BR).
+                        if n == 3 && q4 == 3 { 2 } else { q4 }
                     }
-                }
-                if n > 0 {
-                    sum[seg] += s / n as f64;
-                    count[seg] += 1;
+                };
+                if q < 4 {
+                    sum[q] += v as f64;
+                    count[q] += 1;
                 }
             }
         }
         let mut means = [0.0f32; 4];
-        for s in 0..num_segments.min(4) {
+        for s in 0..n {
             if count[s] > 0 {
                 means[s] = (sum[s] / count[s] as f64) as f32;
             }
         }
-        // Find worst (highest mean) and best (lowest mean) active
-        // segments.
+
+        // Find worst (highest mean) and best (lowest mean) quadrants.
         let mut worst = 0usize;
         let mut best = 0usize;
-        for s in 0..num_segments.min(4) {
+        let mut found_worst = false;
+        let mut found_best = false;
+        for s in 0..n {
             if count[s] == 0 {
                 continue;
             }
-            if means[s] > means[worst] || count[worst] == 0 {
+            if !found_worst || means[s] > means[worst] {
                 worst = s;
+                found_worst = true;
             }
-            if means[s] < means[best] || count[best] == 0 {
+            if !found_best || means[s] < means[best] {
                 best = s;
+                found_best = true;
             }
         }
 
         let mut out = cum;
         let gap = target.target - score;
         if gap > 0.0 {
-            // Score below target — tighten worst segment.
-            // Step magnitude scaled to gap: small gap → -1, larger → up to -3.
             let step = if gap > 4.0 {
                 -3
             } else if gap > 2.0 {
@@ -736,13 +719,10 @@ pub(crate) mod iteration {
             } else {
                 -1
             };
-            // Soft cap accumulated tightening at -16 to leave room for
-            // future passes and stay within sensible quant range.
             out[worst] = (i32::from(out[worst]) + step).clamp(-16, 16) as i8;
         } else if let Some(t) = target.max_overshoot
             && (score - target.target) > t
         {
-            // Above the comfort band — loosen the best segment.
             let overshoot = score - target.target - t;
             let step = if overshoot > 4.0 {
                 3

--- a/src/encoder/zensim_target.rs
+++ b/src/encoder/zensim_target.rs
@@ -97,7 +97,18 @@ impl ZensimTarget {
             ..Default::default()
         }
     }
+}
 
+impl From<f32> for ZensimTarget {
+    /// Build a `ZensimTarget` from a bare target value, using default
+    /// tolerances / passes. Lets [`LossyConfig::with_target_zensim`]
+    /// accept either an `f32` or a fully-built `ZensimTarget`.
+    fn from(target: f32) -> Self {
+        Self::new(target)
+    }
+}
+
+impl ZensimTarget {
     /// Builder-style override of [`Self::max_overshoot`].
     #[must_use]
     pub fn with_max_overshoot(mut self, v: Option<f32>) -> Self {
@@ -121,7 +132,7 @@ impl ZensimTarget {
 }
 
 /// Outcome of a target-zensim encode, returned alongside the WebP bytes
-/// from `LossyConfig::encode_rgb_with_metrics` and friends.
+/// from [`EncodeRequest::encode_with_metrics`](super::api::EncodeRequest::encode_with_metrics).
 ///
 /// `targets_met` is `false` when:
 /// - the iteration ran (target_zensim was set with the feature enabled), AND

--- a/src/encoder/zensim_target.rs
+++ b/src/encoder/zensim_target.rs
@@ -43,17 +43,16 @@ use super::analysis::ImageContentType;
 /// best-effort behavior tuned to land in band on pass 1 for typical
 /// photo content and never iterate more than once.
 ///
-/// # Pixel layout: RGB8-only
+/// # Pixel layout
 ///
-/// `target_zensim` currently only supports `PixelLayout::Rgb8`
-/// inputs. Setting it on a config and then submitting any other
-/// layout (RGBA / BGRA / BGR / ARGB / L8 / LA8 / YUV420) returns
+/// `target_zensim` supports `PixelLayout::Rgb8` and
+/// `PixelLayout::Rgba8`. RGBA inputs are encoded as alpha-bearing
+/// WebP and measured against the source via zensim's
+/// deterministic-noise compositing — the same composite is applied to
+/// source and reconstruction, so alpha quality is fully defined.
+/// Other layouts (BGR, BGRA, ARGB, L8, LA8, YUV420) with
+/// `target_zensim` set return
 /// [`EncodeError::TargetZensimUnsupportedLayout`](super::api::EncodeError::TargetZensimUnsupportedLayout).
-/// The iteration's decode-and-measure step needs RGB pixels and we
-/// refuse to silently strip alpha. RGBA support is tracked as a
-/// follow-up; for alpha-preserving target_zensim today, run iteration
-/// on an RGB projection and re-encode RGBA at the converged quality
-/// outside the loop.
 ///
 /// # Tolerance bands
 ///
@@ -597,16 +596,27 @@ pub(crate) mod iteration {
     pub(crate) fn run(
         cfg: &LossyConfig,
         target: ZensimTarget,
-        rgb: &[u8],
+        pixels: &[u8],
+        layout: PixelLayout,
         width: u32,
         height: u32,
     ) -> IterationResult {
+        // Layout gate: Rgb8 / Rgba8 only. The public API gate
+        // (`EncodeRequest::try_encode_target_zensim_with_metrics`) already
+        // enforces this; the redundant check here keeps the iteration
+        // entry honest if an internal caller ever skips that gate.
+        match layout {
+            PixelLayout::Rgb8 | PixelLayout::Rgba8 => {}
+            other => {
+                return Err(EncodeError::TargetZensimUnsupportedLayout(other));
+            }
+        }
         // 1. Detect bucket from a quick classifier pass on the source.
         // Skipped entirely when the naive-starting-q ablation is on.
         let bucket = if ablate_naive_starting_q() {
             None
         } else {
-            detect_bucket(rgb, width, height)
+            detect_bucket(pixels, layout, width, height)
         };
 
         // 2. Resolve the starting q.
@@ -631,7 +641,8 @@ pub(crate) mod iteration {
         // also captures the encoder's per-MB segment_map via the internal
         // `EncodeDiagnostics` struct so Phase 3 can aggregate the diffmap
         // per real k-means segment instead of a 2x2 spatial proxy.
-        let (bytes0, diag0) = encode_at_with_diagnostics(cfg, q, false, None, rgb, width, height)?;
+        let (bytes0, diag0) =
+            encode_at_with_diagnostics(cfg, q, false, None, pixels, layout, width, height)?;
         let max_passes = target.max_passes.max(1);
 
         if trace_phase3() {
@@ -659,14 +670,17 @@ pub(crate) mod iteration {
         }
 
         // 4. Measure pass 0 with per-pixel diffmap (used by Phase 3 if
-        // segments are active).
+        // segments are active). The reference and the decoded probe
+        // both go through the same layout-aware path so the pair is
+        // measured consistently (RGB→RGB, RGBA→RGBA with deterministic
+        // noise compositing).
         let z = zensim::Zensim::new(zensim::ZensimProfile::latest());
-        let pre = build_source_reference(&z, rgb, width, height).ok_or_else(|| {
+        let pre = build_source_reference(&z, pixels, layout, width, height).ok_or_else(|| {
             EncodeError::InvalidBufferSize(
                 "zensim precompute_reference failed (image too small?)".into(),
             )
         })?;
-        let (score0, dm0) = measure_score_and_diffmap(&z, &pre, &bytes0, width, height)?;
+        let (score0, dm0) = measure_score_and_diffmap(&z, &pre, &bytes0, layout, width, height)?;
 
         if trace_phase3() {
             eprintln!(
@@ -837,9 +851,18 @@ pub(crate) mod iteration {
             // user's LossyConfig value when
             // [`AblationToggles::no_multi_pass_stats`] is set.
             let mps = !ablate_no_multi_pass_stats();
-            let (bytes_n, diag_n) =
-                encode_at_with_diagnostics(cfg, next_q, mps, next_overrides, rgb, width, height)?;
-            let (score_n, dm_n) = measure_score_and_diffmap(&z, &pre, &bytes_n, width, height)?;
+            let (bytes_n, diag_n) = encode_at_with_diagnostics(
+                cfg,
+                next_q,
+                mps,
+                next_overrides,
+                pixels,
+                layout,
+                width,
+                height,
+            )?;
+            let (score_n, dm_n) =
+                measure_score_and_diffmap(&z, &pre, &bytes_n, layout, width, height)?;
             let passes_used = pass + 1;
 
             if trace_phase3() {
@@ -1022,21 +1045,27 @@ pub(crate) mod iteration {
         ))
     }
 
-    /// Encode RGB pixels at the given quality with optional per-segment
-    /// quant-index overrides, returning the WebP bytes alongside the
-    /// encoder's per-MB `segment_map` (via the internal
+    /// Encode RGB or RGBA pixels at the given quality with optional
+    /// per-segment quant-index overrides, returning the WebP bytes
+    /// alongside the encoder's per-MB `segment_map` (via the internal
     /// [`EncodeDiagnostics`] companion struct). On-wire bytes are
     /// byte-identical to the regular [`crate::EncodeRequest::encode`]
     /// path for the same inputs.
     ///
     /// `enable_multi_pass` toggles `multi_pass_stats` on the probe — a
     /// small size-saving option that amortizes across passes.
+    ///
+    /// `layout` is propagated through to the encoder; for `Rgba8` the
+    /// resulting WebP is alpha-bearing (VP8 + VP8L alpha), and the
+    /// closed loop's measurement decodes back to the same layout to
+    /// keep the comparison consistent.
     fn encode_at_with_diagnostics(
         cfg: &LossyConfig,
         q: f32,
         enable_multi_pass: bool,
         seg_overrides: Option<[i8; 4]>,
-        rgb: &[u8],
+        pixels: &[u8],
+        layout: PixelLayout,
         width: u32,
         height: u32,
     ) -> Result<(Vec<u8>, EncodeDiagnostics), EncodeError> {
@@ -1050,40 +1079,72 @@ pub(crate) mod iteration {
         probe_cfg.target_zensim = None;
         probe_cfg.segment_quant_overrides = seg_overrides;
 
-        let req = crate::encoder::api::EncodeRequest::lossy(
-            &probe_cfg,
-            rgb,
-            PixelLayout::Rgb8,
-            width,
-            height,
-        );
+        let req =
+            crate::encoder::api::EncodeRequest::lossy(&probe_cfg, pixels, layout, width, height);
         match req.encode_inner_with_diagnostics() {
             Ok((bytes, _stats, diag)) => Ok((bytes, diag)),
             Err(at_err) => Err(at_err.decompose().0),
         }
     }
 
-    /// Build a precomputed zensim reference from RGB bytes.
+    /// Build a precomputed zensim reference from interleaved RGB or
+    /// RGBA bytes. RGBA goes through `zensim::RgbaSlice` which composites
+    /// over a deterministic noise background internally — the same
+    /// composite is applied to source and to the decoded probe so the
+    /// pair is comparable.
     fn build_source_reference(
         z: &zensim::Zensim,
-        rgb: &[u8],
+        pixels: &[u8],
+        layout: PixelLayout,
         width: u32,
         height: u32,
     ) -> Option<zensim::PrecomputedReference> {
         let w = width as usize;
         let h = height as usize;
-        if rgb.len() < w * h * 3 {
-            return None;
+        match layout {
+            PixelLayout::Rgb8 => {
+                if pixels.len() < w * h * 3 {
+                    return None;
+                }
+                let chunks: &[[u8; 3]] = bytemuck::cast_slice(&pixels[..w * h * 3]);
+                let slice = zensim::RgbSlice::new(chunks, w, h);
+                z.precompute_reference(&slice).ok()
+            }
+            PixelLayout::Rgba8 => {
+                if pixels.len() < w * h * 4 {
+                    return None;
+                }
+                let chunks: &[[u8; 4]] = bytemuck::cast_slice(&pixels[..w * h * 4]);
+                let slice = zensim::RgbaSlice::new(chunks, w, h);
+                z.precompute_reference(&slice).ok()
+            }
+            // Unreachable: the gate in iteration::run rejects everything else.
+            _ => None,
         }
-        let pixels: &[[u8; 3]] = bytemuck::cast_slice(&rgb[..w * h * 3]);
-        let slice = zensim::RgbSlice::new(pixels, w, h);
-        z.precompute_reference(&slice).ok()
     }
 
-    /// Decode `webp` and compute zensim score + per-pixel diffmap. The
+    /// Decode `webp` and compute zensim score + per-pixel diffmap.
+    /// The decode is layout-aware (RGB→`decode_rgb`, RGBA→`decode_rgba`)
+    /// so the distorted side is fed into zensim with the same
+    /// composite-vs-RGB shape as the precomputed reference. The
     /// diffmap is `Vec<f32>` of length `width * height` in row-major
     /// order — used by Phase 3 per-segment aggregation.
     fn measure_score_and_diffmap(
+        z: &zensim::Zensim,
+        pre: &zensim::PrecomputedReference,
+        webp: &[u8],
+        layout: PixelLayout,
+        width: u32,
+        height: u32,
+    ) -> Result<(f32, Vec<f32>), EncodeError> {
+        match layout {
+            PixelLayout::Rgb8 => measure_rgb(z, pre, webp, width, height),
+            PixelLayout::Rgba8 => measure_rgba(z, pre, webp, width, height),
+            other => Err(EncodeError::TargetZensimUnsupportedLayout(other)),
+        }
+    }
+
+    fn measure_rgb(
         z: &zensim::Zensim,
         pre: &zensim::PrecomputedReference,
         webp: &[u8],
@@ -1110,6 +1171,45 @@ pub(crate) mod iteration {
         }
         let chunks: &[[u8; 3]] = bytemuck::cast_slice(&rgb[..n]);
         let slice = zensim::RgbSlice::new(chunks, w as usize, h as usize);
+        let dm = z
+            .compute_with_ref_and_diffmap(pre, &slice, zensim::DiffmapWeighting::Trained)
+            .map_err(|e| {
+                EncodeError::InvalidBufferSize(format!(
+                    "zensim compute_with_ref_and_diffmap failed: {:?}",
+                    e
+                ))
+            })?;
+        let score = dm.score() as f32;
+        Ok((score, dm.diffmap().to_vec()))
+    }
+
+    fn measure_rgba(
+        z: &zensim::Zensim,
+        pre: &zensim::PrecomputedReference,
+        webp: &[u8],
+        width: u32,
+        height: u32,
+    ) -> Result<(f32, Vec<f32>), EncodeError> {
+        let (rgba, w, h) = crate::oneshot::decode_rgba(webp).map_err(|e| {
+            EncodeError::InvalidBufferSize(format!(
+                "target_zensim: rgba decode for measurement failed: {:?}",
+                e.decompose().0,
+            ))
+        })?;
+        if w != width || h != height {
+            return Err(EncodeError::InvalidBufferSize(format!(
+                "target_zensim: decoded dims {}x{} != source {}x{}",
+                w, h, width, height,
+            )));
+        }
+        let n = (w as usize) * (h as usize) * 4;
+        if rgba.len() < n {
+            return Err(EncodeError::InvalidBufferSize(
+                "target_zensim: short decoded rgba buffer".into(),
+            ));
+        }
+        let chunks: &[[u8; 4]] = bytemuck::cast_slice(&rgba[..n]);
+        let slice = zensim::RgbaSlice::new(chunks, w as usize, h as usize);
         let dm = z
             .compute_with_ref_and_diffmap(pre, &slice, zensim::DiffmapWeighting::Trained)
             .map_err(|e| {
@@ -1416,28 +1516,54 @@ pub(crate) mod iteration {
         out
     }
 
-    /// Run the bucket classifier on the RGB source. We need a Y plane —
-    /// derive a quick luma approximation from RGB rather than running the
-    /// full encoder analyzer (which would re-encode an extra time).
-    fn detect_bucket(rgb: &[u8], width: u32, height: u32) -> Option<ImageContentType> {
+    /// Run the bucket classifier on the RGB or RGBA source. We need a
+    /// Y plane — derive a quick luma approximation from RGB rather than
+    /// running the full encoder analyzer (which would re-encode an
+    /// extra time). For RGBA inputs the alpha channel is fed into the
+    /// classifier's alpha histogram (its primary signal for the Icon
+    /// bucket); for RGB the histogram falls back to Y values
+    /// themselves — the classifier primarily uses bimodality + edge
+    /// density + uniformity, all of which are tolerant of histogram
+    /// shape.
+    fn detect_bucket(
+        pixels: &[u8],
+        layout: PixelLayout,
+        width: u32,
+        height: u32,
+    ) -> Option<ImageContentType> {
         let w = width as usize;
         let h = height as usize;
-        if w < 8 || h < 8 || rgb.len() < w * h * 3 {
+        let bpp = match layout {
+            PixelLayout::Rgb8 => 3usize,
+            PixelLayout::Rgba8 => 4usize,
+            _ => return None,
+        };
+        if w < 8 || h < 8 || pixels.len() < w * h * bpp {
             return None;
         }
         // BT.601 Y = 0.299R + 0.587G + 0.114B.
         let mut y_plane: Vec<u8> = Vec::with_capacity(w * h);
         let mut alpha_hist = [0u32; 256];
-        // Use the high-byte of (Y-difference between neighbors) as a stand-in
-        // for the encoder's alpha histogram. We don't have a real alpha plane
-        // here so populate it with Y values themselves — the classifier
-        // primarily uses bimodality + edge density + uniformity, all of
-        // which are tolerant of histogram shape.
-        for px in rgb.chunks_exact(3) {
-            let y = ((u32::from(px[0]) * 76 + u32::from(px[1]) * 150 + u32::from(px[2]) * 30) >> 8)
-                as u8;
-            y_plane.push(y);
-            alpha_hist[y as usize] += 1;
+        match layout {
+            PixelLayout::Rgb8 => {
+                for px in pixels.chunks_exact(3).take(w * h) {
+                    let y =
+                        ((u32::from(px[0]) * 76 + u32::from(px[1]) * 150 + u32::from(px[2]) * 30)
+                            >> 8) as u8;
+                    y_plane.push(y);
+                    alpha_hist[y as usize] += 1;
+                }
+            }
+            PixelLayout::Rgba8 => {
+                for px in pixels.chunks_exact(4).take(w * h) {
+                    let y =
+                        ((u32::from(px[0]) * 76 + u32::from(px[1]) * 150 + u32::from(px[2]) * 30)
+                            >> 8) as u8;
+                    y_plane.push(y);
+                    alpha_hist[px[3] as usize] += 1;
+                }
+            }
+            _ => return None,
         }
         let bucket = crate::encoder::analysis::classify_image_type(&y_plane, w, h, w, &alpha_hist);
         Some(bucket)

--- a/src/encoder/zensim_target.rs
+++ b/src/encoder/zensim_target.rs
@@ -38,9 +38,34 @@ use super::analysis::ImageContentType;
 
 /// Explicit target-perceptual-quality specification.
 ///
-/// Default: target=80, max_overshoot=Some(1.5), max_undershoot=None,
-/// max_passes=2 — best-effort behavior tuned to land in band on pass 1
-/// for typical photo content and never iterate more than once.
+/// Default: target=80, max_overshoot=Some(1.5),
+/// max_undershoot_ship=Some(0.5), max_undershoot=None, max_passes=2 —
+/// best-effort behavior tuned to land in band on pass 1 for typical
+/// photo content and never iterate more than once.
+///
+/// # Tolerance bands
+///
+/// The encoder uses an asymmetric tolerance band built from three
+/// fields:
+///
+/// - **Ship band** — the range of `achieved_score` values that count
+///   as "close enough" to ship without iterating further. After any
+///   pass, if the result is in `[target - max_undershoot_ship,
+///   target + max_overshoot]`, the encoder ships immediately and the
+///   loop exits. With the defaults above, that's `[79.5, 81.5]` for
+///   `target = 80`.
+/// - **Fail band** — the range of `achieved_score` values below
+///   `target - max_undershoot` (when `max_undershoot.is_some()`). On
+///   the final pass, if the result lands in this band the encoder
+///   returns `Err` instead of shipping. With `max_undershoot = None`
+///   (the default), the encoder never errors on undershoot — it
+///   always ships its best attempt.
+///
+/// `max_undershoot_ship` (the SHIP threshold) is intentionally
+/// distinct from `max_undershoot` (the FAILURE threshold). The ship
+/// threshold says "calibration was good enough — don't risk
+/// overshooting on the next pass"; the failure threshold says "this
+/// undershoot is too big to ship at all".
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ZensimTarget {
@@ -56,6 +81,21 @@ pub struct ZensimTarget {
     /// Default: `Some(1.5)`.
     pub max_overshoot: Option<f32>,
 
+    /// Distance BELOW target the encoder will accept as a successful
+    /// pass-0 ship, without iterating. Asymmetric with
+    /// [`Self::max_overshoot`]: undershoot up to this much is treated
+    /// as "close enough — calibration was already good, don't risk
+    /// overshooting on the next pass". `None` (or `Some(0.0)`) =
+    /// strict at-or-above-target behavior; any undershoot triggers
+    /// another pass when budget allows.
+    ///
+    /// Distinct from [`Self::max_undershoot`]: that field is the
+    /// FAILURE threshold (final-pass error), this is the SHIP
+    /// threshold (early-exit acceptance).
+    ///
+    /// Default: `Some(0.5)`.
+    pub max_undershoot_ship: Option<f32>,
+
     /// Distance BELOW target the encoder will accept as a SUCCESSFUL
     /// encode. `None` = best-effort, never error (default; encoder ships
     /// whatever it managed within `max_passes`). `Some(t)` = if final
@@ -65,6 +105,10 @@ pub struct ZensimTarget {
     /// Set this when you NEED a strictness guarantee (archival, SLA-bound
     /// serving). Permissive callers leave it `None` and inspect
     /// [`ZensimEncodeMetrics::achieved_score`] themselves.
+    ///
+    /// Distinct from [`Self::max_undershoot_ship`]: that field is the
+    /// SHIP threshold (early-exit acceptance), this is the FAILURE
+    /// threshold (final-pass error).
     ///
     /// Default: `None`.
     pub max_undershoot: Option<f32>,
@@ -80,6 +124,7 @@ impl Default for ZensimTarget {
         Self {
             target: 80.0,
             max_overshoot: Some(1.5),
+            max_undershoot_ship: Some(0.5),
             max_undershoot: None,
             max_passes: 2,
         }
@@ -120,6 +165,16 @@ impl ZensimTarget {
     #[must_use]
     pub fn with_max_undershoot(mut self, v: Option<f32>) -> Self {
         self.max_undershoot = v;
+        self
+    }
+
+    /// Builder-style override of [`Self::max_undershoot_ship`].
+    ///
+    /// Ship-threshold (early-exit) — distinct from
+    /// [`Self::with_max_undershoot`] (final-pass error threshold).
+    #[must_use]
+    pub fn with_max_undershoot_ship(mut self, v: Option<f32>) -> Self {
+        self.max_undershoot_ship = v;
         self
     }
 
@@ -862,16 +917,18 @@ pub(crate) mod iteration {
         }
     }
 
-    /// Returns true if `score` is in the comfort band — i.e. >= target
-    /// AND (no overshoot configured OR overshoot within budget).
+    /// Returns true if `score` is in the asymmetric ship band:
+    ///   `[target - max_undershoot_ship.unwrap_or(0.0),
+    ///     target + max_overshoot.unwrap_or(∞)]`.
+    ///
+    /// `max_undershoot_ship` lets callers accept a small undershoot as
+    /// "close enough" without triggering another pass — useful when the
+    /// calibrator landed near the band on pass 0 and a correction pass
+    /// would risk swinging into overshoot.
     fn in_band(score: f32, target: &ZensimTarget) -> bool {
-        if score < target.target {
-            return false;
-        }
-        match target.max_overshoot {
-            Some(t) => (score - target.target) <= t,
-            None => true, // No claw-back wanted; first feasible ships.
-        }
+        let lower = target.target - target.max_undershoot_ship.unwrap_or(0.0);
+        let upper = target.target + target.max_overshoot.unwrap_or(f32::INFINITY);
+        score >= lower && score <= upper
     }
 
     /// Compute next q via secant when we have a previous probe, fixed-
@@ -1384,6 +1441,7 @@ mod tests {
         let t = ZensimTarget::default();
         assert_eq!(t.target, 80.0);
         assert_eq!(t.max_overshoot, Some(1.5));
+        assert_eq!(t.max_undershoot_ship, Some(0.5));
         assert_eq!(t.max_undershoot, None);
         assert_eq!(t.max_passes, 2);
     }
@@ -1392,10 +1450,12 @@ mod tests {
     fn target_builder() {
         let t = ZensimTarget::new(85.0)
             .with_max_overshoot(Some(0.5))
+            .with_max_undershoot_ship(Some(0.25))
             .with_max_undershoot(Some(2.0))
             .with_max_passes(3);
         assert_eq!(t.target, 85.0);
         assert_eq!(t.max_overshoot, Some(0.5));
+        assert_eq!(t.max_undershoot_ship, Some(0.25));
         assert_eq!(t.max_undershoot, Some(2.0));
         assert_eq!(t.max_passes, 3);
     }

--- a/src/encoder/zensim_target.rs
+++ b/src/encoder/zensim_target.rs
@@ -259,6 +259,106 @@ fn interpolate_anchors(target: f32, anchors: &[(f32, f32)]) -> f32 {
 }
 
 // ============================================================================
+// Ablation toggles (dev-only, gated on `ablation` feature)
+// ============================================================================
+//
+// The PR shipping target_zensim (Phases 1/2/3) is a stack of distinct
+// mechanisms. The `ablation` feature exposes per-chunk disable toggles
+// via thread-local cells set explicitly by `dev/zensim_*.rs` measurement
+// binaries. Production builds (the `target-zensim` feature alone, no
+// `ablation`) get const `false` for every toggle — the compiler folds
+// them away entirely. **No environment variables are read in either
+// configuration**: ablation is off-by-default, and turning it on requires
+// a typed call to [`ablation::set_toggles`].
+//
+// None of these toggles touches the encoded bytestream — they only
+// change the iteration loop's decisions (which q to start at, whether
+// to take a per-segment vs global-q correction step, etc.).
+
+/// Dev-only ablation toggles for the closed-loop `target_zensim`
+/// iteration. **Gated on the unstable `ablation` Cargo feature** —
+/// production callers do not see this type and the iteration loop uses
+/// constant defaults.
+///
+/// All fields are off by default (matching production behavior).
+/// Set them via [`set_toggles`] to disable individual phases of the
+/// adaptive encoder for measurement binaries (`dev/zensim_*.rs`).
+///
+/// This API is **not** part of the stable zenwebp surface — it is
+/// dev-only by design and may change without a major-version bump.
+#[cfg(feature = "ablation")]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct AblationToggles {
+    /// Force the global-q fallback path even when segments are active
+    /// (Phase 3 disabled).
+    pub disable_phase3: bool,
+    /// Emit `PHASE3_TRACE` lines to stderr per pass.
+    pub trace_phase3: bool,
+    /// Skip the bucket classifier and use a single linear ramp.
+    pub naive_starting_q: bool,
+    /// Don't force `multi_pass_stats=true` inside the iteration loop.
+    pub no_multi_pass_stats: bool,
+    /// Restore the pre-Phase-2 hand-distilled anchors.
+    pub pre_phase2_anchors: bool,
+    /// Use a fixed proportional Δq instead of the secant.
+    pub no_secant: bool,
+    /// Phase 3 aggregator: use the 2x2 spatial-quadrant proxy instead of
+    /// the encoder's real k-means `segment_map`.
+    pub use_quadrant_proxy: bool,
+    /// Threshold (`|target - achieved|`) below which Phase 3 per-segment
+    /// correction is preferred over the global-q secant. `None` keeps
+    /// the production default (0.5).
+    pub phase3_fine_gap: Option<f32>,
+}
+
+#[cfg(feature = "ablation")]
+mod ablation_runtime {
+    use core::cell::Cell;
+    use std::thread_local;
+
+    thread_local! {
+        pub(crate) static DISABLE_PHASE3: Cell<bool> = const { Cell::new(false) };
+        pub(crate) static TRACE_PHASE3: Cell<bool> = const { Cell::new(false) };
+        pub(crate) static NAIVE_STARTING_Q: Cell<bool> = const { Cell::new(false) };
+        pub(crate) static NO_MULTI_PASS_STATS: Cell<bool> = const { Cell::new(false) };
+        pub(crate) static PRE_PHASE2_ANCHORS: Cell<bool> = const { Cell::new(false) };
+        pub(crate) static NO_SECANT: Cell<bool> = const { Cell::new(false) };
+        pub(crate) static USE_QUADRANT_PROXY: Cell<bool> = const { Cell::new(false) };
+        // f32::NAN means "use the production default (0.5)".
+        pub(crate) static PHASE3_FINE_GAP: Cell<f32> = const { Cell::new(f32::NAN) };
+    }
+}
+
+/// Set ablation toggles for the **current thread**. Dev-only — exposed
+/// only when the `ablation` Cargo feature is enabled.
+///
+/// Each call replaces the entire toggle state (any field not set in
+/// `t` reverts to its default value). Effects are scoped to the calling
+/// thread; toggles do NOT propagate to threads spawned afterwards.
+///
+/// The `target_zensim` iteration loop reads these values once at the
+/// start of each phase decision; toggling mid-encode is allowed but the
+/// loop won't observe the change until its next polling point.
+#[cfg(feature = "ablation")]
+pub fn set_toggles(t: AblationToggles) {
+    use ablation_runtime::*;
+    DISABLE_PHASE3.with(|c| c.set(t.disable_phase3));
+    TRACE_PHASE3.with(|c| c.set(t.trace_phase3));
+    NAIVE_STARTING_Q.with(|c| c.set(t.naive_starting_q));
+    NO_MULTI_PASS_STATS.with(|c| c.set(t.no_multi_pass_stats));
+    PRE_PHASE2_ANCHORS.with(|c| c.set(t.pre_phase2_anchors));
+    NO_SECANT.with(|c| c.set(t.no_secant));
+    USE_QUADRANT_PROXY.with(|c| c.set(t.use_quadrant_proxy));
+    // None → NaN sentinel, meaning "use production default 0.5".
+    PHASE3_FINE_GAP.with(|c| c.set(t.phase3_fine_gap.unwrap_or(f32::NAN)));
+}
+
+/// Production default for the Phase 3 fine-gap threshold. See the
+/// long-form comment on the iteration loop for why 0.5.
+#[cfg(feature = "target-zensim")]
+const PHASE3_FINE_GAP_DEFAULT: f32 = 0.5;
+
+// ============================================================================
 // Iteration loop (gated on the `target-zensim` feature)
 // ============================================================================
 
@@ -275,31 +375,13 @@ pub(crate) mod iteration {
     /// an error if a hard constraint was violated.
     pub(crate) type IterationResult = Result<(Vec<u8>, ZensimEncodeMetrics), EncodeError>;
 
-    // ============================================================================
-    // Ablation toggles (dev-only, gated on `ablation` feature)
-    // ============================================================================
-    //
-    // The PR shipping target_zensim (Phases 1/2/3) is a stack of distinct
-    // mechanisms. The `ablation` feature wires per-chunk disable toggles
-    // read from environment variables so `dev/zensim_*.rs` measurement
-    // binaries can re-run leg-by-leg comparisons. Production builds (the
-    // `target-zensim` feature alone, no `ablation`) get const `false` for
-    // every toggle and the compiler elides them entirely — zero
-    // `std::env::var` calls on the iteration hot path.
-    //
-    // None of these toggles touches the encoded bytestream — they only
-    // change the iteration loop's decisions (which q to start at, whether
-    // to take a per-segment vs global-q correction step, etc.).
-
     /// Disable Phase 3 per-segment correction. When set, every pass after
     /// pass 0 takes the global-q secant step (or fallback step) instead of
     /// computing per-segment quant overrides from the diffmap. Equivalent
     /// to "Phase 1 (+ Phase 2 anchors) only".
     #[cfg(feature = "ablation")]
     fn ablate_disable_phase3() -> bool {
-        std::env::var("ZENWEBP_ABLATE_NO_PHASE3")
-            .map(|v| v == "1")
-            .unwrap_or(false)
+        super::ablation_runtime::DISABLE_PHASE3.with(|c| c.get())
     }
     #[cfg(not(feature = "ablation"))]
     const fn ablate_disable_phase3() -> bool {
@@ -314,9 +396,7 @@ pub(crate) mod iteration {
     ///     cum_overrides=[d0,d1,d2,d3] decision=<reason>
     #[cfg(feature = "ablation")]
     fn trace_phase3() -> bool {
-        std::env::var("ZENWEBP_PHASE3_TRACE")
-            .map(|v| v == "1")
-            .unwrap_or(false)
+        super::ablation_runtime::TRACE_PHASE3.with(|c| c.get())
     }
     #[cfg(not(feature = "ablation"))]
     const fn trace_phase3() -> bool {
@@ -329,9 +409,7 @@ pub(crate) mod iteration {
     /// Drawing get replaced with the naive identity-ish ramp).
     #[cfg(feature = "ablation")]
     fn ablate_naive_starting_q() -> bool {
-        std::env::var("ZENWEBP_ABLATE_NAIVE_Q")
-            .map(|v| v == "1")
-            .unwrap_or(false)
+        super::ablation_runtime::NAIVE_STARTING_Q.with(|c| c.get())
     }
     #[cfg(not(feature = "ablation"))]
     const fn ablate_naive_starting_q() -> bool {
@@ -343,9 +421,7 @@ pub(crate) mod iteration {
     /// (typically `false`).
     #[cfg(feature = "ablation")]
     fn ablate_no_multi_pass_stats() -> bool {
-        std::env::var("ZENWEBP_ABLATE_NO_MULTI_PASS_STATS")
-            .map(|v| v == "1")
-            .unwrap_or(false)
+        super::ablation_runtime::NO_MULTI_PASS_STATS.with(|c| c.get())
     }
     #[cfg(not(feature = "ablation"))]
     const fn ablate_no_multi_pass_stats() -> bool {
@@ -358,9 +434,7 @@ pub(crate) mod iteration {
     /// its weight vs the original judgement-based table.
     #[cfg(feature = "ablation")]
     fn ablate_pre_phase2_anchors() -> bool {
-        std::env::var("ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS")
-            .map(|v| v == "1")
-            .unwrap_or(false)
+        super::ablation_runtime::PRE_PHASE2_ANCHORS.with(|c| c.get())
     }
     #[cfg(not(feature = "ablation"))]
     const fn ablate_pre_phase2_anchors() -> bool {
@@ -371,9 +445,7 @@ pub(crate) mod iteration {
     /// when Phase 3 is also disabled (the global-q fallback path).
     #[cfg(feature = "ablation")]
     fn ablate_no_secant() -> bool {
-        std::env::var("ZENWEBP_ABLATE_NO_SECANT")
-            .map(|v| v == "1")
-            .unwrap_or(false)
+        super::ablation_runtime::NO_SECANT.with(|c| c.get())
     }
     #[cfg(not(feature = "ablation"))]
     const fn ablate_no_secant() -> bool {
@@ -384,7 +456,8 @@ pub(crate) mod iteration {
     /// when the bucket classifier is bypassed. Shape mirrors zenjpeg's
     /// `zq_to_starting_jpegli_q`: a gentle ramp that crosses target=q at
     /// the high end and starts conservatively at the low end. Only reached
-    /// under the `ablation` feature when `ZENWEBP_ABLATE_NAIVE_Q=1`.
+    /// under the `ablation` feature when
+    /// [`AblationToggles::naive_starting_q`] is set.
     #[cfg_attr(not(feature = "ablation"), allow(dead_code))]
     fn naive_starting_q(target: f32) -> f32 {
         const NAIVE: &[(f32, f32)] = &[
@@ -401,8 +474,8 @@ pub(crate) mod iteration {
 
     /// Pre-Phase-2 hand-distilled Photo / Drawing anchors. Recovered from
     /// commit `17b9c9a^:src/encoder/zensim_target.rs`. Used only when
-    /// the `ablation` feature is on AND `ZENWEBP_ABLATE_PRE_PHASE2_ANCHORS=1`
-    /// is set (chunk E ablation).
+    /// the `ablation` feature is on AND
+    /// [`AblationToggles::pre_phase2_anchors`] is set (chunk E ablation).
     #[cfg_attr(not(feature = "ablation"), allow(dead_code))]
     fn pre_phase2_starting_q(target: f32, bucket: ImageContentType) -> f32 {
         const PHOTO_HAND: &[(f32, f32)] = &[
@@ -559,8 +632,9 @@ pub(crate) mod iteration {
         // to a single segment) or the segment_map is empty, we fall back
         // to global-q correction.
         //
-        // Chunk A ablation: when ZENWEBP_ABLATE_NO_PHASE3=1, force the
-        // global-q fallback path even when segments are active.
+        // Chunk A ablation: when [`AblationToggles::disable_phase3`] is
+        // set, force the global-q fallback path even when segments are
+        // active.
         let per_segment_enabled = !ablate_disable_phase3()
             && diag0.num_segments > 1
             && !diag0.segment_map.is_empty()
@@ -600,18 +674,23 @@ pub(crate) mod iteration {
         // per-segment ever could; switching mid-trajectory throws away
         // that information and tends to produce out-of-band finals.
         //
-        // Under the `ablation` feature the `ZENWEBP_PHASE3_FINE_GAP` env
-        // var (float, default 0.5) overrides the threshold for tuning
-        // experiments. Set it to a very large value (e.g. 1000) to
-        // recover the pre-fix always-on Phase 3 behavior for A/B testing.
-        // Production builds use the constant 0.5.
+        // Under the `ablation` feature the
+        // [`AblationToggles::phase3_fine_gap`] field (float, default 0.5)
+        // overrides the threshold for tuning experiments. Set it to a
+        // very large value (e.g. 1000) to recover the pre-fix always-on
+        // Phase 3 behavior for A/B testing. Production builds use the
+        // constant default.
         #[cfg(feature = "ablation")]
-        let phase3_fine_gap: f32 = std::env::var("ZENWEBP_PHASE3_FINE_GAP")
-            .ok()
-            .and_then(|s| s.parse::<f32>().ok())
-            .unwrap_or(0.5);
+        let phase3_fine_gap: f32 = {
+            let v = super::ablation_runtime::PHASE3_FINE_GAP.with(|c| c.get());
+            if v.is_nan() {
+                super::PHASE3_FINE_GAP_DEFAULT
+            } else {
+                v
+            }
+        };
         #[cfg(not(feature = "ablation"))]
-        let phase3_fine_gap: f32 = 0.5;
+        let phase3_fine_gap: f32 = super::PHASE3_FINE_GAP_DEFAULT;
         for pass in 1..max_passes {
             let abs_gap = (target.target - last_score).abs();
             let use_per_segment =
@@ -688,7 +767,8 @@ pub(crate) mod iteration {
 
             // multi_pass_stats=true on probe encodes — small size win
             // amortizes across passes. Chunk D ablation: leave it at the
-            // user's LossyConfig value when ZENWEBP_ABLATE_NO_MULTI_PASS_STATS=1.
+            // user's LossyConfig value when
+            // [`AblationToggles::no_multi_pass_stats`] is set.
             let mps = !ablate_no_multi_pass_stats();
             let (bytes_n, diag_n) =
                 encode_at_with_diagnostics(cfg, next_q, mps, next_overrides, rgb, width, height)?;
@@ -795,8 +875,9 @@ pub(crate) mod iteration {
     }
 
     /// Compute next q via secant when we have a previous probe, fixed-
-    /// step otherwise. Chunk F ablation: when ZENWEBP_ABLATE_NO_SECANT=1,
-    /// always use a fixed proportional step `(target - achieved) * 0.5`.
+    /// step otherwise. Chunk F ablation: when
+    /// [`AblationToggles::no_secant`] is set, always use a fixed
+    /// proportional step `(target - achieved) * 0.5`.
     fn compute_next_q(
         q: f32,
         last_score: f32,
@@ -1015,9 +1096,10 @@ pub(crate) mod iteration {
         score: f32,
         target: &ZensimTarget,
     ) -> OverrideDecision {
-        // Content-type-dependent fallback hatch: when the env var
-        // ZENWEBP_PHASE3_QUADRANT=1 is set, fall back to the 2x2
-        // spatial-quadrant proxy that this code shipped with originally.
+        // Content-type-dependent fallback hatch: when the
+        // [`AblationToggles::use_quadrant_proxy`] flag is set on the
+        // current thread, fall back to the 2x2 spatial-quadrant proxy
+        // that this code shipped with originally.
         //
         // A/B run (CID22 + gb82 + gb82-sc, 76 images x 3 targets =
         // 228 cells, target ∈ {75, 80, 85}, max_overshoot=1.5,
@@ -1038,12 +1120,10 @@ pub(crate) mod iteration {
         // but on photo content the quadrant proxy occasionally lands
         // closer to target. Under the `ablation` feature the
         // `dev/zensim_ab_quadrant_vs_segmap.rs` binary toggles this
-        // var to re-run the comparison. Production builds always use
-        // the real segment_map.
+        // via [`AblationToggles::use_quadrant_proxy`] to re-run the
+        // comparison. Production builds always use the real segment_map.
         #[cfg(feature = "ablation")]
-        let use_quadrant = std::env::var("ZENWEBP_PHASE3_QUADRANT")
-            .map(|v| v == "1")
-            .unwrap_or(false);
+        let use_quadrant = super::ablation_runtime::USE_QUADRANT_PROXY.with(|c| c.get());
         #[cfg(not(feature = "ablation"))]
         let use_quadrant = false;
         if use_quadrant {
@@ -1191,8 +1271,8 @@ pub(crate) mod iteration {
 
     /// Pre-deviation aggregation: 2x2 spatial-quadrant proxy. Kept for
     /// A/B comparison under the `ablation` feature via
-    /// `ZENWEBP_PHASE3_QUADRANT=1`. Production code uses the real
-    /// `segment_map` via [`next_segment_overrides`].
+    /// [`AblationToggles::use_quadrant_proxy`]. Production code uses
+    /// the real `segment_map` via [`next_segment_overrides`].
     #[cfg_attr(not(feature = "ablation"), allow(dead_code))]
     fn next_segment_overrides_quadrant_proxy(
         cum: [i8; 4],

--- a/src/encoder/zensim_target.rs
+++ b/src/encoder/zensim_target.rs
@@ -43,6 +43,18 @@ use super::analysis::ImageContentType;
 /// best-effort behavior tuned to land in band on pass 1 for typical
 /// photo content and never iterate more than once.
 ///
+/// # Pixel layout: RGB8-only
+///
+/// `target_zensim` currently only supports `PixelLayout::Rgb8`
+/// inputs. Setting it on a config and then submitting any other
+/// layout (RGBA / BGRA / BGR / ARGB / L8 / LA8 / YUV420) returns
+/// [`EncodeError::TargetZensimUnsupportedLayout`](super::api::EncodeError::TargetZensimUnsupportedLayout).
+/// The iteration's decode-and-measure step needs RGB pixels and we
+/// refuse to silently strip alpha. RGBA support is tracked as a
+/// follow-up; for alpha-preserving target_zensim today, run iteration
+/// on an RGB projection and re-encode RGBA at the converged quality
+/// outside the loop.
+///
 /// # Tolerance bands
 ///
 /// The encoder uses an asymmetric tolerance band built from three

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ pub use zenpixels::Orientation;
 // Re-export core encoder types
 pub use encoder::{
     CostModel, EncodeError, EncodeRequest, EncodeResult, EncoderConfig, ImageMetadata,
-    LosslessConfig, LossyConfig, PixelLayout, Preset,
+    LosslessConfig, LossyConfig, PixelLayout, Preset, ZensimEncodeMetrics, ZensimTarget,
 };
 
 /// Re-export sharp YUV configuration from zenyuv.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,11 @@ pub use encoder::{
     LosslessConfig, LossyConfig, PixelLayout, Preset, ZensimEncodeMetrics, ZensimTarget,
 };
 
+/// Dev-only ablation toggles (gated on the unstable `ablation` feature).
+/// See [`encoder::AblationToggles`].
+#[cfg(feature = "ablation")]
+pub use encoder::{AblationToggles, set_ablation_toggles};
+
 /// Re-export sharp YUV configuration from zenyuv.
 pub use zenyuv::SharpYuvConfig;
 

--- a/tests/target_zensim.rs
+++ b/tests/target_zensim.rs
@@ -1,0 +1,211 @@
+//! Closed-loop `target_zensim` adaptive encoder tests.
+//!
+//! These tests exercise the full encode → decode → measure → adjust loop
+//! and the strict-mode error path. Convergence bands are intentionally
+//! generous (see issue #47): the calibration is approximate by design,
+//! and tightening the band would create a noisy gate without protecting
+//! anything callers actually care about.
+
+#![cfg(feature = "target-zensim")]
+
+use zenwebp::{LossyConfig, ZensimEncodeMetrics, ZensimTarget};
+
+/// Build a 256×256 RGB8 mixed-content image: smooth gradient + low-
+/// amplitude band-limited "natural" texture. Designed to give the
+/// encoder genuine RD-tradeoff work without the perceptually-impossible
+/// pure noise that caps zensim well below 60 even at q=100.
+fn mixed_content_256() -> (Vec<u8>, u32, u32) {
+    let w: u32 = 256;
+    let h: u32 = 256;
+    let mut buf = Vec::with_capacity((w * h * 3) as usize);
+    // Use a smooth f32-domain pattern: two overlaid sine waves + a slow
+    // gradient. This is "photo-like" content that VP8 can encode well.
+    for y in 0..h {
+        for x in 0..w {
+            let fx = x as f32 / w as f32;
+            let fy = y as f32 / h as f32;
+            // Slow gradient.
+            let base_r = 80.0 + 100.0 * fx;
+            let base_g = 100.0 + 80.0 * fy;
+            let base_b = 90.0 + 80.0 * (1.0 - fx);
+            // Low-amplitude band-limited "texture" — sin waves at modest
+            // frequencies. Stays well within VP8's coding capability.
+            let tex = 18.0
+                * ((fx * 9.0).sin() * (fy * 7.0).cos()
+                    + 0.6 * (fx * 17.0 + fy * 11.0).sin());
+            let r = (base_r + tex).clamp(0.0, 255.0) as u8;
+            let g = (base_g + tex * 0.7).clamp(0.0, 255.0) as u8;
+            let b = (base_b - tex * 0.5).clamp(0.0, 255.0) as u8;
+            buf.extend_from_slice(&[r, g, b]);
+        }
+    }
+    (buf, w, h)
+}
+
+/// Smooth gradient — easy content where pass 1 at calibrated q tends to
+/// overshoot the target. Used to exercise the bytes-recovery path.
+fn smooth_gradient_256() -> (Vec<u8>, u32, u32) {
+    let w: u32 = 256;
+    let h: u32 = 256;
+    let mut buf = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let r = ((x * 255) / w) as u8;
+            let g = ((y * 255) / h) as u8;
+            let b = (((x + y) * 255) / (w + h)) as u8;
+            buf.extend_from_slice(&[r, g, b]);
+        }
+    }
+    (buf, w, h)
+}
+
+#[test]
+fn converges_to_target_80_within_two_passes() {
+    let (rgb, w, h) = mixed_content_256();
+    let cfg = LossyConfig::new()
+        .with_method(4)
+        .with_target_zensim(80.0);
+
+    let (bytes, metrics) = cfg
+        .encode_rgb_with_metrics(&rgb, w, h)
+        .expect("encode failed");
+
+    assert!(!bytes.is_empty(), "encoder produced no bytes");
+    assert!(metrics.passes_used <= 2, "used {} passes (>2)", metrics.passes_used);
+    // Generous band — calibration is approximate. The tighter band
+    // [78.5, 81.5] is the spec target but is sensitive to encoder/zensim
+    // version drift. We test the looser band that catches gross bugs.
+    let s = metrics.achieved_score;
+    assert!(s.is_finite(), "score is non-finite: {s}");
+    assert!(
+        (75.0..=86.0).contains(&s),
+        "achieved {s} outside acceptable convergence band [75, 86] for target=80"
+    );
+}
+
+#[test]
+fn metrics_no_target_when_disabled() {
+    let (rgb, w, h) = smooth_gradient_256();
+    let cfg = LossyConfig::new().with_method(4).with_quality(75.0);
+    let (bytes, metrics) = cfg
+        .encode_rgb_with_metrics(&rgb, w, h)
+        .expect("encode failed");
+    assert!(!bytes.is_empty());
+    assert!(metrics.achieved_score.is_nan(), "no_target should be NaN");
+    assert_eq!(metrics.passes_used, 1);
+    assert!(metrics.targets_met);
+}
+
+#[test]
+fn strict_undershoot_errors_on_unreachable_target() {
+    let (rgb, w, h) = mixed_content_256();
+    // Target 99 with a tight 0.5 floor and just one pass: the
+    // calibrated start at q≈98 is unlikely to clear 99 on a noisy
+    // mixed-content image, so this MUST error rather than silently
+    // ship.
+    let target = ZensimTarget::new(99.0)
+        .with_max_undershoot(Some(0.5))
+        .with_max_passes(1);
+    let cfg = LossyConfig::new()
+        .with_method(4)
+        .with_target_zensim_target(target);
+
+    // Single-pass strict mode bypasses iteration entirely (max_passes=1
+    // ships the calibrated encode without measuring). To make strict-mode
+    // bite we need max_passes >= 2 so the loop runs and finalize() can
+    // check the floor. Use a 2-pass strict run instead.
+    let target2 = ZensimTarget::new(99.0)
+        .with_max_undershoot(Some(0.5))
+        .with_max_passes(2);
+    let cfg2 = LossyConfig::new()
+        .with_method(4)
+        .with_target_zensim_target(target2);
+    let _ = cfg; // suppress unused
+    let result = cfg2.encode_rgb_with_metrics(&rgb, w, h);
+    assert!(
+        result.is_err(),
+        "expected strict-mode error for unreachable target 99 on mixed content; got Ok"
+    );
+}
+
+#[test]
+fn bytes_recovery_drops_size_when_overshooting() {
+    // Smooth gradient at target=70: calibrated start at q≈65 likely
+    // overshoots into the 80s. Pass 2 should claw back bytes.
+    let (rgb, w, h) = smooth_gradient_256();
+    let cfg_low_target = LossyConfig::new()
+        .with_method(4)
+        .with_target_zensim_target(
+            ZensimTarget::new(70.0)
+                .with_max_overshoot(Some(0.5))
+                .with_max_passes(2),
+        );
+    let (bytes_two_pass, metrics) = cfg_low_target
+        .encode_rgb_with_metrics(&rgb, w, h)
+        .expect("encode failed");
+
+    // For comparison: single-pass (max_passes=1) just ships the
+    // calibrated start, no claw-back.
+    let cfg_one_pass = LossyConfig::new()
+        .with_method(4)
+        .with_target_zensim_target(
+            ZensimTarget::new(70.0)
+                .with_max_overshoot(Some(0.5))
+                .with_max_passes(1),
+        );
+    let (bytes_one_pass, _m1) = cfg_one_pass
+        .encode_rgb_with_metrics(&rgb, w, h)
+        .expect("encode failed");
+
+    // If pass 1 was already in band, claw-back doesn't run. Skip the
+    // assertion silently in that case so the test isn't fragile.
+    let one_pass_bytes = bytes_one_pass.len();
+    let two_pass_bytes = bytes_two_pass.len();
+    eprintln!(
+        "smooth-gradient target=70: 1-pass bytes={}, 2-pass bytes={} (achieved {:.2}, passes {})",
+        one_pass_bytes, two_pass_bytes, metrics.achieved_score, metrics.passes_used
+    );
+    if metrics.passes_used >= 2 {
+        // We took a recovery pass — bytes should not have grown
+        // significantly. Allow a small uptick in case the secant
+        // overshot in the other direction.
+        assert!(
+            two_pass_bytes <= (one_pass_bytes as f64 * 1.10) as usize,
+            "2-pass bytes {} grew >10% beyond 1-pass bytes {}",
+            two_pass_bytes,
+            one_pass_bytes
+        );
+    }
+    // Final score must still meet the target (best-effort).
+    if metrics.achieved_score.is_finite() {
+        assert!(
+            metrics.achieved_score >= 68.0,
+            "claw-back went too far: achieved {} < 68 (target 70)",
+            metrics.achieved_score
+        );
+    }
+}
+
+#[test]
+fn zensim_target_default_constructor() {
+    let t = ZensimTarget::default();
+    assert_eq!(t.target, 80.0);
+    let t2 = ZensimTarget::new(85.0);
+    assert_eq!(t2.target, 85.0);
+    assert_eq!(t2.max_passes, 2);
+}
+
+#[test]
+fn metrics_no_target_helper_exists() {
+    // ZensimEncodeMetrics is in the public API; smoke-test the no-target
+    // path. The struct itself is `#[non_exhaustive]` so callers don't
+    // construct it directly — they observe it from encode_rgb_with_metrics.
+    let cfg = LossyConfig::new();
+    let (rgb, w, h) = smooth_gradient_256();
+    let (_bytes, m) = cfg
+        .encode_rgb_with_metrics(&rgb, w, h)
+        .expect("encode failed");
+    assert!(m.bytes > 0);
+    assert!(m.targets_met);
+    let _: ZensimEncodeMetrics = m;
+}

--- a/tests/target_zensim.rs
+++ b/tests/target_zensim.rs
@@ -107,9 +107,7 @@ fn strict_undershoot_errors_on_unreachable_target() {
     let target = ZensimTarget::new(99.0)
         .with_max_undershoot(Some(0.5))
         .with_max_passes(1);
-    let cfg = LossyConfig::new()
-        .with_method(4)
-        .with_target_zensim_target(target);
+    let cfg = LossyConfig::new().with_method(4).with_target_zensim(target);
 
     // Single-pass strict mode bypasses iteration entirely (max_passes=1
     // ships the calibrated encode without measuring). To make strict-mode
@@ -120,7 +118,7 @@ fn strict_undershoot_errors_on_unreachable_target() {
         .with_max_passes(2);
     let cfg2 = LossyConfig::new()
         .with_method(4)
-        .with_target_zensim_target(target2);
+        .with_target_zensim(target2);
     let _ = cfg; // suppress unused
     let result = EncodeRequest::lossy(&cfg2, &rgb, PixelLayout::Rgb8, w, h).encode_with_metrics();
     assert!(
@@ -134,7 +132,7 @@ fn bytes_recovery_drops_size_when_overshooting() {
     // Smooth gradient at target=70: calibrated start at q≈65 likely
     // overshoots into the 80s. Pass 2 should claw back bytes.
     let (rgb, w, h) = smooth_gradient_256();
-    let cfg_low_target = LossyConfig::new().with_method(4).with_target_zensim_target(
+    let cfg_low_target = LossyConfig::new().with_method(4).with_target_zensim(
         ZensimTarget::new(70.0)
             .with_max_overshoot(Some(0.5))
             .with_max_passes(2),
@@ -146,7 +144,7 @@ fn bytes_recovery_drops_size_when_overshooting() {
 
     // For comparison: single-pass (max_passes=1) just ships the
     // calibrated start, no claw-back.
-    let cfg_one_pass = LossyConfig::new().with_method(4).with_target_zensim_target(
+    let cfg_one_pass = LossyConfig::new().with_method(4).with_target_zensim(
         ZensimTarget::new(70.0)
             .with_max_overshoot(Some(0.5))
             .with_max_passes(1),
@@ -228,7 +226,7 @@ fn per_segment_correction_converges_on_color_blocks() {
     let cfg = LossyConfig::new()
         .with_method(4)
         .with_segments(4)
-        .with_target_zensim_target(
+        .with_target_zensim(
             ZensimTarget::new(82.0)
                 .with_max_overshoot(Some(2.0))
                 .with_max_passes(3),
@@ -266,7 +264,7 @@ fn per_segment_disabled_when_one_segment() {
     let cfg = LossyConfig::new()
         .with_method(4)
         .with_segments(1)
-        .with_target_zensim_target(
+        .with_target_zensim(
             ZensimTarget::new(82.0)
                 .with_max_overshoot(Some(2.0))
                 .with_max_passes(3),

--- a/tests/target_zensim.rs
+++ b/tests/target_zensim.rs
@@ -8,7 +8,7 @@
 
 #![cfg(feature = "target-zensim")]
 
-use zenwebp::{LossyConfig, ZensimEncodeMetrics, ZensimTarget};
+use zenwebp::{EncodeRequest, LossyConfig, PixelLayout, ZensimEncodeMetrics, ZensimTarget};
 
 /// Build a 256×256 RGB8 mixed-content image: smooth gradient + low-
 /// amplitude band-limited "natural" texture. Designed to give the
@@ -63,8 +63,8 @@ fn converges_to_target_80_within_two_passes() {
     let (rgb, w, h) = mixed_content_256();
     let cfg = LossyConfig::new().with_method(4).with_target_zensim(80.0);
 
-    let (bytes, metrics) = cfg
-        .encode_rgb_with_metrics(&rgb, w, h)
+    let (bytes, metrics) = EncodeRequest::lossy(&cfg, &rgb, PixelLayout::Rgb8, w, h)
+        .encode_with_metrics()
         .expect("encode failed");
 
     assert!(!bytes.is_empty(), "encoder produced no bytes");
@@ -88,8 +88,8 @@ fn converges_to_target_80_within_two_passes() {
 fn metrics_no_target_when_disabled() {
     let (rgb, w, h) = smooth_gradient_256();
     let cfg = LossyConfig::new().with_method(4).with_quality(75.0);
-    let (bytes, metrics) = cfg
-        .encode_rgb_with_metrics(&rgb, w, h)
+    let (bytes, metrics) = EncodeRequest::lossy(&cfg, &rgb, PixelLayout::Rgb8, w, h)
+        .encode_with_metrics()
         .expect("encode failed");
     assert!(!bytes.is_empty());
     assert!(metrics.achieved_score.is_nan(), "no_target should be NaN");
@@ -122,7 +122,7 @@ fn strict_undershoot_errors_on_unreachable_target() {
         .with_method(4)
         .with_target_zensim_target(target2);
     let _ = cfg; // suppress unused
-    let result = cfg2.encode_rgb_with_metrics(&rgb, w, h);
+    let result = EncodeRequest::lossy(&cfg2, &rgb, PixelLayout::Rgb8, w, h).encode_with_metrics();
     assert!(
         result.is_err(),
         "expected strict-mode error for unreachable target 99 on mixed content; got Ok"
@@ -139,9 +139,10 @@ fn bytes_recovery_drops_size_when_overshooting() {
             .with_max_overshoot(Some(0.5))
             .with_max_passes(2),
     );
-    let (bytes_two_pass, metrics) = cfg_low_target
-        .encode_rgb_with_metrics(&rgb, w, h)
-        .expect("encode failed");
+    let (bytes_two_pass, metrics) =
+        EncodeRequest::lossy(&cfg_low_target, &rgb, PixelLayout::Rgb8, w, h)
+            .encode_with_metrics()
+            .expect("encode failed");
 
     // For comparison: single-pass (max_passes=1) just ships the
     // calibrated start, no claw-back.
@@ -150,8 +151,8 @@ fn bytes_recovery_drops_size_when_overshooting() {
             .with_max_overshoot(Some(0.5))
             .with_max_passes(1),
     );
-    let (bytes_one_pass, _m1) = cfg_one_pass
-        .encode_rgb_with_metrics(&rgb, w, h)
+    let (bytes_one_pass, _m1) = EncodeRequest::lossy(&cfg_one_pass, &rgb, PixelLayout::Rgb8, w, h)
+        .encode_with_metrics()
         .expect("encode failed");
 
     // If pass 1 was already in band, claw-back doesn't run. Skip the
@@ -232,8 +233,8 @@ fn per_segment_correction_converges_on_color_blocks() {
                 .with_max_overshoot(Some(2.0))
                 .with_max_passes(3),
         );
-    let (bytes, metrics) = cfg
-        .encode_rgb_with_metrics(&rgb, w, h)
+    let (bytes, metrics) = EncodeRequest::lossy(&cfg, &rgb, PixelLayout::Rgb8, w, h)
+        .encode_with_metrics()
         .expect("encode failed");
     assert!(!bytes.is_empty());
     assert!(metrics.passes_used <= 3);
@@ -270,8 +271,8 @@ fn per_segment_disabled_when_one_segment() {
                 .with_max_overshoot(Some(2.0))
                 .with_max_passes(3),
         );
-    let (bytes, metrics) = cfg
-        .encode_rgb_with_metrics(&rgb, w, h)
+    let (bytes, metrics) = EncodeRequest::lossy(&cfg, &rgb, PixelLayout::Rgb8, w, h)
+        .encode_with_metrics()
         .expect("encode failed");
     assert!(!bytes.is_empty());
     assert!(
@@ -285,11 +286,11 @@ fn per_segment_disabled_when_one_segment() {
 fn metrics_no_target_helper_exists() {
     // ZensimEncodeMetrics is in the public API; smoke-test the no-target
     // path. The struct itself is `#[non_exhaustive]` so callers don't
-    // construct it directly — they observe it from encode_rgb_with_metrics.
+    // construct it directly — they observe it from encode_with_metrics.
     let cfg = LossyConfig::new();
     let (rgb, w, h) = smooth_gradient_256();
-    let (_bytes, m) = cfg
-        .encode_rgb_with_metrics(&rgb, w, h)
+    let (_bytes, m) = EncodeRequest::lossy(&cfg, &rgb, PixelLayout::Rgb8, w, h)
+        .encode_with_metrics()
         .expect("encode failed");
     assert!(m.bytes > 0);
     assert!(m.targets_met);

--- a/tests/target_zensim.rs
+++ b/tests/target_zensim.rs
@@ -30,9 +30,8 @@ fn mixed_content_256() -> (Vec<u8>, u32, u32) {
             let base_b = 90.0 + 80.0 * (1.0 - fx);
             // Low-amplitude band-limited "texture" — sin waves at modest
             // frequencies. Stays well within VP8's coding capability.
-            let tex = 18.0
-                * ((fx * 9.0).sin() * (fy * 7.0).cos()
-                    + 0.6 * (fx * 17.0 + fy * 11.0).sin());
+            let tex =
+                18.0 * ((fx * 9.0).sin() * (fy * 7.0).cos() + 0.6 * (fx * 17.0 + fy * 11.0).sin());
             let r = (base_r + tex).clamp(0.0, 255.0) as u8;
             let g = (base_g + tex * 0.7).clamp(0.0, 255.0) as u8;
             let b = (base_b - tex * 0.5).clamp(0.0, 255.0) as u8;
@@ -62,16 +61,18 @@ fn smooth_gradient_256() -> (Vec<u8>, u32, u32) {
 #[test]
 fn converges_to_target_80_within_two_passes() {
     let (rgb, w, h) = mixed_content_256();
-    let cfg = LossyConfig::new()
-        .with_method(4)
-        .with_target_zensim(80.0);
+    let cfg = LossyConfig::new().with_method(4).with_target_zensim(80.0);
 
     let (bytes, metrics) = cfg
         .encode_rgb_with_metrics(&rgb, w, h)
         .expect("encode failed");
 
     assert!(!bytes.is_empty(), "encoder produced no bytes");
-    assert!(metrics.passes_used <= 2, "used {} passes (>2)", metrics.passes_used);
+    assert!(
+        metrics.passes_used <= 2,
+        "used {} passes (>2)",
+        metrics.passes_used
+    );
     // Generous band — calibration is approximate. The tighter band
     // [78.5, 81.5] is the spec target but is sensitive to encoder/zensim
     // version drift. We test the looser band that catches gross bugs.
@@ -133,26 +134,22 @@ fn bytes_recovery_drops_size_when_overshooting() {
     // Smooth gradient at target=70: calibrated start at q≈65 likely
     // overshoots into the 80s. Pass 2 should claw back bytes.
     let (rgb, w, h) = smooth_gradient_256();
-    let cfg_low_target = LossyConfig::new()
-        .with_method(4)
-        .with_target_zensim_target(
-            ZensimTarget::new(70.0)
-                .with_max_overshoot(Some(0.5))
-                .with_max_passes(2),
-        );
+    let cfg_low_target = LossyConfig::new().with_method(4).with_target_zensim_target(
+        ZensimTarget::new(70.0)
+            .with_max_overshoot(Some(0.5))
+            .with_max_passes(2),
+    );
     let (bytes_two_pass, metrics) = cfg_low_target
         .encode_rgb_with_metrics(&rgb, w, h)
         .expect("encode failed");
 
     // For comparison: single-pass (max_passes=1) just ships the
     // calibrated start, no claw-back.
-    let cfg_one_pass = LossyConfig::new()
-        .with_method(4)
-        .with_target_zensim_target(
-            ZensimTarget::new(70.0)
-                .with_max_overshoot(Some(0.5))
-                .with_max_passes(1),
-        );
+    let cfg_one_pass = LossyConfig::new().with_method(4).with_target_zensim_target(
+        ZensimTarget::new(70.0)
+            .with_max_overshoot(Some(0.5))
+            .with_max_passes(1),
+    );
     let (bytes_one_pass, _m1) = cfg_one_pass
         .encode_rgb_with_metrics(&rgb, w, h)
         .expect("encode failed");
@@ -193,6 +190,95 @@ fn zensim_target_default_constructor() {
     let t2 = ZensimTarget::new(85.0);
     assert_eq!(t2.target, 85.0);
     assert_eq!(t2.max_passes, 2);
+}
+
+/// Build a synthetic "color_blocks"-style image with 4 sharp-edged flat
+/// regions of distinct colors. This exercises Phase 3 — per-segment
+/// quantization gives the encoder a tool the global-q step doesn't
+/// have, so the per-segment correction path should converge within the
+/// pass budget on content like this.
+fn color_blocks_256() -> (Vec<u8>, u32, u32) {
+    let w: u32 = 256;
+    let h: u32 = 256;
+    let mut buf = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let q = (y < h / 2, x < w / 2);
+            let (r, g, b) = match q {
+                (true, true) => (220, 50, 50),    // top-left red
+                (true, false) => (60, 200, 80),   // top-right green
+                (false, true) => (50, 80, 220),   // bottom-left blue
+                (false, false) => (200, 200, 60), // bottom-right yellow
+            };
+            buf.extend_from_slice(&[r, g, b]);
+        }
+    }
+    (buf, w, h)
+}
+
+#[test]
+fn per_segment_correction_converges_on_color_blocks() {
+    // Phase 3: color_blocks content (4 flat regions) has segment-able
+    // structure. The default 4-segment config should converge within
+    // the pass budget. We don't assert "fewer bytes than global-q"
+    // because per-segment correction trades off bytes for spatial
+    // accuracy — it's a correctness test, not a parsimony test.
+    let (rgb, w, h) = color_blocks_256();
+    let cfg = LossyConfig::new()
+        .with_method(4)
+        .with_segments(4)
+        .with_target_zensim_target(
+            ZensimTarget::new(82.0)
+                .with_max_overshoot(Some(2.0))
+                .with_max_passes(3),
+        );
+    let (bytes, metrics) = cfg
+        .encode_rgb_with_metrics(&rgb, w, h)
+        .expect("encode failed");
+    assert!(!bytes.is_empty());
+    assert!(metrics.passes_used <= 3);
+    assert!(
+        metrics.achieved_score.is_finite(),
+        "score non-finite: {}",
+        metrics.achieved_score
+    );
+    // Generous band.
+    assert!(
+        metrics.achieved_score >= 75.0,
+        "achieved {} < 75 for target 82 on color_blocks (passes={})",
+        metrics.achieved_score,
+        metrics.passes_used
+    );
+    eprintln!(
+        "color_blocks per-segment: target=82 achieved={:.2} passes={} bytes={}",
+        metrics.achieved_score,
+        metrics.passes_used,
+        bytes.len()
+    );
+}
+
+#[test]
+fn per_segment_disabled_when_one_segment() {
+    // num_segments=1 disables Phase 3 → global-q step takes over.
+    // Convergence should still work; just via a different path.
+    let (rgb, w, h) = color_blocks_256();
+    let cfg = LossyConfig::new()
+        .with_method(4)
+        .with_segments(1)
+        .with_target_zensim_target(
+            ZensimTarget::new(82.0)
+                .with_max_overshoot(Some(2.0))
+                .with_max_passes(3),
+        );
+    let (bytes, metrics) = cfg
+        .encode_rgb_with_metrics(&rgb, w, h)
+        .expect("encode failed");
+    assert!(!bytes.is_empty());
+    assert!(
+        metrics.achieved_score >= 75.0,
+        "achieved {} < 75 for target 82 with segments=1",
+        metrics.achieved_score
+    );
 }
 
 #[test]

--- a/tests/target_zensim.rs
+++ b/tests/target_zensim.rs
@@ -106,6 +106,7 @@ fn strict_undershoot_errors_on_unreachable_target() {
     // ship.
     let target = ZensimTarget::new(99.0)
         .with_max_undershoot(Some(0.5))
+        .with_max_undershoot_ship(None) // disable lenient ship-band undershoot
         .with_max_passes(1);
     let cfg = LossyConfig::new().with_method(4).with_target_zensim(target);
 
@@ -115,6 +116,7 @@ fn strict_undershoot_errors_on_unreachable_target() {
     // check the floor. Use a 2-pass strict run instead.
     let target2 = ZensimTarget::new(99.0)
         .with_max_undershoot(Some(0.5))
+        .with_max_undershoot_ship(None) // disable lenient ship-band undershoot
         .with_max_passes(2);
     let cfg2 = LossyConfig::new()
         .with_method(4)

--- a/tests/target_zensim.rs
+++ b/tests/target_zensim.rs
@@ -43,6 +43,37 @@ fn mixed_content_256() -> (Vec<u8>, u32, u32) {
     (buf, w, h)
 }
 
+/// 256x256 RGBA "photo + alpha" sibling of [`mixed_content_256`]. The
+/// RGB channels are the same band-limited photo facsimile; alpha is a
+/// horizontal gradient (0 at the left edge, 255 at the right edge) so
+/// the encoder has real alpha-channel work to do, but the image still
+/// has plenty of opaque area for the deterministic-noise composite to
+/// land at expected zensim scores.
+fn mixed_content_rgba_256() -> (Vec<u8>, u32, u32) {
+    let w: u32 = 256;
+    let h: u32 = 256;
+    let mut buf = Vec::with_capacity((w * h * 4) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let fx = x as f32 / w as f32;
+            let fy = y as f32 / h as f32;
+            let base_r = 80.0 + 100.0 * fx;
+            let base_g = 100.0 + 80.0 * fy;
+            let base_b = 90.0 + 80.0 * (1.0 - fx);
+            let tex =
+                18.0 * ((fx * 9.0).sin() * (fy * 7.0).cos() + 0.6 * (fx * 17.0 + fy * 11.0).sin());
+            let r = (base_r + tex).clamp(0.0, 255.0) as u8;
+            let g = (base_g + tex * 0.7).clamp(0.0, 255.0) as u8;
+            let b = (base_b - tex * 0.5).clamp(0.0, 255.0) as u8;
+            // Alpha gradient: 64..=255 left-to-right (fully transparent
+            // pixels would defeat the zensim measurement on those pixels).
+            let a = (64.0 + 191.0 * fx).clamp(0.0, 255.0) as u8;
+            buf.extend_from_slice(&[r, g, b, a]);
+        }
+    }
+    (buf, w, h)
+}
+
 /// Smooth gradient — easy content where pass 1 at calibrated q tends to
 /// overshoot the target. Used to exercise the bytes-recovery path.
 fn smooth_gradient_256() -> (Vec<u8>, u32, u32) {
@@ -299,42 +330,47 @@ fn metrics_no_target_helper_exists() {
     let _: ZensimEncodeMetrics = m;
 }
 
-/// `target_zensim` currently requires `PixelLayout::Rgb8`. Setting it
-/// on the config and then submitting a non-RGB8 input must return the
-/// typed [`EncodeError::TargetZensimUnsupportedLayout`] error rather
-/// than silently dropping alpha (or otherwise mutating the input) to
-/// make iteration fire. RGBA support is tracked as a follow-up.
+/// `target_zensim` accepts `PixelLayout::Rgba8` directly: the iteration
+/// loop encodes alpha-bearing WebP and measures via zensim's
+/// deterministic-noise compositing path. Confirms the loop fires,
+/// converges, and emits a non-empty WebP that decodes back as RGBA.
 #[test]
-fn target_zensim_rejects_rgba_input_with_typed_error() {
-    let w: u32 = 32;
-    let h: u32 = 32;
-    let mut rgba = Vec::with_capacity((w * h * 4) as usize);
-    for y in 0..h {
-        for x in 0..w {
-            let r = ((x * 255) / w) as u8;
-            let g = ((y * 255) / h) as u8;
-            rgba.extend_from_slice(&[r, g, 100, 200]);
-        }
-    }
+fn target_zensim_accepts_rgba_input() {
+    use zenwebp::oneshot::decode_rgba;
+
+    let (rgba, w, h) = mixed_content_rgba_256();
     let cfg = LossyConfig::new()
         .with_method(4)
-        .with_target_zensim(ZensimTarget::new(80.0));
-    let result = EncodeRequest::lossy(&cfg, &rgba, PixelLayout::Rgba8, w, h).encode_with_metrics();
-    let at = result.expect_err("expected error for RGBA + target_zensim");
-    let inner: EncodeError = at.into();
-    match inner {
-        EncodeError::TargetZensimUnsupportedLayout(layout) => {
-            assert_eq!(layout, PixelLayout::Rgba8);
-        }
-        other => panic!("expected TargetZensimUnsupportedLayout, got {other:?}"),
-    }
+        .with_target_zensim(ZensimTarget::new(80.0).with_max_passes(3));
+    let (bytes, m) = EncodeRequest::lossy(&cfg, &rgba, PixelLayout::Rgba8, w, h)
+        .encode_with_metrics()
+        .expect("RGBA target_zensim encode should succeed");
+    assert!(!bytes.is_empty(), "encoded bytes should be non-empty");
+    assert!(
+        m.targets_met,
+        "target_zensim should converge for the synthetic photo+alpha image (achieved={}, passes={})",
+        m.achieved_score, m.passes_used,
+    );
+    assert!(
+        m.achieved_score.is_finite(),
+        "achieved_score should be finite once iteration runs",
+    );
+    // Round-trip: the converged bytes must decode back as RGBA at the
+    // original dimensions. This proves the encoder produced an
+    // alpha-bearing WebP, not RGB-only output.
+    let (decoded_rgba, dw, dh) = decode_rgba(&bytes).expect("decode_rgba on converged bytes");
+    assert_eq!((dw, dh), (w, h));
+    assert_eq!(decoded_rgba.len(), (w * h * 4) as usize);
+    let _: ZensimEncodeMetrics = m;
 }
 
-/// Same gate, also verified via the bytes-only entry point. Confirms
-/// the error fires through `EncodeRequest::encode()` (not just
-/// `encode_with_metrics`).
+/// `target_zensim` only accepts `PixelLayout::Rgb8` and `Rgba8`.
+/// Other layouts (BGR / BGRA / ARGB / L8 / LA8 / YUV420) with
+/// `target_zensim` set must surface as the typed
+/// [`EncodeError::TargetZensimUnsupportedLayout`] error, both via the
+/// metrics entry and the bytes-only `encode()` path.
 #[test]
-fn target_zensim_rejects_bgr_input_via_encode_bytes() {
+fn target_zensim_rejects_unsupported_layouts_via_encode_bytes() {
     let w: u32 = 16;
     let h: u32 = 16;
     let bgr = vec![64u8; (w * h * 3) as usize];
@@ -347,6 +383,22 @@ fn target_zensim_rejects_bgr_input_via_encode_bytes() {
     match inner {
         EncodeError::TargetZensimUnsupportedLayout(layout) => {
             assert_eq!(layout, PixelLayout::Bgr8);
+        }
+        other => panic!("expected TargetZensimUnsupportedLayout, got {other:?}"),
+    }
+
+    // Same gate, also verified via the metrics entry on a different
+    // unsupported layout (BGRA).
+    let bgra = vec![64u8; (w * h * 4) as usize];
+    let cfg = LossyConfig::new()
+        .with_method(4)
+        .with_target_zensim(ZensimTarget::new(80.0));
+    let result = EncodeRequest::lossy(&cfg, &bgra, PixelLayout::Bgra8, w, h).encode_with_metrics();
+    let at = result.expect_err("expected error for BGRA + target_zensim");
+    let inner: EncodeError = at.into();
+    match inner {
+        EncodeError::TargetZensimUnsupportedLayout(layout) => {
+            assert_eq!(layout, PixelLayout::Bgra8);
         }
         other => panic!("expected TargetZensimUnsupportedLayout, got {other:?}"),
     }

--- a/tests/target_zensim.rs
+++ b/tests/target_zensim.rs
@@ -8,7 +8,9 @@
 
 #![cfg(feature = "target-zensim")]
 
-use zenwebp::{EncodeRequest, LossyConfig, PixelLayout, ZensimEncodeMetrics, ZensimTarget};
+use zenwebp::{
+    EncodeError, EncodeRequest, LossyConfig, PixelLayout, ZensimEncodeMetrics, ZensimTarget,
+};
 
 /// Build a 256×256 RGB8 mixed-content image: smooth gradient + low-
 /// amplitude band-limited "natural" texture. Designed to give the
@@ -295,4 +297,73 @@ fn metrics_no_target_helper_exists() {
     assert!(m.bytes > 0);
     assert!(m.targets_met);
     let _: ZensimEncodeMetrics = m;
+}
+
+/// `target_zensim` currently requires `PixelLayout::Rgb8`. Setting it
+/// on the config and then submitting a non-RGB8 input must return the
+/// typed [`EncodeError::TargetZensimUnsupportedLayout`] error rather
+/// than silently dropping alpha (or otherwise mutating the input) to
+/// make iteration fire. RGBA support is tracked as a follow-up.
+#[test]
+fn target_zensim_rejects_rgba_input_with_typed_error() {
+    let w: u32 = 32;
+    let h: u32 = 32;
+    let mut rgba = Vec::with_capacity((w * h * 4) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let r = ((x * 255) / w) as u8;
+            let g = ((y * 255) / h) as u8;
+            rgba.extend_from_slice(&[r, g, 100, 200]);
+        }
+    }
+    let cfg = LossyConfig::new()
+        .with_method(4)
+        .with_target_zensim(ZensimTarget::new(80.0));
+    let result = EncodeRequest::lossy(&cfg, &rgba, PixelLayout::Rgba8, w, h).encode_with_metrics();
+    let at = result.expect_err("expected error for RGBA + target_zensim");
+    let inner: EncodeError = at.into();
+    match inner {
+        EncodeError::TargetZensimUnsupportedLayout(layout) => {
+            assert_eq!(layout, PixelLayout::Rgba8);
+        }
+        other => panic!("expected TargetZensimUnsupportedLayout, got {other:?}"),
+    }
+}
+
+/// Same gate, also verified via the bytes-only entry point. Confirms
+/// the error fires through `EncodeRequest::encode()` (not just
+/// `encode_with_metrics`).
+#[test]
+fn target_zensim_rejects_bgr_input_via_encode_bytes() {
+    let w: u32 = 16;
+    let h: u32 = 16;
+    let bgr = vec![64u8; (w * h * 3) as usize];
+    let cfg = LossyConfig::new()
+        .with_method(4)
+        .with_target_zensim(ZensimTarget::new(80.0));
+    let result = EncodeRequest::lossy(&cfg, &bgr, PixelLayout::Bgr8, w, h).encode();
+    let at = result.expect_err("expected error for BGR + target_zensim");
+    let inner: EncodeError = at.into();
+    match inner {
+        EncodeError::TargetZensimUnsupportedLayout(layout) => {
+            assert_eq!(layout, PixelLayout::Bgr8);
+        }
+        other => panic!("expected TargetZensimUnsupportedLayout, got {other:?}"),
+    }
+}
+
+/// Without `target_zensim` set, non-RGB8 inputs continue to work
+/// normally — the new gate must only fire when the user actually
+/// asked for closed-loop iteration. This guards against a regression
+/// where the gate accidentally rejects every non-RGB8 encode.
+#[test]
+fn non_rgb8_works_when_target_zensim_unset() {
+    let w: u32 = 16;
+    let h: u32 = 16;
+    let rgba = vec![128u8; (w * h * 4) as usize];
+    let cfg = LossyConfig::new().with_method(4);
+    let bytes = EncodeRequest::lossy(&cfg, &rgba, PixelLayout::Rgba8, w, h)
+        .encode()
+        .expect("RGBA encode without target_zensim should succeed");
+    assert!(!bytes.is_empty());
 }


### PR DESCRIPTION
Closes #47.

Closed-loop perceptual-quality encode that mirrors the design of zenjpeg's shipped `target-zq` work. Encoder iterates encode → decode → measure (zensim) → adjust until the achieved score lands in the asymmetric tolerance band, with per-bucket starting-q calibration to keep typical content to 1–2 passes.

## Public API

```rust
use zenwebp::{EncodeRequest, LossyConfig, PixelLayout, ZensimTarget};

// Bytes-only — target_zensim is honored transparently when set:
let bytes = EncodeRequest::lossy(&cfg, &rgb, PixelLayout::Rgb8, w, h).encode()?;

// Bytes + metrics:
let cfg = LossyConfig::new()
    .with_method(4)
    .with_target_zensim(80.0); // bare f32, default tolerances/passes

let (bytes, metrics) = EncodeRequest::lossy(&cfg, &rgb, PixelLayout::Rgb8, w, h)
    .encode_with_metrics()?;

// Strict / archival form — pass a ZensimTarget directly (Into<ZensimTarget>):
let cfg = LossyConfig::new().with_target_zensim(
    ZensimTarget::new(85.0)
        .with_max_overshoot(Some(0.5))
        .with_max_undershoot(Some(0.5)) // hard error if missed by >0.5
        .with_max_passes(3),
);
let (bytes, metrics) = EncodeRequest::lossy(&cfg, &rgb, PixelLayout::Rgb8, w, h)
    .encode_with_metrics()?;
```

`ZensimTarget`, `ZensimEncodeMetrics`, `with_target_zensim<T: Into<ZensimTarget>>`, and `EncodeRequest::encode_with_metrics()` are added to the public API. `LossyConfig::encode_rgb` / `encode_rgb_with_metrics` are now `pub(crate)` (the iteration loop's internal entry); the canonical public path is `EncodeRequest`. The iteration loop is gated on the new `target-zensim` cargo feature; the type definitions compile without it (a non-feature build with `target_zensim = Some(_)` falls back to a single encode at the calibrated starting q, matching zenjpeg's behavior).

## Cargo features

- `target-zensim` — enables the iteration loop and pulls in `zensim` for perceptual measurement.
- `ablation` (depends on `target-zensim`) — **dev-only**. Enables runtime ablation toggles read from environment variables (`ZENWEBP_ABLATE_*`, `ZENWEBP_PHASE3_*`) for the `dev/zensim_*.rs` measurement binaries. Production builds (`target-zensim` alone) make zero `std::env::var` calls on the iteration hot path; every `ablate_*()` helper compiles to `const false` and the compiler elides the branches.

## What landed (all three phases)

**Phase 1 — global-q secant + per-bucket calibration (`src/encoder/zensim_target.rs`):**
- `ZensimTarget` (target / max_overshoot / max_undershoot / max_passes) and `ZensimEncodeMetrics` (achieved_score / passes_used / bytes / targets_met) — same shape as zenjpeg's `ZqTarget` / `EncodeMetrics`. Both `#[non_exhaustive]`.
- Per-bucket starting-q tables (Photo / Drawing / Icon, 7 anchors each) keyed off the existing `Preset::Auto` `ImageContentType` classifier.
- One-pair secant step on subsequent passes; `compute_with_ref_and_diffmap` powers Phase 3.
- Strict mode: `max_undershoot=Some(t)` returns `Err` if `achieved < target - t` after the budget.
- `multi_pass_stats=true` is forced on probe encodes (the size-win case the existing flag was specifically scaffolded for in #37).

**Phase 2 — calibration tool (`dev/zensim_calibrate.rs`):**
- Sweeps a corpus across `q ∈ {30..100}`, decodes, measures zensim, finds the median smallest q meeting target ∈ {60, 70, 75, 80, 85, 90, 95} per content bucket. Emits a TSV (block storage, gitignored — `/mnt/v/output/zenwebp/zensim-calibrate/`) plus a Rust const block ready to paste into `zensim_target.rs`.
- Ran against 20 images of CID22 validation (Photo n=12, Drawing n=8). Anchors in `zensim_target.rs` are now the fitted values; Icon stays hand-distilled because the CID22 subset has no ≤128px images.
- Diagnostic harness `dev/zensim_convergence_eval.rs` reports per-image convergence + summary.

**Phase 3 — per-segment diffmap correction:**
- After pass 1, zensim's per-pixel diffmap is aggregated into per-MB means and accumulated into per-segment sums using the encoder's actual k-means `segment_map`. Tighten the worst-mean segment (-1 to -3 quant_index) when score < target; loosen the best-mean segment when overshooting.
- Per-segment overrides plumbed via a new crate-internal `LossyConfig.segment_quant_overrides: Option<[i8; 4]>` and `EncoderParams.segment_quant_overrides`, applied in `analyze_and_assign_segments` after `compute_segment_quant`. `None` (default) keeps non-target-zensim encodes bit-identical.
- Falls back to global-q secant when `num_segments == 1` (segments disabled or simplified down to one).

### Phase 3 segment_map threading

The encoder's per-MB `segment_map` is threaded to the iteration loop via a new `pub(crate) struct EncodeDiagnostics` companion to `EncodeStats` (gated on the `target-zensim` feature). The loop calls `pub(crate) fn EncodeRequest::encode_inner_with_diagnostics()` for every probe; on-wire bytes are byte-identical to the regular `encode()` path. Public `EncodeStats` is untouched and `cargo semver-checks` reports no semver update required (196/196 checks pass).

## Review fixes (latest push, 3 commits on top of `5e1260c`)

- **review #1**: Ablation env-var hatches are now gated behind a new `ablation` cargo feature. Production builds (`target-zensim` alone) get zero env-var reads on the iteration hot path. `ZENWEBP_PHASE3_FINE_GAP` becomes a hardcoded constant (0.5) outside the feature. (`fb45882`)
- **review #2**: Module-level `#![allow(dead_code)]` on `zensim_target.rs` dropped; one remaining real dead_code site (the `Candidate` struct's diagnostic `q` / `seg_overrides` fields) annotated specifically. (`fb45882`)
- **review #3**: `ZensimEncodeMetrics` already had `#[non_exhaustive]`; verified no change required.
- **review #4**: Public surface consolidated. `LossyConfig::encode_rgb` / `encode_rgb_with_metrics` moved to `pub(crate)`. New canonical public entry `EncodeRequest::encode_with_metrics()` returns `(Vec<u8>, ZensimEncodeMetrics)`. The existing `EncodeRequest::encode()` honors `target_zensim` transparently for RGB8 lossy configs. (`3e3b3d5`)
- **review #5**: `with_target_zensim_target` removed; `with_target_zensim<T: Into<ZensimTarget>>(t: T)` is the single builder. `From<f32> for ZensimTarget` lets either form compile. (`3fc951c`)

## Convergence (CID22 validation, 20-image subset, m4)

| Target | Avg passes | Median passes | Median achieved | Targets met | Undershoots | In-band |
|--------|------------|---------------|-----------------|-------------|-------------|---------|
| 80     | 1.90       | 2             | 82.14           | 20/20       | 4/20        | 4/20    |
| 85     | 1.45       | 1             | 85.29           | 20/20 (best-effort) | 7/20 | 12/20 |

`p25` / `p75` passes-to-converge are both 1 or 2 across both runs. No image needed more than 2 passes.

## Phase 3 A/B: real `segment_map` vs 2x2 quadrant proxy

Re-run on real corpora (replaces an earlier synthetic 10-image probe that locked at 99-100 saturation). Per-image TSV in block storage at `/mnt/v/output/zenwebp/zensim-ab/ab_2026-04-26.tsv`; harness is `dev/zensim_ab_quadrant_vs_segmap.rs` (now requires `--features ablation`).

Settings: m4, max_overshoot=1.5, max_passes=3, targets ∈ {75, 80, 85}. Corpora: CID22 validation (41 photos), gb82 (25 photos), gb82-sc (10 screen-content). 76 images × 3 targets = 228 cells per leg. ~1m36s wall-clock.

| corpus | n | avg passes q→s | avg \|d\| q→s | targets_met | undershoots q→s | median bytes q→s |
|---|---|---|---|---|---|---|
| CID22 | 123 | 2.36 → 2.33 | 2.185 → 2.206 | 123/123 both | 34 → 32 | 34494 → 34494 |
| gb82 | 75 | 2.40 → 2.39 | 1.616 → 1.636 | 75/75 both | 20 → 16 | 38386 → 38602 |
| gb82-sc | 30 | 2.87 → 2.87 | 5.754 → 5.678 | 30/30 both | 6 → 6 | 77663 → 78042 |
| **ALL** | **228** | **2.44 → 2.42** | **2.468 → 2.476** | **228/228** | **60 → 54** | **38925 → 39652** |

By target (across all corpora):

| target | n | avg \|d\| q→s | undershoots q→s | win seg/quad/tied |
|---|---|---|---|---|
| 75 | 76 | 2.504 → 2.494 | 26 → 24 | 14/25/37 |
| 80 | 76 | 2.789 → 2.828 | 12 → 9 | 17/29/30 |
| 85 | 76 | 2.109 → 2.104 | 22 → 21 | 12/13/51 |

97 of 228 cells converge in pass 1 before per-segment correction fires (achieved/bytes byte-identical between legs). Restricted to the 131 cells where the two aggregators actually diverged:

| corpus | divergent n | Δ avg \|d\| (s − q) | reading |
|---|---|---|---|
| gb82-sc (screen content) | 17 | **−0.134** | seg tighter (hypothesis directionally validated) |
| gb82 (photos) | 46 | +0.032 | quad tighter |
| CID22 (photos) | 68 | +0.039 | quad tighter |

**Decision: keep the quadrant aggregation reachable under the `ablation` feature via `ZENWEBP_PHASE3_QUADRANT=1`.** Both legs hit `targets_met = 228/228`, so neither regresses. Real `segment_map` (the production default) is correct in spirit and directionally better on screen content; on photo content the simpler quadrant proxy is marginally tighter (+0.03 to +0.04 \|d\|). Production builds always use the real `segment_map` and never read the env var.


## Tests

- `tests/target_zensim.rs` — 8 tests covering convergence, strict mode, bytes recovery, per-segment vs global-q paths, default constructor. Updated to use `EncodeRequest::encode_with_metrics()`.
- All existing `target_size` / `target_psnr` tests stay green.
- `cargo test --release` — 252+ unit tests pass.
- `cargo build --no-default-features` — no_std build still compiles.
- `cargo clippy --all-targets --features target-zensim -- -D warnings` — clean.
- `cargo clippy --all-targets --features "target-zensim ablation" -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `cargo semver-checks check-release --baseline-rev origin/main` — no semver update required.
- `tests/simd_tier_parity.rs` — byte-identical encode guarantee preserved.

## Test plan

- [x] target=80 converges within 2 passes with achieved in [78, 86]
- [x] strict-mode `max_undershoot=Some(0.5)` errors on unreachable target=99
- [x] target=70 on smooth gradient claws back bytes when overshooting
- [x] Phase 3 per-segment correction converges on color_blocks within 3 passes
- [x] `segments=1` falls back to global-q
- [x] Default-feature build untouched (no_std + std)
- [x] Phase 3 uses real k-means segment_map (deviation closed)
- [x] Public API consolidated through `EncodeRequest`; ablation hatches gated behind `ablation` feature
- [ ] CI green across all platforms (will appear once draft is opened)
