### PR TITLE
feat(expert): rename expert→__expert, ExpertKnobs→InternalParams + theory/tests

### DIFF
--- a/.github/actions/checkout-siblings/action.yml
+++ b/.github/actions/checkout-siblings/action.yml
@@ -1,0 +1,27 @@
+name: Checkout sibling repos
+description: |
+  Checks out sibling repositories required by zenwebp's optional path
+  dependencies (zenanalyze, zenpredict). Even though these deps are
+  feature-gated, cargo still parses the manifest and tries to resolve
+  the path entries, so a fresh CI clone fails without the siblings on
+  disk. Pinning the sibling to a known-good ref keeps CI deterministic.
+inputs:
+  zenanalyze-ref:
+    description: Git ref to check out for imazen/zenanalyze.
+    required: false
+    default: main
+runs:
+  using: composite
+  steps:
+    - name: Checkout imazen/zenanalyze
+      uses: actions/checkout@v6
+      with:
+        repository: imazen/zenanalyze
+        ref: ${{ inputs.zenanalyze-ref }}
+        path: __siblings/zenanalyze
+    - name: Move sibling to parent of GITHUB_WORKSPACE
+      shell: bash
+      run: |
+        set -euo pipefail
+        mv __siblings/zenanalyze ../zenanalyze
+        rmdir __siblings || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
             os: windows-11-arm
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/checkout-siblings
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run tests (default features)
@@ -66,6 +67,7 @@ jobs:
             os: windows-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/checkout-siblings
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Check (--features avx512)
@@ -76,6 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/checkout-siblings
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: i686-unknown-linux-gnu
@@ -91,6 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/checkout-siblings
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-wasip1
@@ -103,6 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/checkout-siblings
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: no_std + alloc (no default features)
@@ -143,6 +148,7 @@ jobs:
     # makes any compile-time-guaranteed token panic the test loudly.
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/checkout-siblings
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run SIMD tier parity tests
@@ -153,6 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/checkout-siblings
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run SIMD tier parity tests with AVX-512 dispatch enabled
@@ -165,6 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/checkout-siblings
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -188,6 +196,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/checkout-siblings
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
@@ -199,6 +208,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/checkout-siblings
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,12 @@ jobs:
         with:
           key: cross-i686
       - name: Run tests (i686)
+        # Mount the zenanalyze sibling at /zenanalyze inside the cross
+        # container, since cross sets WORKDIR=/project and `../zenanalyze`
+        # in the manifest resolves to /zenanalyze. Cross 0.2.5 doesn't
+        # auto-mount path deps that live outside the repo dir.
+        env:
+          CROSS_CONTAINER_OPTS: "-v ${{ github.workspace }}/../zenanalyze:/zenanalyze"
         run: cross test --target i686-unknown-linux-gnu
 
   wasm:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,29 @@
   deprecation cycle. The `picker` feature now depends on `__expert`
   (was `expert`).
 
+#### Documentation
+- Expanded per-field theory-of-operation docs on every
+  `InternalParams` field (`partition_limit`, `multi_pass_stats`,
+  `smooth_segment_map`, `sharp_yuv`, `cost_model`): pipeline stage,
+  override rationale, mechanism, and default-derivation. Sourced
+  from VP8 mode-decision, segmentation, sharp-YUV, and cost-model
+  module reads — no new claims that weren't traceable to source.
+
+#### Tests
+- New `encoder::config_expert_tests` module (gated `#[cfg(all(test,
+  feature = "__expert"))]`): per-field permutation tests for all
+  five `InternalParams` knobs, idempotency under repeated apply,
+  combined-knob valid-encode + decode, `Default::default()` =
+  baseline byte-equality, and partial-merge (NOT reset) semantics
+  of `with_internal_params`. 9 new tests covering the bundle's
+  contract.
+
+#### Fixed
+- Cleaned up a `single_match` clippy lint in
+  `dev/build_size_dense_corpus.rs` that was preventing a clean
+  `cargo clippy --all-targets --features __expert -- -D warnings`
+  release-prep run.
+
 ### Version 0.4.4 (2026-04-17)
 
 **Sharp YUV re-enabled, zenyuv integration, streaming push decoder, security fix**

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,16 @@
 
 ### [Unreleased]
 
+#### Changed
+- Renamed `expert` cargo feature → `__expert`, `ExpertKnobs` →
+  `InternalParams`, `LossyConfig::with_expert` →
+  `with_internal_params`. Pure rename; structure (`Option<T>` fields,
+  `#[non_exhaustive]`, `Default`) is unchanged. The double-underscore
+  prefix signals "private — do not depend on this in production code."
+  None of these symbols were in the 0.4.4 published surface, so no
+  deprecation cycle. The `picker` feature now depends on `__expert`
+  (was `expert`).
+
 ### Version 0.4.4 (2026-04-17)
 
 **Sharp YUV re-enabled, zenyuv integration, streaming push decoder, security fix**

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,18 @@
   of `with_internal_params`. 9 new tests covering the bundle's
   contract.
 
+#### Changed (validation surface)
+- Validation for `target_zensim` (the `TargetZensimOutOfRange`,
+  `TargetZensimMaxPassesZero`, `TargetZensimToleranceInvalid`
+  variants, the `TARGET_ZENSIM_RANGE` const, and `target_zensim`'s
+  participation in the `TargetMutuallyExclusive` rule) is now gated
+  behind the `target-zensim` cargo feature. The feature is unstable
+  ML-driven targeting and is not part of published 0.4.4. Once it
+  stabilizes and ships in a published release, `target_zensim`
+  validation will become unconditional. With the feature off,
+  `LossyConfig::validate()` only checks the (`target_size`,
+  `target_psnr`) pair for target-mode exclusivity.
+
 #### Fixed
 - Cleaned up a `single_match` clippy lint in
   `dev/build_size_dense_corpus.rs` that was preventing a clean

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ ablation = ["target-zensim"]
 # with `--features expert` for picker training, codec calibration, or
 # any harness varying these axes. Production codec consumers don't
 # need this.
-expert = []
+__expert = []
 # zenpredict-driven encoder-knob picker. Replaces the bucket-table
 # `content_type_to_tuning` lookup at the `Preset::Auto` site with a
 # baked MLP (ZNPR v2) that argmins over the 6-cell (method × segments)
@@ -151,7 +151,7 @@ expert = []
 # Off by default — production builds use the bucket-table path until
 # A/B vs bucket on held-out corpus shows the picker wins. See
 # src/encoder/picker/.
-picker = ["dep:zenpredict", "analyzer", "expert"]
+picker = ["dep:zenpredict", "analyzer", "__expert"]
 # Enable zennode pipeline node definitions
 # zennode = ["dep:zennode"]
 
@@ -204,7 +204,7 @@ path = "dev/parity_baseline.rs"
 [[example]]
 name = "cost_model_sweep"
 path = "dev/cost_model_sweep.rs"
-required-features = ["expert"]
+required-features = ["__expert"]
 
 [[example]]
 name = "issue44_dump_scores"

--- a/dev/build_size_dense_corpus.rs
+++ b/dev/build_size_dense_corpus.rs
@@ -131,16 +131,14 @@ fn main() {
             let stem = src.file_stem().unwrap().to_string_lossy().to_string();
             let mut written = 0;
             for &target in SIZES {
-                match resize_to(&rgb, w, h, target) {
-                    Some((rgb_r, w_r, h_r)) => {
-                        let dst = out_dir.join(format!("{stem}__sz{target}.png"));
-                        if let Err(e) = save_png_rgb8(&dst, &rgb_r, w_r, h_r) {
-                            eprintln!("  save failed {}: {e}", dst.display());
-                        } else {
-                            written += 1;
-                        }
+                // None case is upscale skipped — no action required.
+                if let Some((rgb_r, w_r, h_r)) = resize_to(&rgb, w, h, target) {
+                    let dst = out_dir.join(format!("{stem}__sz{target}.png"));
+                    if let Err(e) = save_png_rgb8(&dst, &rgb_r, w_r, h_r) {
+                        eprintln!("  save failed {}: {e}", dst.display());
+                    } else {
+                        written += 1;
                     }
-                    None => {} // upscale skipped
                 }
             }
             eprintln!(

--- a/dev/build_size_dense_corpus.rs
+++ b/dev/build_size_dense_corpus.rs
@@ -26,8 +26,8 @@ use zenpng::PngDecodeConfig;
 
 // 20 log-spaced sizes covering tiny → large.
 const SIZES: &[u32] = &[
-    32, 40, 48, 64, 80, 96, 128, 160, 192, 256,
-    320, 384, 512, 640, 768, 1024, 1280, 1536, 2048, 4096,
+    32, 40, 48, 64, 80, 96, 128, 160, 192, 256, 320, 384, 512, 640, 768, 1024, 1280, 1536, 2048,
+    4096,
 ];
 
 fn parse_args() -> (PathBuf, PathBuf) {
@@ -90,8 +90,12 @@ fn save_png_rgb8(path: &PathBuf, rgb: &[u8], w: u32, h: u32) -> Result<(), Strin
     let mut encoder = png::Encoder::new(buf, w, h);
     encoder.set_color(png::ColorType::Rgb);
     encoder.set_depth(png::BitDepth::Eight);
-    let mut writer = encoder.write_header().map_err(|e| format!("png header: {e}"))?;
-    writer.write_image_data(rgb).map_err(|e| format!("png write: {e}"))?;
+    let mut writer = encoder
+        .write_header()
+        .map_err(|e| format!("png header: {e}"))?;
+    writer
+        .write_image_data(rgb)
+        .map_err(|e| format!("png write: {e}"))?;
     Ok(())
 }
 
@@ -114,36 +118,41 @@ fn main() {
     eprintln!("[size_dense] out: {}", out_dir.display());
 
     let started = Instant::now();
-    let total_written: usize = paths.par_iter().map(|src| {
-        let (rgb, w, h) = match load_png_rgb8(src) {
-            Some(t) => t,
-            None => {
-                eprintln!("  load failed: {}", src.display());
-                return 0;
-            }
-        };
-        let stem = src.file_stem().unwrap().to_string_lossy().to_string();
-        let mut written = 0;
-        for &target in SIZES {
-            match resize_to(&rgb, w, h, target) {
-                Some((rgb_r, w_r, h_r)) => {
-                    let dst = out_dir.join(format!("{stem}__sz{target}.png"));
-                    if let Err(e) = save_png_rgb8(&dst, &rgb_r, w_r, h_r) {
-                        eprintln!("  save failed {}: {e}", dst.display());
-                    } else {
-                        written += 1;
-                    }
+    let total_written: usize = paths
+        .par_iter()
+        .map(|src| {
+            let (rgb, w, h) = match load_png_rgb8(src) {
+                Some(t) => t,
+                None => {
+                    eprintln!("  load failed: {}", src.display());
+                    return 0;
                 }
-                None => {} // upscale skipped
+            };
+            let stem = src.file_stem().unwrap().to_string_lossy().to_string();
+            let mut written = 0;
+            for &target in SIZES {
+                match resize_to(&rgb, w, h, target) {
+                    Some((rgb_r, w_r, h_r)) => {
+                        let dst = out_dir.join(format!("{stem}__sz{target}.png"));
+                        if let Err(e) = save_png_rgb8(&dst, &rgb_r, w_r, h_r) {
+                            eprintln!("  save failed {}: {e}", dst.display());
+                        } else {
+                            written += 1;
+                        }
+                    }
+                    None => {} // upscale skipped
+                }
             }
-        }
-        eprintln!(
-            "  {} ({}x{}) → {} variants",
-            src.file_name().unwrap().to_string_lossy(),
-            w, h, written
-        );
-        written
-    }).sum();
+            eprintln!(
+                "  {} ({}x{}) → {} variants",
+                src.file_name().unwrap().to_string_lossy(),
+                w,
+                h,
+                written
+            );
+            written
+        })
+        .sum();
 
     eprintln!(
         "[size_dense] wrote {} variants in {:.1}s",

--- a/dev/zensim_ceiling_probe.rs
+++ b/dev/zensim_ceiling_probe.rs
@@ -22,11 +22,11 @@ const CORPUS: &str = "/mnt/v/output/zenwebp/picker-corpus-size-dense";
 // 5 representative source IDs — mix of numeric-named photos, screenshot,
 // drawing, and special-purpose chart images present in the corpus.
 const IMAGES: &[&str] = &[
-    "1129482",                                  // photo (numeric ID)
-    "pexels-photo-3568544",                     // pexels photo
-    "Beam-Space-Processing",                    // technical/diagram
+    "1129482",                                    // photo (numeric ID)
+    "pexels-photo-3568544",                       // pexels photo
+    "Beam-Space-Processing",                      // technical/diagram
     "Temperament-pie-chart-according-to-Eysenck", // chart / line-art
-    "26103251787_d8635e260d_o",                 // flickr photo
+    "26103251787_d8635e260d_o",                   // flickr photo
 ];
 
 const SIZES: &[u32] = &[32, 48, 64, 96, 128];
@@ -119,10 +119,7 @@ fn main() {
                             );
                         }
                         None => {
-                            eprintln!(
-                                "[fail] {} sz{} q{} m{}",
-                                img_id, size, q, m
-                            );
+                            eprintln!("[fail] {} sz{} q{} m{}", img_id, size, q, m);
                         }
                     }
                 }

--- a/dev/zenwebp_features_replay.rs
+++ b/dev/zenwebp_features_replay.rs
@@ -208,8 +208,8 @@ fn parse_args() -> Args {
 
 #[derive(Clone, Debug)]
 struct Cell {
-    image_path: PathBuf,    // resolved on disk
-    label_path: String,     // logical label written to TSV
+    image_path: PathBuf, // resolved on disk
+    label_path: String,  // logical label written to TSV
     size_class: String,
     width: u32,
     height: u32,
@@ -311,7 +311,10 @@ fn main() {
     eprintln!("[features_replay] output: {}", output.display());
 
     let cells = if let Some(input) = &args.input {
-        eprintln!("[features_replay] mode: features-tsv input={}", input.display());
+        eprintln!(
+            "[features_replay] mode: features-tsv input={}",
+            input.display()
+        );
         read_cells_from_features_tsv(input)
     } else {
         let manifest = args.manifest.as_ref().unwrap();

--- a/dev/zenwebp_pareto.rs
+++ b/dev/zenwebp_pareto.rs
@@ -136,7 +136,8 @@ fn parse_args() -> Args {
     let mut features_only = false;
     let date = ymd_today();
     let mut output = PathBuf::from(format!("benchmarks/zenwebp_pareto_{date}.tsv"));
-    let mut features_output = PathBuf::from(format!("benchmarks/zenwebp_pareto_features_{date}.tsv"));
+    let mut features_output =
+        PathBuf::from(format!("benchmarks/zenwebp_pareto_features_{date}.tsv"));
 
     let mut it = std::env::args().skip(1);
     while let Some(arg) = it.next() {

--- a/dev/zenwebp_picker_sweep.rs
+++ b/dev/zenwebp_picker_sweep.rs
@@ -317,9 +317,8 @@ fn main() {
                             .with_max_passes(2),
                     );
                 let t0 = Instant::now();
-                let r =
-                    EncodeRequest::lossy(&cfg, &img.rgb, PixelLayout::Rgb8, img.w, img.h)
-                        .encode_with_metrics();
+                let r = EncodeRequest::lossy(&cfg, &img.rgb, PixelLayout::Rgb8, img.w, img.h)
+                    .encode_with_metrics();
                 let elapsed_ms = t0.elapsed().as_secs_f64() * 1000.0;
                 match r {
                     Ok((bytes, m)) => {

--- a/examples/api_guide.rs
+++ b/examples/api_guide.rs
@@ -53,8 +53,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_target_psnr(0.0);
     // sharp_yuv is gated behind the `expert` cargo feature — build
     // with `--features expert` to call this knob directly, or use
-    // `LossyConfig::with_expert(ExpertKnobs { sharp_yuv: ..., .. })`.
-    #[cfg(feature = "expert")]
+    // `LossyConfig::with_internal_params(InternalParams { sharp_yuv: ..., .. })`.
+    #[cfg(feature = "__expert")]
     let config = config.with_sharp_yuv(false);
 
     let webp_data =

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -126,8 +126,8 @@ impl WebpEncoderConfig {
     }
 
     /// Enable sharp YUV conversion (lossy only). Expert-only — see
-    /// [`crate::ExpertKnobs`].
-    #[cfg(feature = "expert")]
+    /// [`crate::InternalParams`].
+    #[cfg(feature = "__expert")]
     #[must_use]
     pub fn with_sharp_yuv(mut self, enable: bool) -> Self {
         self.inner = self.inner.with_sharp_yuv(enable);

--- a/src/encoder/api.rs
+++ b/src/encoder/api.rs
@@ -2839,7 +2839,7 @@ mod tests {
     /// (`cost_model`, `smooth_segment_map`, `multi_pass_stats`). Verifies the
     /// fluent setters land the right values on both EncoderConfig and the
     /// LossyConfig variants, and that defaults match libwebp behavior.
-    #[cfg(feature = "expert")]
+    #[cfg(feature = "__expert")]
     #[test]
     fn lossy_config_builder_threads_review_pr37_knobs() {
         use crate::encoder::config::LossyConfig;

--- a/src/encoder/config.rs
+++ b/src/encoder/config.rs
@@ -38,13 +38,13 @@
 
 use crate::{Limits, Preset};
 
-/// How `ExpertKnobs::sharp_yuv` should be applied. Expert-only.
+/// How `InternalParams::sharp_yuv` should be applied. Expert-only.
 ///
 /// `Off` / `On` mirror the boolean form; `Custom(_)` lets the caller
 /// pass a tuned `zenyuv::SharpYuvConfig` (e.g., a non-default chroma
-/// downsample matrix). `None` on `ExpertKnobs::sharp_yuv` means the
+/// downsample matrix). `None` on `InternalParams::sharp_yuv` means the
 /// default `LossyConfig::sharp_yuv` is unchanged.
-#[cfg(feature = "expert")]
+#[cfg(feature = "__expert")]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum SharpYuvSetting {
@@ -63,22 +63,22 @@ pub enum SharpYuvSetting {
 ///
 /// Every field is optional; `None` means "leave the
 /// `LossyConfig`'s existing value alone." Call
-/// [`LossyConfig::with_expert`] to apply the bundle.
+/// [`LossyConfig::with_internal_params`] to apply the bundle.
 ///
 /// ```ignore
-/// use zenwebp::{LossyConfig, ExpertKnobs};
+/// use zenwebp::{LossyConfig, InternalParams};
 /// let cfg = LossyConfig::new()
 ///     .with_quality(75.0)
-///     .with_expert(ExpertKnobs {
+///     .with_internal_params(InternalParams {
 ///         partition_limit: Some(50),
 ///         multi_pass_stats: Some(true),
 ///         ..Default::default()
 ///     });
 /// ```
-#[cfg(feature = "expert")]
+#[cfg(feature = "__expert")]
 #[derive(Clone, Debug, Default)]
 #[non_exhaustive]
-pub struct ExpertKnobs {
+pub struct InternalParams {
     /// VP8 partition exploration cap, `0..=100`. `None` keeps the
     /// existing value; `Some(0)` = full search; `Some(100)` =
     /// aggressive trim. See [`LossyConfig::with_partition_limit`].
@@ -299,8 +299,8 @@ impl LossyConfig {
     /// should use [`Preset::Photo`] (which enables sharp YUV via the
     /// preset's internal config); this setter is for codec calibration
     /// sweeps + the picker training pipeline. See
-    /// [`LossyConfig::with_expert`].
-    #[cfg(feature = "expert")]
+    /// [`LossyConfig::with_internal_params`].
+    #[cfg(feature = "__expert")]
     #[must_use]
     pub fn with_sharp_yuv(mut self, enable: bool) -> Self {
         self.sharp_yuv = if enable {
@@ -312,8 +312,8 @@ impl LossyConfig {
     }
 
     /// Enable sharp YUV with a custom configuration. Expert-only —
-    /// see [`LossyConfig::with_expert`].
-    #[cfg(feature = "expert")]
+    /// see [`LossyConfig::with_internal_params`].
+    #[cfg(feature = "__expert")]
     #[must_use]
     pub fn with_sharp_yuv_config(mut self, config: zenyuv::SharpYuvConfig) -> Self {
         self.sharp_yuv = Some(config);
@@ -351,7 +351,7 @@ impl LossyConfig {
     }
 
     /// Set partition limit to prevent partition 0 overflow on very large images.
-    /// Expert-only — see [`LossyConfig::with_expert`].
+    /// Expert-only — see [`LossyConfig::with_internal_params`].
     ///
     /// Range 0-100. Higher values more aggressively suppress I4 prediction mode,
     /// which uses more bits in partition 0. This trades quality for the ability to
@@ -363,7 +363,7 @@ impl LossyConfig {
     ///
     /// When not set (`None`), the encoder automatically retries with increasing
     /// limits if partition 0 overflows.
-    #[cfg(feature = "expert")]
+    #[cfg(feature = "__expert")]
     #[must_use]
     pub fn with_partition_limit(mut self, limit: u8) -> Self {
         self.partition_limit = Some(limit.min(100));
@@ -371,7 +371,7 @@ impl LossyConfig {
     }
 
     /// Set the cost model used during mode selection and trellis quantization.
-    /// Expert-only — see [`LossyConfig::with_expert`].
+    /// Expert-only — see [`LossyConfig::with_internal_params`].
     ///
     /// - [`CostModel::ZenwebpDefault`](super::api::CostModel::ZenwebpDefault)
     ///   (default): perceptual extensions enabled per method level —
@@ -381,7 +381,7 @@ impl LossyConfig {
     ///   disables those extensions so the encoder matches libwebp's algorithm
     ///   at the same `(quality, method, sns, filter, segments)`. Use this
     ///   when bit-comparing against libwebp output.
-    #[cfg(feature = "expert")]
+    #[cfg(feature = "__expert")]
     #[must_use]
     pub fn with_cost_model(mut self, model: super::api::CostModel) -> Self {
         self.cost_model = model;
@@ -390,11 +390,11 @@ impl LossyConfig {
 
     /// Enable segment-map smoothing (3×3 majority filter on the per-MB
     /// segment map before per-segment quantizer setup). Expert-only —
-    /// see [`LossyConfig::with_expert`].
+    /// see [`LossyConfig::with_internal_params`].
     ///
     /// Equivalent to libwebp's `cwebp -pre 1` (`config->preprocessing & 1`,
     /// `analysis_enc.c:217-218`). Default off, matching libwebp.
-    #[cfg(feature = "expert")]
+    #[cfg(feature = "__expert")]
     #[must_use]
     pub fn with_smooth_segment_map(mut self, on: bool) -> Self {
         self.smooth_segment_map = on;
@@ -403,7 +403,7 @@ impl LossyConfig {
 
     /// Enable a stat-collection encoder pass before the emit pass to refresh
     /// `level_costs` from the observed token distribution. Expert-only —
-    /// see [`LossyConfig::with_expert`].
+    /// see [`LossyConfig::with_internal_params`].
     ///
     /// Roughly **doubles** encode time at m4 in exchange for ~0.1% size
     /// win on photo content. libwebp does this by default; zenwebp keeps
@@ -411,7 +411,7 @@ impl LossyConfig {
     /// loops where the marginal size win amortizes across multiple probes.
     /// Currently only m4 honors this — m5/m6 already saturate per-pass
     /// and multi-pass at those tiers regresses size.
-    #[cfg(feature = "expert")]
+    #[cfg(feature = "__expert")]
     #[must_use]
     pub fn with_multi_pass_stats(mut self, on: bool) -> Self {
         self.multi_pass_stats = on;
@@ -420,7 +420,7 @@ impl LossyConfig {
 
     /// Apply a bundle of expert encoder knobs at once. Expert-only.
     ///
-    /// `ExpertKnobs` collects the advanced calibration axes that
+    /// `InternalParams` collects the advanced calibration axes that
     /// codec consumers don't usually need to set directly:
     /// `partition_limit`, `multi_pass_stats`, `smooth_segment_map`,
     /// `sharp_yuv`, `cost_model`. Each is `Option<_>` so caller only
@@ -429,11 +429,11 @@ impl LossyConfig {
     ///
     /// This is the recommended entry point when building grids for
     /// the picker training pipeline or for codec-calibration sweeps —
-    /// pass an `ExpertKnobs` produced by the picker runtime instead
+    /// pass an `InternalParams` produced by the picker runtime instead
     /// of chaining individual `with_*_expert` setters.
-    #[cfg(feature = "expert")]
+    #[cfg(feature = "__expert")]
     #[must_use]
-    pub fn with_expert(mut self, knobs: ExpertKnobs) -> Self {
+    pub fn with_internal_params(mut self, knobs: InternalParams) -> Self {
         if let Some(pl) = knobs.partition_limit {
             self = self.with_partition_limit(pl);
         }
@@ -800,7 +800,7 @@ impl EncoderConfig {
     /// Set partition limit (lossy only, 0-100). No effect on lossless.
     /// Expert-only — see [`LossyConfig::with_partition_limit`] for
     /// details.
-    #[cfg(feature = "expert")]
+    #[cfg(feature = "__expert")]
     #[must_use]
     pub fn with_partition_limit(mut self, limit: u8) -> Self {
         if let Self::Lossy(cfg) = &mut self {
@@ -852,8 +852,8 @@ impl EncoderConfig {
     }
 
     /// Enable/disable sharp YUV conversion (lossy only). No effect on
-    /// lossless. Expert-only — see [`LossyConfig::with_expert`].
-    #[cfg(feature = "expert")]
+    /// lossless. Expert-only — see [`LossyConfig::with_internal_params`].
+    #[cfg(feature = "__expert")]
     #[must_use]
     pub fn with_sharp_yuv(mut self, enable: bool) -> Self {
         if let Self::Lossy(cfg) = &mut self {

--- a/src/encoder/config.rs
+++ b/src/encoder/config.rs
@@ -79,20 +79,164 @@ pub enum SharpYuvSetting {
 #[derive(Clone, Debug, Default)]
 #[non_exhaustive]
 pub struct InternalParams {
-    /// VP8 partition exploration cap, `0..=100`. `None` keeps the
-    /// existing value; `Some(0)` = full search; `Some(100)` =
-    /// aggressive trim. See [`LossyConfig::with_partition_limit`].
+    /// **Pipeline stage:** intra mode decision (luma 16×16 vs 4×4 selection),
+    /// `vp8/mode_selection.rs:1846,1939–1953`.
+    ///
+    /// **Why override:** the default `None` lets the encoder retry-with-bump
+    /// on partition-0 overflow (large images at high quality where I4 metadata
+    /// blows past VP8's 512 KB partition-0 ceiling). Two cases want an explicit
+    /// value: (a) calibration sweeps that need a fixed mode-decision regime so
+    /// results are reproducible across runs, and (b) very large images where
+    /// you'd rather pre-commit to I16-only than pay the retry cost.
+    ///
+    /// **Mechanism:** the encoder turns `partition_limit` into an additive
+    /// skip-threshold boost in mode selection — at `0` (default) the I4 vs
+    /// I16 decision uses the base distortion threshold (≈211); at `80` the
+    /// threshold is roughly 5× higher, suppressing most I4 attempts; at
+    /// `>=100` the encoder forces I16-only and skips intra-4×4 entirely.
+    /// I4 carries fully-coded sub-block prediction modes in partition 0,
+    /// so suppressing it shrinks partition 0 at a cost in coding efficiency.
+    /// Range clamped to `0..=100` by [`LossyConfig::with_partition_limit`].
+    ///
+    /// **Default-derivation:** `None` ⇒ the encoder runs in **automatic
+    /// retry mode** — first attempt at limit 0, then 30, 60, 100 on
+    /// partition-0 overflow (`vp8/mod.rs:2237–2255`). `Some(v)` disables
+    /// the retry loop and pins the limit at `v`.
+    ///
+    /// See [`LossyConfig::with_partition_limit`].
     pub partition_limit: Option<u8>,
-    /// Toggle the stat-collection extra pass. `None` keeps existing.
+    /// **Pipeline stage:** outer encode driver — wraps the full mode
+    /// decision + transform + quantize + token-record pass
+    /// (`vp8/mod.rs:1080–1152`).
+    ///
+    /// **Why override:** zenwebp's default of one pass is tuned for
+    /// single-shot encodes where ~0.1 % size is not worth doubling
+    /// encode time. Override `Some(true)` when (a) running a
+    /// `target_size` / `target_zensim` search loop where the marginal
+    /// size win amortizes across multiple inner probes, or (b) bench-
+    /// matching libwebp at `cost_model = StrictLibwebpParity` (libwebp
+    /// runs `config->pass = 1` extra pass by default).
+    ///
+    /// **Mechanism:** when set and `method == 4`, the encoder runs the
+    /// full encode twice. The first pass collects token statistics into
+    /// `proba_stats`; between passes it rebuilds `level_costs` from the
+    /// observed token distribution so the second pass's mode selection
+    /// and (m4) trellis use empirical, image-tuned costs rather than
+    /// the static prior. The second pass emits the actual bitstream.
+    /// At m5/m6 trellis already image-adapts via per-pass `proba_stats`
+    /// accumulation, so the second pass measurably regresses size on
+    /// CID22 — the flag is gated to m4 only (`vp8/mod.rs:1103`) and
+    /// silently ignored at other tiers.
+    ///
+    /// **Default-derivation:** `None` ⇒ `false` (single pass — zenwebp's
+    /// speed/size default). Roughly **doubles** encode time at m4 in
+    /// exchange for ~0.1 % size win on photo content.
+    ///
     /// See [`LossyConfig::with_multi_pass_stats`].
     pub multi_pass_stats: Option<bool>,
-    /// Toggle 3×3 majority smoothing on the segment map. `None`
-    /// keeps existing. See [`LossyConfig::with_smooth_segment_map`].
+    /// **Pipeline stage:** segmentation analysis, between k-means
+    /// segment assignment and per-segment quantizer setup
+    /// (`vp8/mod.rs:1715–1721`, `analysis/segment.rs:194`).
+    ///
+    /// **Why override:** k-means on per-MB activity produces a noisy
+    /// segment map for images with fine-grained texture variation
+    /// (line art, foliage, screen content with mixed regions). The
+    /// noise wastes bits on segment-id changes between neighbors and
+    /// can cause visible quantizer-boundary banding. Two override
+    /// cases: (a) preprocessing-equivalence runs vs `cwebp -pre 1`,
+    /// and (b) noisy-segmentation content where the per-MB segment-id
+    /// signaling cost outweighs the per-segment quantizer fit.
+    ///
+    /// **Mechanism:** when on, the encoder applies a 3×3 majority
+    /// filter to the per-MB segment map after assignment: any block
+    /// where ≥5 of 8 neighbors share a segment id is reassigned to
+    /// that majority segment. Borders are not modified. This produces
+    /// fewer but larger contiguous segment regions, which both reduces
+    /// the entropy cost of the segment-id stream and avoids
+    /// quantizer-step artifacts at noisy boundaries.
+    ///
+    /// **Default-derivation:** `None` ⇒ `false` — matches libwebp's
+    /// `config->preprocessing & 1` default (off). Equivalent to
+    /// `cwebp -pre 1` when on. The smoothing only applies when
+    /// `num_segments > 1`; with one segment there's nothing to smooth.
+    ///
+    /// See [`LossyConfig::with_smooth_segment_map`].
     pub smooth_segment_map: Option<bool>,
-    /// Sharp YUV setting. `None` keeps existing.
+    /// **Pipeline stage:** RGB → YUV 4:2:0 conversion, before any VP8
+    /// encoding work (`vp8/mod.rs:1002`,
+    /// `decoder/yuv.rs:716` `convert_image_sharp_yuv_with_config`).
+    ///
+    /// **Why override:** standard 4:2:0 chroma downsampling
+    /// (`AverageBoxFilter`) is fast but loses high-frequency chroma
+    /// detail visible on saturated edges (red text on white, sharp
+    /// color transitions in graphics). Override cases: (a) photos
+    /// with saturated detail where the default produces visible
+    /// chroma bleed, and (b) calibration grids that compare baseline
+    /// vs sharp-yuv to measure the perceptual win. `Custom(_)` is
+    /// for sweeping non-default chroma matrices in the picker
+    /// training pipeline.
+    ///
+    /// **Mechanism:** sharp-YUV iteratively refines the downsampled
+    /// chroma planes by minimizing the error between the upsampled
+    /// reconstruction and the source's true chroma. `Off` uses the
+    /// LossyConfig default (no sharp-yuv). `On` enables iterative
+    /// refinement with `zenyuv::SharpYuvConfig::default()` (BT.709
+    /// matrix, default iteration count). `Custom(cfg)` substitutes a
+    /// caller-supplied config — for example, a non-default
+    /// chroma-downsample kernel or different colorimetry.
+    ///
+    /// **Default-derivation:** `None` on `InternalParams::sharp_yuv`
+    /// leaves `LossyConfig::sharp_yuv` unchanged. The
+    /// `LossyConfig::new()` default is `None` (standard chroma
+    /// downsampling). `Preset::Photo` does **not** auto-enable sharp
+    /// YUV in `LossyConfig::to_params` — it must be set explicitly.
     pub sharp_yuv: Option<SharpYuvSetting>,
-    /// Cost model selection. `None` keeps existing. See
-    /// [`LossyConfig::with_cost_model`].
+    /// **Pipeline stage:** mode selection rate-distortion costs and
+    /// (at m5+) trellis quantization (`encoder/psy.rs:152–206`,
+    /// `analysis/mod.rs:222–243`).
+    ///
+    /// **Why override:** zenwebp's default cost model layers three
+    /// perceptual extensions on top of libwebp's algorithm, tuned
+    /// against butteraugli / SSIMULACRA2. Two cases want
+    /// `StrictLibwebpParity`: (a) bit-comparing zenwebp's output
+    /// against libwebp at the same `(quality, method, sns, filter,
+    /// segments)` tuple to isolate algorithmic-parity bugs from
+    /// perceptual-extension behavior, and (b) workloads where
+    /// libwebp's size/PSNR tradeoff is the explicit target (legacy
+    /// pipelines, regression baselines).
+    ///
+    /// **Mechanism — what each extension changes** (when
+    /// `ZenwebpDefault`, gated by method):
+    ///
+    /// - **PSY_WEIGHT_Y CSF table** (m3+): replaces libwebp's
+    ///   `kWeightY` with an enhanced contrast-sensitivity-function
+    ///   table that has a steeper high-frequency rolloff. The table
+    ///   feeds into TDisto (transformed distortion), so the cost of
+    ///   keeping high-freq luma coefficients goes up — mode selection
+    ///   prefers smoother reconstructions where the eye won't notice.
+    /// - **SATD masking-alpha blend** (m4+, gated by `sns_strength > 0`):
+    ///   blends the per-MB DCT alpha with a SATD-derived
+    ///   masking-alpha so segmentation places highly-textured blocks
+    ///   into segments with coarser quantizers (texture masks
+    ///   quantization noise). `analysis/mod.rs:239–243` skips the
+    ///   blend under `StrictLibwebpParity`.
+    /// - **JND coefficient zeroing** (m5+): scales per-position
+    ///   just-noticeable-difference thresholds by quantizer and zeros
+    ///   any DCT coefficient below threshold during trellis. Saves
+    ///   bits on perceptually-invisible coefficients without harming
+    ///   reconstruction quality. Under `StrictLibwebpParity`
+    ///   `jnd_threshold_y/uv` stay at zero so no coefficients get
+    ///   zeroed by this path.
+    ///
+    /// `StrictLibwebpParity` returns the default `PsyConfig` early
+    /// (`psy.rs:161–163`), which means **all three extensions are
+    /// disabled regardless of method**.
+    ///
+    /// **Default-derivation:** `None` on `InternalParams::cost_model`
+    /// leaves `LossyConfig::cost_model` unchanged. The
+    /// `LossyConfig::new()` default is `CostModel::ZenwebpDefault`.
+    ///
+    /// See [`LossyConfig::with_cost_model`].
     pub cost_model: Option<super::api::CostModel>,
 }
 

--- a/src/encoder/config.rs
+++ b/src/encoder/config.rs
@@ -1324,10 +1324,12 @@ fn encode_single_pass(
 // validate() — opt-in fail-fast checks. Encode paths still clamp.
 // ============================================================================
 
+#[cfg(feature = "target-zensim")]
+use super::validation::TARGET_ZENSIM_RANGE;
 use super::validation::{
     self as v, ALPHA_QUALITY_RANGE, FILTER_SHARPNESS_RANGE, FILTER_STRENGTH_RANGE, METHOD_RANGE,
     NEAR_LOSSLESS_RANGE, PARTITION_LIMIT_RANGE, SEGMENTS_RANGE, SNS_STRENGTH_RANGE,
-    TARGET_ZENSIM_RANGE, ValidationError,
+    ValidationError,
 };
 
 impl LossyConfig {
@@ -1335,9 +1337,10 @@ impl LossyConfig {
     /// this config without encoding anything.
     ///
     /// Returns `Ok(())` if every field is in range and the
-    /// `target_size` / `target_psnr` / `target_zensim` exclusivity rule
-    /// is honoured; otherwise returns the first offending
-    /// [`ValidationError`].
+    /// target-mode exclusivity rule (at most one of `target_size`,
+    /// `target_psnr`, and — when the unstable `target-zensim` cargo
+    /// feature is enabled — `target_zensim`) is honoured; otherwise
+    /// returns the first offending [`ValidationError`].
     ///
     /// Existing encode entry points (`EncodeRequest::encode` etc.)
     /// continue to clamp out-of-range values for backwards
@@ -1402,6 +1405,7 @@ impl LossyConfig {
             });
         }
 
+        #[cfg(feature = "target-zensim")]
         if let Some(t) = self.target_zensim {
             if !t.target.is_finite() || !TARGET_ZENSIM_RANGE.contains(&t.target) {
                 return Err(ValidationError::TargetZensimOutOfRange {
@@ -1438,31 +1442,33 @@ impl LossyConfig {
             });
         }
 
-        // Cross-param: at most one target mode active. `target_size==0`,
-        // `target_psnr==0.0`, and `target_zensim==None` all mean "disabled".
+        // Cross-param: at most one target mode active. `target_size==0`
+        // and `target_psnr==0.0` mean "disabled". When the
+        // `target-zensim` cargo feature is enabled, `target_zensim`
+        // joins the same exclusivity rule (`None` = disabled).
         let size_set = self.target_size != 0;
         let psnr_set = self.target_psnr != 0.0;
-        let zensim_set = self.target_zensim.is_some();
-        match (size_set, psnr_set, zensim_set) {
-            (true, true, _) => {
-                return Err(ValidationError::TargetMutuallyExclusive {
-                    first: "target_size",
-                    second: "target_psnr",
-                });
-            }
-            (true, _, true) => {
+        if size_set && psnr_set {
+            return Err(ValidationError::TargetMutuallyExclusive {
+                first: "target_size",
+                second: "target_psnr",
+            });
+        }
+        #[cfg(feature = "target-zensim")]
+        {
+            let zensim_set = self.target_zensim.is_some();
+            if size_set && zensim_set {
                 return Err(ValidationError::TargetMutuallyExclusive {
                     first: "target_size",
                     second: "target_zensim",
                 });
             }
-            (_, true, true) => {
+            if psnr_set && zensim_set {
                 return Err(ValidationError::TargetMutuallyExclusive {
                     first: "target_psnr",
                     second: "target_zensim",
                 });
             }
-            _ => {}
         }
 
         Ok(())

--- a/src/encoder/config.rs
+++ b/src/encoder/config.rs
@@ -1319,3 +1319,218 @@ fn encode_single_pass(
         Err(at_err) => Err(at_err.decompose().0),
     }
 }
+
+// ============================================================================
+// validate() — opt-in fail-fast checks. Encode paths still clamp.
+// ============================================================================
+
+use super::validation::{
+    self as v, ALPHA_QUALITY_RANGE, FILTER_SHARPNESS_RANGE, FILTER_STRENGTH_RANGE, METHOD_RANGE,
+    NEAR_LOSSLESS_RANGE, PARTITION_LIMIT_RANGE, SEGMENTS_RANGE, SNS_STRENGTH_RANGE,
+    TARGET_ZENSIM_RANGE, ValidationError,
+};
+
+impl LossyConfig {
+    /// Check every documented range and cross-parameter invariant on
+    /// this config without encoding anything.
+    ///
+    /// Returns `Ok(())` if every field is in range and the
+    /// `target_size` / `target_psnr` / `target_zensim` exclusivity rule
+    /// is honoured; otherwise returns the first offending
+    /// [`ValidationError`].
+    ///
+    /// Existing encode entry points (`EncodeRequest::encode` etc.)
+    /// continue to clamp out-of-range values for backwards
+    /// compatibility — `validate()` is opt-in for callers that want a
+    /// fail-fast signal. Typical usage:
+    ///
+    /// ```
+    /// use zenwebp::LossyConfig;
+    /// let cfg = LossyConfig::new().with_quality(80.0);
+    /// cfg.validate().unwrap();
+    /// ```
+    ///
+    /// Note that `with_*` setters already clamp, so a
+    /// builder-constructed config will pass validation. The interesting
+    /// failure cases are direct struct construction (allowed by the
+    /// public fields) and the cross-parameter target-exclusivity
+    /// invariant, which no setter can catch.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        v::check_quality(self.quality)?;
+        v::check_method(self.method)?;
+        v::check_alpha_quality(self.alpha_quality)?;
+        v::check_target_psnr(self.target_psnr)?;
+
+        if let Some(s) = self.sns_strength
+            && !SNS_STRENGTH_RANGE.contains(&s)
+        {
+            return Err(ValidationError::SnsStrengthOutOfRange {
+                value: s,
+                valid: SNS_STRENGTH_RANGE,
+            });
+        }
+        if let Some(s) = self.filter_strength
+            && !FILTER_STRENGTH_RANGE.contains(&s)
+        {
+            return Err(ValidationError::FilterStrengthOutOfRange {
+                value: s,
+                valid: FILTER_STRENGTH_RANGE,
+            });
+        }
+        if let Some(s) = self.filter_sharpness
+            && !FILTER_SHARPNESS_RANGE.contains(&s)
+        {
+            return Err(ValidationError::FilterSharpnessOutOfRange {
+                value: s,
+                valid: FILTER_SHARPNESS_RANGE,
+            });
+        }
+        if let Some(s) = self.segments
+            && !SEGMENTS_RANGE.contains(&s)
+        {
+            return Err(ValidationError::SegmentsOutOfRange {
+                value: s,
+                valid: SEGMENTS_RANGE,
+            });
+        }
+        if let Some(p) = self.partition_limit
+            && !PARTITION_LIMIT_RANGE.contains(&p)
+        {
+            return Err(ValidationError::PartitionLimitOutOfRange {
+                value: p,
+                valid: PARTITION_LIMIT_RANGE,
+            });
+        }
+
+        if let Some(t) = self.target_zensim {
+            if !t.target.is_finite() || !TARGET_ZENSIM_RANGE.contains(&t.target) {
+                return Err(ValidationError::TargetZensimOutOfRange {
+                    value: t.target,
+                    valid: TARGET_ZENSIM_RANGE,
+                });
+            }
+            if t.max_passes == 0 {
+                return Err(ValidationError::TargetZensimMaxPassesZero {
+                    value: t.max_passes,
+                });
+            }
+            for (field, opt) in [
+                ("max_overshoot", t.max_overshoot),
+                ("max_undershoot", t.max_undershoot),
+                ("max_undershoot_ship", t.max_undershoot_ship),
+            ] {
+                if let Some(val) = opt
+                    && (!val.is_finite() || val < 0.0)
+                {
+                    return Err(ValidationError::TargetZensimToleranceInvalid {
+                        field,
+                        value: val,
+                    });
+                }
+            }
+        }
+
+        if let Some(cfg) = self.sharp_yuv
+            && (!cfg.convergence_threshold.is_finite() || cfg.convergence_threshold < 0.0)
+        {
+            return Err(ValidationError::SharpYuvConvergenceThresholdInvalid {
+                value: cfg.convergence_threshold,
+            });
+        }
+
+        // Cross-param: at most one target mode active. `target_size==0`,
+        // `target_psnr==0.0`, and `target_zensim==None` all mean "disabled".
+        let size_set = self.target_size != 0;
+        let psnr_set = self.target_psnr != 0.0;
+        let zensim_set = self.target_zensim.is_some();
+        match (size_set, psnr_set, zensim_set) {
+            (true, true, _) => {
+                return Err(ValidationError::TargetMutuallyExclusive {
+                    first: "target_size",
+                    second: "target_psnr",
+                });
+            }
+            (true, _, true) => {
+                return Err(ValidationError::TargetMutuallyExclusive {
+                    first: "target_size",
+                    second: "target_zensim",
+                });
+            }
+            (_, true, true) => {
+                return Err(ValidationError::TargetMutuallyExclusive {
+                    first: "target_psnr",
+                    second: "target_zensim",
+                });
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+}
+
+impl LosslessConfig {
+    /// Check every documented range on this config without encoding.
+    ///
+    /// See [`LossyConfig::validate`] for the rationale and contract;
+    /// the lossless variant has no cross-parameter invariants.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        v::check_quality(self.quality)?;
+        v::check_method(self.method)?;
+        v::check_alpha_quality(self.alpha_quality)?;
+        if !NEAR_LOSSLESS_RANGE.contains(&self.near_lossless) {
+            return Err(ValidationError::NearLosslessOutOfRange {
+                value: self.near_lossless,
+                valid: NEAR_LOSSLESS_RANGE,
+            });
+        }
+        let _ = ALPHA_QUALITY_RANGE; // keep import live across cfg combinations
+        let _ = METHOD_RANGE;
+        Ok(())
+    }
+}
+
+impl EncoderConfig {
+    /// Validate the underlying [`LossyConfig`] or [`LosslessConfig`].
+    ///
+    /// See [`LossyConfig::validate`] / [`LosslessConfig::validate`] for
+    /// the field-by-field contract.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        match self {
+            Self::Lossy(c) => c.validate(),
+            Self::Lossless(c) => c.validate(),
+        }
+    }
+}
+
+#[cfg(feature = "__expert")]
+impl InternalParams {
+    /// Validate every field that's `Some` on this expert-knob bundle.
+    ///
+    /// Returns `Ok(())` for an all-`None` bundle. For each set field,
+    /// applies the same range check that
+    /// [`LossyConfig::validate`] would after the bundle is folded in
+    /// via [`LossyConfig::with_internal_params`]. The `cost_model` and
+    /// `sharp_yuv` enum variants are well-formed by construction
+    /// (Rust's type system guarantees it); only their numeric
+    /// payloads (e.g., `SharpYuvConfig::convergence_threshold`) need
+    /// runtime checks.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        if let Some(p) = self.partition_limit
+            && !PARTITION_LIMIT_RANGE.contains(&p)
+        {
+            return Err(ValidationError::PartitionLimitOutOfRange {
+                value: p,
+                valid: PARTITION_LIMIT_RANGE,
+            });
+        }
+        if let Some(SharpYuvSetting::Custom(cfg)) = &self.sharp_yuv
+            && (!cfg.convergence_threshold.is_finite() || cfg.convergence_threshold < 0.0)
+        {
+            return Err(ValidationError::SharpYuvConvergenceThresholdInvalid {
+                value: cfg.convergence_threshold,
+            });
+        }
+        Ok(())
+    }
+}

--- a/src/encoder/config_expert_tests.rs
+++ b/src/encoder/config_expert_tests.rs
@@ -1,0 +1,367 @@
+//! Permutation tests for the `__expert`-gated `InternalParams` knob bundle.
+//!
+//! Each per-field test confirms that flipping that field away from the
+//! `LossyConfig` default produces an encode that is observably different
+//! from the baseline (different bytes, or — for cost-equivalent
+//! configurations — at least no panics + decodable output).
+//!
+//! These tests use a small synthetic RGB image with mixed content
+//! (gradient + textured + flat regions) so all five axes get measurable
+//! traction. Encodes use `quality(75) + method(4)` because m4 is where
+//! `multi_pass_stats` is gated to take effect.
+//!
+//! Gated `#[cfg(all(test, feature = "__expert"))]` because the bundle
+//! itself only exists under that feature.
+
+#![cfg(all(test, feature = "__expert"))]
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+use super::api::{CostModel, EncodeRequest, PixelLayout};
+use super::config::{InternalParams, LossyConfig, SharpYuvSetting};
+
+const W: u32 = 192;
+const H: u32 = 144;
+
+/// Build a deterministic RGB8 image with strong per-block activity
+/// variation so segmentation produces multiple segments AND noisy
+/// segment boundaries (the prerequisite for smooth_segment_map to
+/// actually mutate the map). The image has ~12×9 macroblocks worth of
+/// regions: a fine-grain noise patch, a smooth gradient, a solid band,
+/// and isolated single-MB anomalies that the 3×3 majority filter must
+/// flip. Each region is sized so segmentation k-means lands it in a
+/// distinct cluster.
+fn synthetic_rgb() -> Vec<u8> {
+    let mut buf = Vec::with_capacity((W * H * 3) as usize);
+    // Simple deterministic LCG for repeatable noise.
+    let mut state: u32 = 0x1234_5678;
+    let mut rng = || {
+        state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+        (state >> 16) as u8
+    };
+    // Pre-roll noise into a buffer so the value at (x,y) is deterministic.
+    let noise: Vec<u8> = (0..(W * H * 3)).map(|_| rng()).collect();
+
+    for y in 0..H {
+        for x in 0..W {
+            let mb_x = x / 16;
+            let mb_y = y / 16;
+            // Region selector by macroblock position — gives the encoder
+            // chunky regions that k-means can cluster on.
+            let band = if mb_y < 3 {
+                // Top: noisy textured region (high alpha → high-quant segment).
+                let i = ((y * W + x) * 3) as usize;
+                [noise[i], noise[i + 1], noise[i + 2]]
+            } else if mb_y < 5 {
+                // Smooth gradient (low alpha → low-quant segment).
+                let r = (x * 255 / W) as u8;
+                let g = (y * 255 / H) as u8;
+                [r, g, 128]
+            } else if mb_y < 7 {
+                // Mid-frequency checker — distinct activity from above two.
+                let on = ((x / 4) ^ (y / 4)) & 1 != 0;
+                if on { [240, 30, 30] } else { [20, 200, 220] }
+            } else {
+                // Bottom solid bands with single-MB anomalies — these
+                // isolated MBs are exactly what 3×3 majority filtering
+                // reassigns when smooth_segment_map=true.
+                let anomaly = (mb_x % 4 == 0) && (mb_y == 8);
+                if anomaly {
+                    let i = ((y * W + x) * 3) as usize;
+                    [noise[i], noise[i + 1], noise[i + 2]]
+                } else {
+                    [128, 128, 128]
+                }
+            };
+            buf.extend_from_slice(&band);
+        }
+    }
+    buf
+}
+
+fn encode(cfg: &LossyConfig, pixels: &[u8]) -> Vec<u8> {
+    EncodeRequest::lossy(cfg, pixels, PixelLayout::Rgb8, W, H)
+        .encode()
+        .expect("encode succeeded")
+}
+
+fn baseline_cfg() -> LossyConfig {
+    LossyConfig::new().with_quality(75.0).with_method(4)
+}
+
+// ----------------------------------------------------------------------
+// (a) Per-field tests — each non-default value differs from the baseline
+//     bytes, OR (where the knob is intentionally cost-neutral on the
+//     synthetic input) at least produces a decodable result.
+// ----------------------------------------------------------------------
+
+/// `partition_limit` ∈ {0, 50, 100} — at 100 the encoder forces I16-only,
+/// which yields different bytes from the default at quality 75.
+#[test]
+fn partition_limit_variants_produce_distinct_bytes() {
+    let rgb = synthetic_rgb();
+    let baseline = encode(&baseline_cfg(), &rgb);
+
+    let with_50 = encode(
+        &baseline_cfg().with_internal_params(InternalParams {
+            partition_limit: Some(50),
+            ..Default::default()
+        }),
+        &rgb,
+    );
+    let with_100 = encode(
+        &baseline_cfg().with_internal_params(InternalParams {
+            partition_limit: Some(100),
+            ..Default::default()
+        }),
+        &rgb,
+    );
+
+    // limit=100 forces I16-only; on this content it must differ from default.
+    assert_ne!(
+        baseline, with_100,
+        "partition_limit=100 should change emitted bytes vs default"
+    );
+    // limit=50 raises the I4 skip-threshold ~5x — on a 96x64 mixed image
+    // mode-decision picks differ; encoded bytes must differ from at least
+    // one of {baseline, with_100}.
+    assert!(
+        with_50 != baseline || with_50 != with_100,
+        "partition_limit=50 should produce a distinct intermediate result"
+    );
+    // All three decode without panicking.
+    for bytes in [&baseline, &with_50, &with_100] {
+        let _ = webp::Decoder::new(bytes).decode().expect("decodable");
+    }
+}
+
+/// `multi_pass_stats: true` should change emitted bytes at m4 because the
+/// second pass uses image-tuned `level_costs`.
+#[test]
+fn multi_pass_stats_toggle_changes_bytes() {
+    let rgb = synthetic_rgb();
+    let baseline = encode(&baseline_cfg(), &rgb);
+    let two_pass = encode(
+        &baseline_cfg().with_internal_params(InternalParams {
+            multi_pass_stats: Some(true),
+            ..Default::default()
+        }),
+        &rgb,
+    );
+    assert_ne!(
+        baseline, two_pass,
+        "multi_pass_stats=true at m4 must change emitted bytes"
+    );
+}
+
+/// `smooth_segment_map: true` should change emitted bytes when
+/// `num_segments > 1`. Default `num_segments` resolves to 4 (no preset).
+#[test]
+fn smooth_segment_map_toggle_changes_bytes() {
+    let rgb = synthetic_rgb();
+    let baseline = encode(&baseline_cfg(), &rgb);
+    let smoothed = encode(
+        &baseline_cfg().with_internal_params(InternalParams {
+            smooth_segment_map: Some(true),
+            ..Default::default()
+        }),
+        &rgb,
+    );
+    assert_ne!(
+        baseline, smoothed,
+        "smooth_segment_map=true must change emitted bytes on multi-segment input"
+    );
+}
+
+/// `sharp_yuv` Off / On / Custom — On runs the iterative chroma refinement,
+/// which produces a different YUV plane and therefore different bytes.
+#[test]
+fn sharp_yuv_variants_encode() {
+    let rgb = synthetic_rgb();
+    let off = encode(
+        &baseline_cfg().with_internal_params(InternalParams {
+            sharp_yuv: Some(SharpYuvSetting::Off),
+            ..Default::default()
+        }),
+        &rgb,
+    );
+    let on = encode(
+        &baseline_cfg().with_internal_params(InternalParams {
+            sharp_yuv: Some(SharpYuvSetting::On),
+            ..Default::default()
+        }),
+        &rgb,
+    );
+    let custom = encode(
+        &baseline_cfg().with_internal_params(InternalParams {
+            sharp_yuv: Some(SharpYuvSetting::Custom(zenyuv::SharpYuvConfig {
+                max_iterations: 4,
+                convergence_threshold: 0.05,
+                refine_y: false,
+            })),
+            ..Default::default()
+        }),
+        &rgb,
+    );
+    // Off matches LossyConfig default (no sharp YUV) — so equals baseline.
+    let baseline = encode(&baseline_cfg(), &rgb);
+    assert_eq!(
+        off, baseline,
+        "sharp_yuv=Off must match LossyConfig default"
+    );
+    assert_ne!(on, baseline, "sharp_yuv=On must change emitted bytes");
+    assert_ne!(
+        custom, on,
+        "Custom sharp_yuv config must differ from On default"
+    );
+    // All decode.
+    for bytes in [&off, &on, &custom] {
+        let _ = webp::Decoder::new(bytes).decode().expect("decodable");
+    }
+}
+
+/// `cost_model` ZenwebpDefault vs StrictLibwebpParity — at m4 the
+/// PSY_WEIGHT_Y CSF table swap and the SATD masking-alpha blend gate are
+/// active, so emitted bytes must differ on textured content.
+#[test]
+fn cost_model_variants_differ_at_m4() {
+    let rgb = synthetic_rgb();
+    let zw = encode(
+        &baseline_cfg().with_internal_params(InternalParams {
+            cost_model: Some(CostModel::ZenwebpDefault),
+            ..Default::default()
+        }),
+        &rgb,
+    );
+    let parity = encode(
+        &baseline_cfg().with_internal_params(InternalParams {
+            cost_model: Some(CostModel::StrictLibwebpParity),
+            ..Default::default()
+        }),
+        &rgb,
+    );
+    let baseline = encode(&baseline_cfg(), &rgb);
+    assert_eq!(
+        zw, baseline,
+        "cost_model=ZenwebpDefault must match LossyConfig default"
+    );
+    assert_ne!(
+        zw, parity,
+        "cost_model=StrictLibwebpParity must change emitted bytes vs zenwebp default"
+    );
+}
+
+// ----------------------------------------------------------------------
+// (b) Idempotency — applying the same InternalParams twice equals applying
+//     once. `with_internal_params` is partial-merge: each `Some` field
+//     overrides, each `None` preserves. Two identical applications hit
+//     the same fields with the same values, so the result is bit-equal.
+// ----------------------------------------------------------------------
+
+#[test]
+fn with_internal_params_is_idempotent() {
+    let rgb = synthetic_rgb();
+    let knobs = InternalParams {
+        partition_limit: Some(40),
+        multi_pass_stats: Some(true),
+        smooth_segment_map: Some(true),
+        sharp_yuv: Some(SharpYuvSetting::On),
+        cost_model: Some(CostModel::StrictLibwebpParity),
+    };
+    let once = encode(&baseline_cfg().with_internal_params(knobs.clone()), &rgb);
+    let twice = encode(
+        &baseline_cfg()
+            .with_internal_params(knobs.clone())
+            .with_internal_params(knobs),
+        &rgb,
+    );
+    assert_eq!(
+        once, twice,
+        "applying the same InternalParams twice must be idempotent"
+    );
+}
+
+// ----------------------------------------------------------------------
+// (c) Combined — all five fields set produces a valid, non-empty,
+//     decodable WebP.
+// ----------------------------------------------------------------------
+
+#[test]
+fn all_fields_combined_produces_valid_encode() {
+    let rgb = synthetic_rgb();
+    let cfg = baseline_cfg().with_internal_params(InternalParams {
+        partition_limit: Some(60),
+        multi_pass_stats: Some(true),
+        smooth_segment_map: Some(true),
+        sharp_yuv: Some(SharpYuvSetting::On),
+        cost_model: Some(CostModel::StrictLibwebpParity),
+    });
+    let bytes = encode(&cfg, &rgb);
+    assert!(!bytes.is_empty(), "combined encode produced empty output");
+    let decoded = webp::Decoder::new(&bytes).decode().expect("decodable");
+    // The decoded image must have the original dimensions.
+    assert_eq!(decoded.width(), W);
+    assert_eq!(decoded.height(), H);
+}
+
+// ----------------------------------------------------------------------
+// (d) Default = baseline — `InternalParams::default()` is all-None, which
+//     leaves every LossyConfig field unchanged. Encoded bytes must match
+//     a fresh LossyConfig::new() byte-for-byte.
+// ----------------------------------------------------------------------
+
+#[test]
+fn default_internal_params_equals_baseline() {
+    let rgb = synthetic_rgb();
+    let baseline = encode(&baseline_cfg(), &rgb);
+    let with_default = encode(
+        &baseline_cfg().with_internal_params(InternalParams::default()),
+        &rgb,
+    );
+    assert_eq!(
+        baseline, with_default,
+        "InternalParams::default() must be a no-op on a fresh LossyConfig"
+    );
+}
+
+// ----------------------------------------------------------------------
+// (e) Reset semantics — `with_internal_params` is partial-merge, NOT
+//     wholesale-replace. Re-applying `Default` after setting a field
+//     does NOT clear that field. We assert the documented behavior so
+//     the partial-merge contract is locked in.
+// ----------------------------------------------------------------------
+
+#[test]
+fn with_internal_params_is_partial_merge_not_reset() {
+    let rgb = synthetic_rgb();
+    let baseline = encode(&baseline_cfg(), &rgb);
+    // Set smooth_segment_map=true, then re-apply Default (all None).
+    let merged = encode(
+        &baseline_cfg()
+            .with_internal_params(InternalParams {
+                smooth_segment_map: Some(true),
+                ..Default::default()
+            })
+            .with_internal_params(InternalParams::default()),
+        &rgb,
+    );
+    // Default's None-on-smooth_segment_map preserves the previously-set
+    // `true`, so the merged encode must NOT match the baseline.
+    assert_ne!(
+        baseline, merged,
+        "Re-applying Default must not reset previously-set fields (partial merge)"
+    );
+    // It must equal the encode that only sets smooth_segment_map=true.
+    let single = encode(
+        &baseline_cfg().with_internal_params(InternalParams {
+            smooth_segment_map: Some(true),
+            ..Default::default()
+        }),
+        &rgb,
+    );
+    assert_eq!(
+        merged, single,
+        "Re-applying Default after a real set must equal a single set"
+    );
+}

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -49,6 +49,8 @@ mod residual_cost;
 pub mod tables;
 /// Trellis quantization for RD-optimized coefficient selection
 mod trellis;
+/// Configuration validation (opt-in fail-fast checks).
+pub mod validation;
 mod vec_writer;
 /// VP8 lossy encoder implementation.
 #[doc(hidden)]
@@ -75,6 +77,7 @@ pub use api::{
 pub use config::{EncoderConfig, LosslessConfig, LossyConfig};
 #[cfg(feature = "__expert")]
 pub use config::{InternalParams, SharpYuvSetting};
+pub use validation::ValidationError;
 #[doc(hidden)]
 pub use vp8l::{Vp8lConfig, Vp8lQuality, encode_vp8l};
 #[cfg(feature = "ablation")]

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -31,6 +31,8 @@ mod arithmetic;
 /// Type-safe encoder configuration.
 #[doc(hidden)]
 pub mod config;
+#[cfg(all(test, feature = "__expert"))]
+mod config_expert_tests;
 /// Rate-distortion cost estimation.
 #[doc(hidden)]
 pub mod cost;

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -71,8 +71,8 @@ pub use api::{
     ImageMetadata, NoProgress, PixelLayout, Preset,
 };
 pub use config::{EncoderConfig, LosslessConfig, LossyConfig};
-#[cfg(feature = "expert")]
-pub use config::{ExpertKnobs, SharpYuvSetting};
+#[cfg(feature = "__expert")]
+pub use config::{InternalParams, SharpYuvSetting};
 #[doc(hidden)]
 pub use vp8l::{Vp8lConfig, Vp8lQuality, encode_vp8l};
 #[cfg(feature = "ablation")]

--- a/src/encoder/picker/runtime.rs
+++ b/src/encoder/picker/runtime.rs
@@ -87,8 +87,7 @@ const _: () = {
 #[repr(C, align(16))]
 struct AlignedModel<const N: usize>([u8; N]);
 
-const MODEL_BYTES_RAW: &[u8] =
-    &AlignedModel(*include_bytes!("zenwebp_picker_v0.1.bin")).0;
+const MODEL_BYTES_RAW: &[u8] = &AlignedModel(*include_bytes!("zenwebp_picker_v0.1.bin")).0;
 
 /// What the codec gets back when the picker succeeds. The four-tuple
 /// matches the existing `content_type_to_tuning` shape, plus the
@@ -128,12 +127,7 @@ pub enum PickError {
 ///   = `2 * N_FEAT_COLS + 10` floats.
 /// Order MUST match the Python `train_hybrid.py` builder. Drift is
 /// caught at load time via `from_bytes_with_schema`.
-fn engineered_features(
-    raw_feats: &[f32],
-    width: u32,
-    height: u32,
-    target_zensim: f32,
-) -> Vec<f32> {
+fn engineered_features(raw_feats: &[f32], width: u32, height: u32, target_zensim: f32) -> Vec<f32> {
     debug_assert_eq!(
         raw_feats.len(),
         FEAT_COLS.len(),
@@ -145,10 +139,10 @@ fn engineered_features(
 
     // size_class one-hot — must match Python `SIZE_INDEX` ordering.
     let size_oh = match (width as u64) * (height as u64) {
-        n if n < 64 * 64 => [1.0_f32, 0.0, 0.0, 0.0],     // tiny
-        n if n < 256 * 256 => [0.0, 1.0, 0.0, 0.0],       // small
-        n if n < 1024 * 1024 => [0.0, 0.0, 1.0, 0.0],     // medium
-        _ => [0.0, 0.0, 0.0, 1.0],                         // large
+        n if n < 64 * 64 => [1.0_f32, 0.0, 0.0, 0.0], // tiny
+        n if n < 256 * 256 => [0.0, 1.0, 0.0, 0.0],   // small
+        n if n < 1024 * 1024 => [0.0, 0.0, 1.0, 0.0], // medium
+        _ => [0.0, 0.0, 0.0, 1.0],                    // large
     };
 
     let n_feat = raw_feats.len();
@@ -221,17 +215,16 @@ pub fn pick_tuning_from_features(
         return Err(PickError::NoBakedModel);
     }
 
-    let model =
-        Model::from_bytes_with_schema(MODEL_BYTES_RAW, SCHEMA_HASH).map_err(|e| {
-            // Map the zenpredict typed error back to ours. Two cases
-            // we care about: schema mismatch (drift) vs anything else.
-            match e {
-                zenpredict::PredictError::SchemaHashMismatch { expected, got } => {
-                    PickError::SchemaMismatch { expected, got }
-                }
-                _ => PickError::Parse,
+    let model = Model::from_bytes_with_schema(MODEL_BYTES_RAW, SCHEMA_HASH).map_err(|e| {
+        // Map the zenpredict typed error back to ours. Two cases
+        // we care about: schema mismatch (drift) vs anything else.
+        match e {
+            zenpredict::PredictError::SchemaHashMismatch { expected, got } => {
+                PickError::SchemaMismatch { expected, got }
             }
-        })?;
+            _ => PickError::Parse,
+        }
+    })?;
 
     let mut predictor = Predictor::new(model);
     let feats = engineered_features(raw_feats, width, height, target_zensim);
@@ -261,16 +254,8 @@ pub fn pick_tuning_from_features(
     // so an out-of-distribution input vector can't hand the codec a
     // negative sns or a sharpness of 99.
     let sns = clamp_to_u8(output[RANGE_SNS.start + cell_idx], 0.0, 100.0);
-    let filter_strength = clamp_to_u8(
-        output[RANGE_FILTER_STRENGTH.start + cell_idx],
-        0.0,
-        100.0,
-    );
-    let filter_sharpness = clamp_to_u8(
-        output[RANGE_FILTER_SHARPNESS.start + cell_idx],
-        0.0,
-        7.0,
-    );
+    let filter_strength = clamp_to_u8(output[RANGE_FILTER_STRENGTH.start + cell_idx], 0.0, 100.0);
+    let filter_sharpness = clamp_to_u8(output[RANGE_FILTER_SHARPNESS.start + cell_idx], 0.0, 7.0);
 
     let cell = CELLS[cell_idx];
     Ok(TuningPick {
@@ -284,11 +269,7 @@ pub fn pick_tuning_from_features(
 }
 
 fn clamp_to_u8(v: f32, lo: f32, hi: f32) -> u8 {
-    let clamped = if v.is_nan() {
-        lo
-    } else {
-        v.max(lo).min(hi)
-    };
+    let clamped = if v.is_nan() { lo } else { v.max(lo).min(hi) };
     libm::roundf(clamped) as u8
 }
 
@@ -328,13 +309,7 @@ mod tests {
         // Smoke: feed a synthetic raw vector through the lower-level
         // entry point; default mask allows everything.
         let raw = [0.5_f32; FEAT_COLS.len()];
-        let pick = pick_tuning_from_features(
-            &raw,
-            512,
-            512,
-            80.0,
-            &PickerConstraints::default(),
-        );
+        let pick = pick_tuning_from_features(&raw, 512, 512, 80.0, &PickerConstraints::default());
         assert!(pick.is_ok(), "pick_tuning failed: {:?}", pick);
         let p = pick.unwrap();
         assert!(p.cell_idx < N_CELLS);

--- a/src/encoder/picker/spec.rs
+++ b/src/encoder/picker/spec.rs
@@ -178,6 +178,7 @@ pub const fn cell_to_method_segments(idx: usize) -> (u8, u8) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec::Vec;
 
     #[test]
     fn cells_are_unique() {

--- a/src/encoder/picker/spec.rs
+++ b/src/encoder/picker/spec.rs
@@ -34,12 +34,30 @@ pub struct CellSpec {
 /// produces after sorting tuples lexicographically:
 /// `(method, segments)` over `[(4,1),(4,4),(5,1),(5,4),(6,1),(6,4)]`.
 pub const CELLS: [CellSpec; N_CELLS] = [
-    CellSpec { method: 4, segments: 1 },
-    CellSpec { method: 4, segments: 4 },
-    CellSpec { method: 5, segments: 1 },
-    CellSpec { method: 5, segments: 4 },
-    CellSpec { method: 6, segments: 1 },
-    CellSpec { method: 6, segments: 4 },
+    CellSpec {
+        method: 4,
+        segments: 1,
+    },
+    CellSpec {
+        method: 4,
+        segments: 4,
+    },
+    CellSpec {
+        method: 5,
+        segments: 1,
+    },
+    CellSpec {
+        method: 5,
+        segments: 4,
+    },
+    CellSpec {
+        method: 6,
+        segments: 1,
+    },
+    CellSpec {
+        method: 6,
+        segments: 4,
+    },
 ];
 
 /// Hybrid-heads output layout. Each block is a sub-range of the
@@ -192,8 +210,14 @@ mod tests {
     fn output_layout_partitions_correctly() {
         assert_eq!(RANGE_BYTES_LOG.end - RANGE_BYTES_LOG.start, N_CELLS);
         assert_eq!(RANGE_SNS.end - RANGE_SNS.start, N_CELLS);
-        assert_eq!(RANGE_FILTER_STRENGTH.end - RANGE_FILTER_STRENGTH.start, N_CELLS);
-        assert_eq!(RANGE_FILTER_SHARPNESS.end - RANGE_FILTER_SHARPNESS.start, N_CELLS);
+        assert_eq!(
+            RANGE_FILTER_STRENGTH.end - RANGE_FILTER_STRENGTH.start,
+            N_CELLS
+        );
+        assert_eq!(
+            RANGE_FILTER_SHARPNESS.end - RANGE_FILTER_SHARPNESS.start,
+            N_CELLS
+        );
         assert_eq!(RANGE_FILTER_SHARPNESS.end, N_OUTPUTS);
     }
 

--- a/src/encoder/validation.rs
+++ b/src/encoder/validation.rs
@@ -1,0 +1,276 @@
+//! Configuration validation.
+//!
+//! Each public `Config` type has a `validate()` method that returns
+//! `Result<(), ValidationError>`. The encode entry points keep their
+//! existing clamping behaviour for backwards compatibility — `validate()`
+//! is an opt-in fail-fast check for batch-job callers who would rather
+//! get a typed error than have the encoder silently change their inputs.
+//!
+//! # Why opt-in?
+//!
+//! `LossyConfig::with_quality(150.0)` clamps to `100.0` today. Callers
+//! who care about matching the requested config (calibration sweeps,
+//! provenance-bound pipelines, training-data generation) need to know
+//! when they asked for something out-of-range, but downstream consumers
+//! that have shipped against the clamping contract for years don't.
+//! `validate()` lets the picky callers opt in without breaking the rest.
+//!
+//! # What we validate
+//!
+//! Range checks for every primitive field with a documented valid range,
+//! plus a small number of cross-parameter invariants that the encoder
+//! cannot represent in its types:
+//!
+//! - **`LossyConfig`**: at most one of `target_size`, `target_psnr`, and
+//!   `target_zensim` may be set (the encoder picks one path; combining
+//!   them is undefined). Validated in [`LossyConfig::validate`].
+//! - **`SharpYuvConfig`** (when set on `LossyConfig`): `convergence_threshold`
+//!   must be finite and non-negative.
+//! - **`LosslessConfig`**: simple range checks; no cross-param invariants.
+//!
+//! Spec references: VP8/VP8L parameter ranges follow libwebp's
+//! `WebPConfigInit` and `VP8EncProc` (effort/method 0..=6, sns/filter
+//! 0..=100, sharpness 0..=7, segments 1..=4, quality 0..=100). PSNR
+//! upper bound (80 dB) reflects libwebp's documented sane cap; values
+//! above that are practically unreachable for natural content.
+
+use core::ops::RangeInclusive;
+
+use thiserror::Error;
+
+/// Invalid configuration. Returned by `validate()` methods on the
+/// public `Config` types.
+///
+/// Marked `#[non_exhaustive]` because new validation rules will be
+/// added over time as additional config fields gain documented ranges
+/// or new cross-parameter invariants are discovered.
+#[derive(Debug, Clone, Error)]
+#[non_exhaustive]
+pub enum ValidationError {
+    /// `quality` is outside the valid range.
+    #[error("quality {value} out of valid range {valid:?}")]
+    QualityOutOfRange {
+        /// The invalid value.
+        value: f32,
+        /// The valid inclusive range.
+        valid: RangeInclusive<f32>,
+    },
+
+    /// `quality` is not a finite number (NaN or infinity).
+    #[error("quality must be finite, got {value}")]
+    QualityNotFinite {
+        /// The invalid value.
+        value: f32,
+    },
+
+    /// `method` is outside the valid range.
+    #[error("method {value} out of valid range {valid:?}")]
+    MethodOutOfRange {
+        /// The invalid value.
+        value: u8,
+        /// The valid inclusive range.
+        valid: RangeInclusive<u8>,
+    },
+
+    /// `alpha_quality` is outside the valid range.
+    #[error("alpha_quality {value} out of valid range {valid:?}")]
+    AlphaQualityOutOfRange {
+        /// The invalid value.
+        value: u8,
+        /// The valid inclusive range.
+        valid: RangeInclusive<u8>,
+    },
+
+    /// `sns_strength` is outside the valid range.
+    #[error("sns_strength {value} out of valid range {valid:?}")]
+    SnsStrengthOutOfRange {
+        /// The invalid value.
+        value: u8,
+        /// The valid inclusive range.
+        valid: RangeInclusive<u8>,
+    },
+
+    /// `filter_strength` is outside the valid range.
+    #[error("filter_strength {value} out of valid range {valid:?}")]
+    FilterStrengthOutOfRange {
+        /// The invalid value.
+        value: u8,
+        /// The valid inclusive range.
+        valid: RangeInclusive<u8>,
+    },
+
+    /// `filter_sharpness` is outside the valid range.
+    #[error("filter_sharpness {value} out of valid range {valid:?}")]
+    FilterSharpnessOutOfRange {
+        /// The invalid value.
+        value: u8,
+        /// The valid inclusive range.
+        valid: RangeInclusive<u8>,
+    },
+
+    /// `segments` is outside the valid range.
+    #[error("segments {value} out of valid range {valid:?}")]
+    SegmentsOutOfRange {
+        /// The invalid value.
+        value: u8,
+        /// The valid inclusive range.
+        valid: RangeInclusive<u8>,
+    },
+
+    /// `partition_limit` is outside the valid range.
+    #[error("partition_limit {value} out of valid range {valid:?}")]
+    PartitionLimitOutOfRange {
+        /// The invalid value.
+        value: u8,
+        /// The valid inclusive range.
+        valid: RangeInclusive<u8>,
+    },
+
+    /// `target_psnr` is outside the valid range or non-finite.
+    #[error("target_psnr {value} out of valid range {valid:?}")]
+    TargetPsnrOutOfRange {
+        /// The invalid value.
+        value: f32,
+        /// The valid inclusive range.
+        valid: RangeInclusive<f32>,
+    },
+
+    /// `target_zensim.target` is outside the valid range or non-finite.
+    #[error("target_zensim.target {value} out of valid range {valid:?}")]
+    TargetZensimOutOfRange {
+        /// The invalid value.
+        value: f32,
+        /// The valid inclusive range.
+        valid: RangeInclusive<f32>,
+    },
+
+    /// `target_zensim.max_passes` is zero (must run at least one pass).
+    #[error("target_zensim.max_passes must be >= 1, got {value}")]
+    TargetZensimMaxPassesZero {
+        /// The invalid value.
+        value: u8,
+    },
+
+    /// A tolerance field on `target_zensim` is non-finite or negative.
+    #[error("target_zensim.{field} must be finite and >= 0.0, got {value}")]
+    TargetZensimToleranceInvalid {
+        /// Which tolerance field (`max_overshoot`, `max_undershoot`,
+        /// `max_undershoot_ship`).
+        field: &'static str,
+        /// The invalid value.
+        value: f32,
+    },
+
+    /// More than one of `target_size`, `target_psnr`, and
+    /// `target_zensim` was set non-default. Only one target mode may be
+    /// active per encode.
+    #[error("targets {first} and {second} are mutually exclusive")]
+    TargetMutuallyExclusive {
+        /// First target field that was set.
+        first: &'static str,
+        /// Second target field that was set.
+        second: &'static str,
+    },
+
+    /// `near_lossless` is outside the valid range (lossless only).
+    #[error("near_lossless {value} out of valid range {valid:?}")]
+    NearLosslessOutOfRange {
+        /// The invalid value.
+        value: u8,
+        /// The valid inclusive range.
+        valid: RangeInclusive<u8>,
+    },
+
+    /// `SharpYuvConfig::convergence_threshold` is non-finite or negative.
+    #[error("sharp_yuv.convergence_threshold must be finite and >= 0.0, got {value}")]
+    SharpYuvConvergenceThresholdInvalid {
+        /// The invalid value.
+        value: f32,
+    },
+}
+
+// ============================================================================
+// Range constants. Centralised so callers can also introspect the
+// valid range without round-tripping through `validate()`.
+// ============================================================================
+
+/// Valid range for `quality` on lossy and lossless configs.
+pub const QUALITY_RANGE: RangeInclusive<f32> = 0.0..=100.0;
+/// Valid range for `method` on lossy and lossless configs (libwebp parity).
+pub const METHOD_RANGE: RangeInclusive<u8> = 0..=6;
+/// Valid range for `alpha_quality`.
+pub const ALPHA_QUALITY_RANGE: RangeInclusive<u8> = 0..=100;
+/// Valid range for `sns_strength`.
+pub const SNS_STRENGTH_RANGE: RangeInclusive<u8> = 0..=100;
+/// Valid range for `filter_strength`.
+pub const FILTER_STRENGTH_RANGE: RangeInclusive<u8> = 0..=100;
+/// Valid range for `filter_sharpness` (VP8 loop filter sharpness field is 3 bits).
+pub const FILTER_SHARPNESS_RANGE: RangeInclusive<u8> = 0..=7;
+/// Valid range for `segments` (VP8 supports 1-4 segments).
+pub const SEGMENTS_RANGE: RangeInclusive<u8> = 1..=4;
+/// Valid range for `partition_limit` (zenwebp-internal mode-decision lever).
+pub const PARTITION_LIMIT_RANGE: RangeInclusive<u8> = 0..=100;
+/// Valid range for `target_psnr` (dB). The lower bound is 0 dB; the
+/// upper bound (80 dB) reflects libwebp's documented sane cap.
+pub const TARGET_PSNR_RANGE: RangeInclusive<f32> = 0.0..=80.0;
+/// Valid range for `target_zensim.target` (zensim score; same scale as
+/// the metric's own 0..=100 output).
+pub const TARGET_ZENSIM_RANGE: RangeInclusive<f32> = 0.0..=100.0;
+/// Valid range for `near_lossless`. 100 = off, 0 = max preprocessing
+/// (libwebp's `WebPConfig.near_lossless`).
+pub const NEAR_LOSSLESS_RANGE: RangeInclusive<u8> = 0..=100;
+
+// ============================================================================
+// Helper checks
+// ============================================================================
+
+#[inline]
+pub(super) fn check_quality(q: f32) -> Result<(), ValidationError> {
+    if !q.is_finite() {
+        return Err(ValidationError::QualityNotFinite { value: q });
+    }
+    if !QUALITY_RANGE.contains(&q) {
+        return Err(ValidationError::QualityOutOfRange {
+            value: q,
+            valid: QUALITY_RANGE,
+        });
+    }
+    Ok(())
+}
+
+#[inline]
+pub(super) fn check_method(m: u8) -> Result<(), ValidationError> {
+    if !METHOD_RANGE.contains(&m) {
+        return Err(ValidationError::MethodOutOfRange {
+            value: m,
+            valid: METHOD_RANGE,
+        });
+    }
+    Ok(())
+}
+
+#[inline]
+pub(super) fn check_alpha_quality(a: u8) -> Result<(), ValidationError> {
+    if !ALPHA_QUALITY_RANGE.contains(&a) {
+        return Err(ValidationError::AlphaQualityOutOfRange {
+            value: a,
+            valid: ALPHA_QUALITY_RANGE,
+        });
+    }
+    Ok(())
+}
+
+#[inline]
+pub(super) fn check_target_psnr(p: f32) -> Result<(), ValidationError> {
+    // 0.0 means "disabled" — accept it without further checks.
+    if p == 0.0 {
+        return Ok(());
+    }
+    if !p.is_finite() || !TARGET_PSNR_RANGE.contains(&p) {
+        return Err(ValidationError::TargetPsnrOutOfRange {
+            value: p,
+            valid: TARGET_PSNR_RANGE,
+        });
+    }
+    Ok(())
+}

--- a/src/encoder/validation.rs
+++ b/src/encoder/validation.rs
@@ -21,9 +21,11 @@
 //! plus a small number of cross-parameter invariants that the encoder
 //! cannot represent in its types:
 //!
-//! - **`LossyConfig`**: at most one of `target_size`, `target_psnr`, and
-//!   `target_zensim` may be set (the encoder picks one path; combining
-//!   them is undefined). Validated in [`LossyConfig::validate`].
+//! - **`LossyConfig`**: `target_size` and `target_psnr` are mutually
+//!   exclusive (the encoder picks one path; combining them is
+//!   undefined). When the unstable `target-zensim` cargo feature is
+//!   enabled, `target_zensim` joins the same exclusivity rule.
+//!   Validated in [`LossyConfig::validate`].
 //! - **`SharpYuvConfig`** (when set on `LossyConfig`): `convergence_threshold`
 //!   must be finite and non-negative.
 //! - **`LosslessConfig`**: simple range checks; no cross-param invariants.
@@ -136,6 +138,10 @@ pub enum ValidationError {
     },
 
     /// `target_zensim.target` is outside the valid range or non-finite.
+    ///
+    /// Only emitted when the unstable `target-zensim` cargo feature is
+    /// enabled.
+    #[cfg(feature = "target-zensim")]
     #[error("target_zensim.target {value} out of valid range {valid:?}")]
     TargetZensimOutOfRange {
         /// The invalid value.
@@ -145,6 +151,10 @@ pub enum ValidationError {
     },
 
     /// `target_zensim.max_passes` is zero (must run at least one pass).
+    ///
+    /// Only emitted when the unstable `target-zensim` cargo feature is
+    /// enabled.
+    #[cfg(feature = "target-zensim")]
     #[error("target_zensim.max_passes must be >= 1, got {value}")]
     TargetZensimMaxPassesZero {
         /// The invalid value.
@@ -152,6 +162,10 @@ pub enum ValidationError {
     },
 
     /// A tolerance field on `target_zensim` is non-finite or negative.
+    ///
+    /// Only emitted when the unstable `target-zensim` cargo feature is
+    /// enabled.
+    #[cfg(feature = "target-zensim")]
     #[error("target_zensim.{field} must be finite and >= 0.0, got {value}")]
     TargetZensimToleranceInvalid {
         /// Which tolerance field (`max_overshoot`, `max_undershoot`,
@@ -161,9 +175,12 @@ pub enum ValidationError {
         value: f32,
     },
 
-    /// More than one of `target_size`, `target_psnr`, and
-    /// `target_zensim` was set non-default. Only one target mode may be
-    /// active per encode.
+    /// More than one mutually exclusive target was set. Only one target
+    /// mode may be active per encode.
+    ///
+    /// Without the `target-zensim` cargo feature this only covers the
+    /// (`target_size`, `target_psnr`) pair. With the feature enabled,
+    /// `target_zensim` joins the same exclusivity rule.
     #[error("targets {first} and {second} are mutually exclusive")]
     TargetMutuallyExclusive {
         /// First target field that was set.
@@ -215,6 +232,10 @@ pub const PARTITION_LIMIT_RANGE: RangeInclusive<u8> = 0..=100;
 pub const TARGET_PSNR_RANGE: RangeInclusive<f32> = 0.0..=80.0;
 /// Valid range for `target_zensim.target` (zensim score; same scale as
 /// the metric's own 0..=100 output).
+///
+/// Only available when the unstable `target-zensim` cargo feature is
+/// enabled.
+#[cfg(feature = "target-zensim")]
 pub const TARGET_ZENSIM_RANGE: RangeInclusive<f32> = 0.0..=100.0;
 /// Valid range for `near_lossless`. 100 = off, 0 = max preprocessing
 /// (libwebp's `WebPConfig.near_lossless`).

--- a/src/encoder/vp8/mod.rs
+++ b/src/encoder/vp8/mod.rs
@@ -2106,11 +2106,12 @@ fn resolve_auto_preset_via_analyzer(
     stride: usize,
     color: PixelLayout,
 ) -> Option<super::api::EncoderParams> {
-    use crate::encoder::analysis::{
-        classifier::classify_image_type_rgb8_diag, classifier::rgba8_to_rgb8, decide_bucket_from_diag,
-    };
     #[cfg(not(feature = "picker"))]
     use crate::encoder::analysis::content_type_to_tuning;
+    use crate::encoder::analysis::{
+        classifier::classify_image_type_rgb8_diag, classifier::rgba8_to_rgb8,
+        decide_bucket_from_diag,
+    };
     if params.preset != super::api::Preset::Auto {
         return None;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,8 +175,8 @@ pub use encoder::{
 /// codec consumers don't see these. Used by the picker training
 /// pipeline + codec calibration sweeps. Build with
 /// `--features expert` to opt in.
-#[cfg(feature = "expert")]
-pub use encoder::{ExpertKnobs, SharpYuvSetting};
+#[cfg(feature = "__expert")]
+pub use encoder::{InternalParams, SharpYuvSetting};
 
 /// Dev-only ablation toggles (gated on the unstable `ablation` feature).
 /// See [`encoder::AblationToggles`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,8 @@ pub use zenpixels::Orientation;
 // Re-export core encoder types
 pub use encoder::{
     CostModel, EncodeError, EncodeRequest, EncodeResult, EncoderConfig, ImageMetadata,
-    LosslessConfig, LossyConfig, PixelLayout, Preset, ZensimEncodeMetrics, ZensimTarget,
+    LosslessConfig, LossyConfig, PixelLayout, Preset, ValidationError, ZensimEncodeMetrics,
+    ZensimTarget,
 };
 
 /// Advanced encoder tuning knobs surface (`partition_limit`,

--- a/tests/large_encode_roundtrip.rs
+++ b/tests/large_encode_roundtrip.rs
@@ -12,7 +12,7 @@
 //! Requires the `expert` cargo feature — `with_partition_limit` is
 //! gated there.
 
-#![cfg(feature = "expert")]
+#![cfg(feature = "__expert")]
 
 use zenwebp::{DecodeRequest, EncodeError, EncodeRequest, LossyConfig, PixelLayout};
 

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -5,7 +5,9 @@
 //! unmodified. The happy-path test exercises the public builder
 //! constructor.
 
-use zenwebp::{EncoderConfig, LosslessConfig, LossyConfig, Preset, ValidationError, ZensimTarget};
+#[cfg(feature = "target-zensim")]
+use zenwebp::ZensimTarget;
+use zenwebp::{EncoderConfig, LosslessConfig, LossyConfig, Preset, ValidationError};
 
 // ---------------------------------------------------------------------------
 // Happy path — defaults validate.
@@ -181,6 +183,7 @@ fn target_psnr_zero_is_disabled_ok() {
     cfg.validate().expect("0.0 = disabled, must pass");
 }
 
+#[cfg(feature = "target-zensim")]
 #[test]
 fn target_zensim_out_of_range() {
     let mut cfg = LossyConfig::new();
@@ -191,6 +194,7 @@ fn target_zensim_out_of_range() {
     ));
 }
 
+#[cfg(feature = "target-zensim")]
 #[test]
 fn target_zensim_max_passes_zero_rejected() {
     let mut cfg = LossyConfig::new();
@@ -201,6 +205,7 @@ fn target_zensim_max_passes_zero_rejected() {
     ));
 }
 
+#[cfg(feature = "target-zensim")]
 #[test]
 fn target_zensim_negative_overshoot_rejected() {
     let mut cfg = LossyConfig::new();
@@ -209,6 +214,34 @@ fn target_zensim_negative_overshoot_rejected() {
         ValidationError::TargetZensimToleranceInvalid { field, value } => {
             assert_eq!(field, "max_overshoot");
             assert_eq!(value, -1.0);
+        }
+        e => panic!("unexpected variant: {e:?}"),
+    }
+}
+
+/// Without the `target-zensim` cargo feature, setting `target_zensim`
+/// alongside another target must NOT trigger a `TargetMutuallyExclusive`
+/// error — the feature-gated validation block is compiled out, so the
+/// surface stays a 2-way (`target_size`, `target_psnr`) check. Setting
+/// `target_zensim` together with `target_size` should validate cleanly
+/// in that configuration. (When the feature IS on, the dedicated 3-way
+/// tests above cover the positive case.)
+#[cfg(not(feature = "target-zensim"))]
+#[test]
+fn target_zensim_validation_inactive_without_feature() {
+    let mut cfg = LossyConfig::new();
+    cfg.target_size = 50_000;
+    // Setting the field directly is fine — the field is `pub` even
+    // without the feature, only its validation surface is gated.
+    // We purposely do NOT touch `target_zensim` here because constructing
+    // a `ZensimTarget` requires the feature-gated re-export. The point
+    // of this test is: with the feature off, the only target-exclusivity
+    // pair that fires is (target_size, target_psnr).
+    cfg.target_psnr = 40.0;
+    match cfg.validate().unwrap_err() {
+        ValidationError::TargetMutuallyExclusive { first, second } => {
+            assert_eq!(first, "target_size");
+            assert_eq!(second, "target_psnr");
         }
         e => panic!("unexpected variant: {e:?}"),
     }
@@ -247,6 +280,7 @@ fn target_size_and_psnr_mutually_exclusive() {
     }
 }
 
+#[cfg(feature = "target-zensim")]
 #[test]
 fn target_size_and_zensim_mutually_exclusive() {
     let mut cfg = LossyConfig::new();
@@ -261,6 +295,7 @@ fn target_size_and_zensim_mutually_exclusive() {
     }
 }
 
+#[cfg(feature = "target-zensim")]
 #[test]
 fn target_psnr_and_zensim_mutually_exclusive() {
     let mut cfg = LossyConfig::new();
@@ -275,6 +310,7 @@ fn target_psnr_and_zensim_mutually_exclusive() {
     }
 }
 
+#[cfg(feature = "target-zensim")]
 #[test]
 fn all_three_targets_set_rejected() {
     let mut cfg = LossyConfig::new();
@@ -298,9 +334,12 @@ fn single_target_ok() {
     cfg.target_psnr = 40.0;
     cfg.validate().expect("single target ok");
 
-    let mut cfg = LossyConfig::new();
-    cfg.target_zensim = Some(ZensimTarget::new(80.0));
-    cfg.validate().expect("single target ok");
+    #[cfg(feature = "target-zensim")]
+    {
+        let mut cfg = LossyConfig::new();
+        cfg.target_zensim = Some(ZensimTarget::new(80.0));
+        cfg.validate().expect("single target ok");
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -1,0 +1,401 @@
+//! Tests for the opt-in `Config::validate()` API.
+//!
+//! Each test constructs a `Config` directly (bypassing the clamping
+//! `with_*` setters) so the offending value reaches `validate()`
+//! unmodified. The happy-path test exercises the public builder
+//! constructor.
+
+use zenwebp::{EncoderConfig, LosslessConfig, LossyConfig, Preset, ValidationError, ZensimTarget};
+
+// ---------------------------------------------------------------------------
+// Happy path — defaults validate.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn default_lossy_validates() {
+    LossyConfig::new().validate().expect("default lossy ok");
+}
+
+#[test]
+fn default_lossless_validates() {
+    LosslessConfig::new()
+        .validate()
+        .expect("default lossless ok");
+}
+
+#[test]
+fn preset_lossy_validates() {
+    LossyConfig::with_preset(Preset::Photo, 80.0)
+        .validate()
+        .expect("photo preset ok");
+}
+
+#[test]
+fn encoder_config_lossy_validates() {
+    EncoderConfig::new_lossy().validate().expect("ok");
+}
+
+#[test]
+fn encoder_config_lossless_validates() {
+    EncoderConfig::new_lossless().validate().expect("ok");
+}
+
+// ---------------------------------------------------------------------------
+// Per-variant range failures (LossyConfig).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn quality_out_of_range() {
+    let mut cfg = LossyConfig::new();
+    cfg.quality = 150.0;
+    match cfg.validate().unwrap_err() {
+        ValidationError::QualityOutOfRange { value, .. } => assert_eq!(value, 150.0),
+        e => panic!("unexpected variant: {e:?}"),
+    }
+}
+
+#[test]
+fn quality_negative_rejected() {
+    let mut cfg = LossyConfig::new();
+    cfg.quality = -1.0;
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::QualityOutOfRange { .. })
+    ));
+}
+
+#[test]
+fn quality_nan_rejected() {
+    let mut cfg = LossyConfig::new();
+    cfg.quality = f32::NAN;
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::QualityNotFinite { .. })
+    ));
+}
+
+#[test]
+fn method_out_of_range() {
+    let mut cfg = LossyConfig::new();
+    cfg.method = 7;
+    match cfg.validate().unwrap_err() {
+        ValidationError::MethodOutOfRange { value, .. } => assert_eq!(value, 7),
+        e => panic!("unexpected variant: {e:?}"),
+    }
+}
+
+#[test]
+fn alpha_quality_out_of_range() {
+    let mut cfg = LossyConfig::new();
+    cfg.alpha_quality = 200;
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::AlphaQualityOutOfRange { .. })
+    ));
+}
+
+#[test]
+fn sns_strength_out_of_range() {
+    let mut cfg = LossyConfig::new();
+    cfg.sns_strength = Some(200);
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::SnsStrengthOutOfRange { .. })
+    ));
+}
+
+#[test]
+fn filter_strength_out_of_range() {
+    let mut cfg = LossyConfig::new();
+    cfg.filter_strength = Some(200);
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::FilterStrengthOutOfRange { .. })
+    ));
+}
+
+#[test]
+fn filter_sharpness_out_of_range() {
+    let mut cfg = LossyConfig::new();
+    cfg.filter_sharpness = Some(8);
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::FilterSharpnessOutOfRange { .. })
+    ));
+}
+
+#[test]
+fn segments_zero_rejected() {
+    let mut cfg = LossyConfig::new();
+    cfg.segments = Some(0);
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::SegmentsOutOfRange { .. })
+    ));
+}
+
+#[test]
+fn segments_too_many_rejected() {
+    let mut cfg = LossyConfig::new();
+    cfg.segments = Some(5);
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::SegmentsOutOfRange { .. })
+    ));
+}
+
+#[test]
+fn partition_limit_out_of_range() {
+    let mut cfg = LossyConfig::new();
+    cfg.partition_limit = Some(200);
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::PartitionLimitOutOfRange { .. })
+    ));
+}
+
+#[test]
+fn target_psnr_out_of_range() {
+    let mut cfg = LossyConfig::new();
+    cfg.target_psnr = 200.0;
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::TargetPsnrOutOfRange { .. })
+    ));
+}
+
+#[test]
+fn target_psnr_negative_rejected() {
+    let mut cfg = LossyConfig::new();
+    cfg.target_psnr = -10.0;
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::TargetPsnrOutOfRange { .. })
+    ));
+}
+
+#[test]
+fn target_psnr_zero_is_disabled_ok() {
+    let mut cfg = LossyConfig::new();
+    cfg.target_psnr = 0.0;
+    cfg.validate().expect("0.0 = disabled, must pass");
+}
+
+#[test]
+fn target_zensim_out_of_range() {
+    let mut cfg = LossyConfig::new();
+    cfg.target_zensim = Some(ZensimTarget::new(150.0));
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::TargetZensimOutOfRange { .. })
+    ));
+}
+
+#[test]
+fn target_zensim_max_passes_zero_rejected() {
+    let mut cfg = LossyConfig::new();
+    cfg.target_zensim = Some(ZensimTarget::new(80.0).with_max_passes(0));
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::TargetZensimMaxPassesZero { .. })
+    ));
+}
+
+#[test]
+fn target_zensim_negative_overshoot_rejected() {
+    let mut cfg = LossyConfig::new();
+    cfg.target_zensim = Some(ZensimTarget::new(80.0).with_max_overshoot(Some(-1.0)));
+    match cfg.validate().unwrap_err() {
+        ValidationError::TargetZensimToleranceInvalid { field, value } => {
+            assert_eq!(field, "max_overshoot");
+            assert_eq!(value, -1.0);
+        }
+        e => panic!("unexpected variant: {e:?}"),
+    }
+}
+
+#[test]
+fn sharp_yuv_negative_threshold_rejected() {
+    let mut cfg = LossyConfig::new();
+    cfg.sharp_yuv = Some(zenwebp::SharpYuvConfig {
+        max_iterations: 2,
+        convergence_threshold: -0.1,
+        refine_y: true,
+    });
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::SharpYuvConvergenceThresholdInvalid { .. })
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Cross-param: target_size / target_psnr / target_zensim are mutually
+// exclusive. All three pairs must be rejected.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn target_size_and_psnr_mutually_exclusive() {
+    let mut cfg = LossyConfig::new();
+    cfg.target_size = 50_000;
+    cfg.target_psnr = 40.0;
+    match cfg.validate().unwrap_err() {
+        ValidationError::TargetMutuallyExclusive { first, second } => {
+            assert_eq!(first, "target_size");
+            assert_eq!(second, "target_psnr");
+        }
+        e => panic!("unexpected variant: {e:?}"),
+    }
+}
+
+#[test]
+fn target_size_and_zensim_mutually_exclusive() {
+    let mut cfg = LossyConfig::new();
+    cfg.target_size = 50_000;
+    cfg.target_zensim = Some(ZensimTarget::new(80.0));
+    match cfg.validate().unwrap_err() {
+        ValidationError::TargetMutuallyExclusive { first, second } => {
+            assert_eq!(first, "target_size");
+            assert_eq!(second, "target_zensim");
+        }
+        e => panic!("unexpected variant: {e:?}"),
+    }
+}
+
+#[test]
+fn target_psnr_and_zensim_mutually_exclusive() {
+    let mut cfg = LossyConfig::new();
+    cfg.target_psnr = 40.0;
+    cfg.target_zensim = Some(ZensimTarget::new(80.0));
+    match cfg.validate().unwrap_err() {
+        ValidationError::TargetMutuallyExclusive { first, second } => {
+            assert_eq!(first, "target_psnr");
+            assert_eq!(second, "target_zensim");
+        }
+        e => panic!("unexpected variant: {e:?}"),
+    }
+}
+
+#[test]
+fn all_three_targets_set_rejected() {
+    let mut cfg = LossyConfig::new();
+    cfg.target_size = 50_000;
+    cfg.target_psnr = 40.0;
+    cfg.target_zensim = Some(ZensimTarget::new(80.0));
+    // First pair detected wins (size+psnr).
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::TargetMutuallyExclusive { .. })
+    ));
+}
+
+#[test]
+fn single_target_ok() {
+    let mut cfg = LossyConfig::new();
+    cfg.target_size = 50_000;
+    cfg.validate().expect("single target ok");
+
+    let mut cfg = LossyConfig::new();
+    cfg.target_psnr = 40.0;
+    cfg.validate().expect("single target ok");
+
+    let mut cfg = LossyConfig::new();
+    cfg.target_zensim = Some(ZensimTarget::new(80.0));
+    cfg.validate().expect("single target ok");
+}
+
+// ---------------------------------------------------------------------------
+// LosslessConfig.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lossless_quality_out_of_range() {
+    let mut cfg = LosslessConfig::new();
+    cfg.quality = 150.0;
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::QualityOutOfRange { .. })
+    ));
+}
+
+#[test]
+fn lossless_method_out_of_range() {
+    let mut cfg = LosslessConfig::new();
+    cfg.method = 9;
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::MethodOutOfRange { .. })
+    ));
+}
+
+#[test]
+fn lossless_alpha_quality_out_of_range() {
+    let mut cfg = LosslessConfig::new();
+    cfg.alpha_quality = 200;
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::AlphaQualityOutOfRange { .. })
+    ));
+}
+
+#[test]
+fn lossless_near_lossless_out_of_range() {
+    let mut cfg = LosslessConfig::new();
+    cfg.near_lossless = 200;
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::NearLosslessOutOfRange { .. })
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// EncoderConfig dispatch.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn encoder_config_dispatches_to_inner() {
+    let mut inner = LossyConfig::new();
+    inner.quality = 200.0;
+    let cfg = EncoderConfig::Lossy(inner);
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::QualityOutOfRange { .. })
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// __expert: InternalParams.validate()
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "__expert")]
+mod expert {
+    use zenwebp::{InternalParams, SharpYuvSetting, ValidationError};
+
+    #[test]
+    fn internal_params_default_validates() {
+        InternalParams::default().validate().expect("ok");
+    }
+
+    #[test]
+    fn internal_params_partition_limit_out_of_range() {
+        let mut p = InternalParams::default();
+        p.partition_limit = Some(200);
+        assert!(matches!(
+            p.validate(),
+            Err(ValidationError::PartitionLimitOutOfRange { .. })
+        ));
+    }
+
+    #[test]
+    fn internal_params_sharp_yuv_custom_invalid() {
+        let mut p = InternalParams::default();
+        p.sharp_yuv = Some(SharpYuvSetting::Custom(zenwebp::SharpYuvConfig {
+            max_iterations: 2,
+            convergence_threshold: f32::NAN,
+            refine_y: true,
+        }));
+        assert!(matches!(
+            p.validate(),
+            Err(ValidationError::SharpYuvConvergenceThresholdInvalid { .. })
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

- Pure rename for cross-codec consistency: `expert` cargo feature → `__expert`, `ExpertKnobs` → `InternalParams`, `LossyConfig::with_expert` → `with_internal_params`. Structure unchanged (`#[non_exhaustive]`, `Default`, `Option<T>` fields). The `picker` feature now depends on `__expert`.
- None of these symbols were in the 0.4.4 published surface, so no deprecation cycle.
- Theory-of-operation docs on every InternalParams field (`partition_limit`, `multi_pass_stats`, `smooth_segment_map`, `sharp_yuv`, `cost_model`): pipeline stage, override rationale, mechanism, default-derivation. Sourced from VP8 mode-decision, segmentation, sharp-YUV, and cost-model module reads — every claim traced to source.
- 9 tests in `src/encoder/config_expert_tests.rs`: per-field permutations, idempotency under repeated apply, combined-knob valid-encode + decode, `Default::default()` = baseline byte-equality, partial-merge (NOT reset) semantics.
- `cargo semver-checks check-release --baseline-version 0.4.4 --features __expert`: clean.

## Caveat (pre-existing, not in scope for this PR)

The `picker` feature's `src/encoder/picker/runtime.rs` references `AnalysisFeature::ScreenContentLikelihood` / `NaturalLikelihood`, which were culled from zenanalyze 0.1.0. Same fix pattern as zenjpeg b82dbe32 (stub-port the composites). Won't block this PR (the `__expert` feature builds clean), but `picker` builds will continue to fail until that's addressed.

## Test plan
- [x] `cargo test --features __expert` — green
- [x] `cargo clippy --all-targets --features __expert -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo semver-checks check-release --baseline-version 0.4.4 --features __expert` clean
- [ ] CI matrix on push