### PR TITLE
fix: route limits through lossless transforms and harden demuxer bounds

### DIFF
--- a/dev/picker_v0_3_holdout_ab.rs
+++ b/dev/picker_v0_3_holdout_ab.rs
@@ -113,7 +113,9 @@ const RAW_TRANSFORMS_V0_3: &[RawTransform] = &[
     RawTransform::Identity, // 34 feat_colourfulness
     RawTransform::Identity, // 35 feat_quant_survival_uv
 ];
-use zenwebp::encoder::analysis::{ImageContentType, classify_image_type_rgb8, content_type_to_tuning};
+use zenwebp::encoder::analysis::{
+    ImageContentType, classify_image_type_rgb8, content_type_to_tuning,
+};
 use zenwebp::{EncodeRequest, LossyConfig, PixelLayout, ZensimTarget};
 
 // -----------------------------------------------------------------------
@@ -355,11 +357,7 @@ fn list_pngs(dir: &Path) -> Vec<PathBuf> {
         .into_iter()
         .flatten()
         .filter_map(|e| e.ok().map(|e| e.path()))
-        .filter(|p| {
-            p.is_file()
-                && p.extension()
-                    .is_some_and(|e| e == "png" || e == "PNG")
-        })
+        .filter(|p| p.is_file() && p.extension().is_some_and(|e| e == "png" || e == "PNG"))
         .collect();
     v.sort();
     v
@@ -459,8 +457,9 @@ fn pick_knobs(predictor: &mut Predictor<'_>, feats82: &[f32]) -> PickerKnobs {
     let output = predictor.predict(feats82).expect("predict");
     let mask_arr = [true; N_CELLS];
     let mask = AllowedMask::new(&mask_arr);
-    let cell_idx = argmin_masked_in_range(output, RANGE_BYTES_LOG, &mask, ScoreTransform::Exp, None)
-        .expect("argmin");
+    let cell_idx =
+        argmin_masked_in_range(output, RANGE_BYTES_LOG, &mask, ScoreTransform::Exp, None)
+            .expect("argmin");
     assert!(cell_idx < N_CELLS);
     let (method, segments) = CELLS[cell_idx];
     let sns = clamp_to_u8(output[OFF_SNS + cell_idx], 0.0, 100.0);
@@ -800,7 +799,11 @@ fn main() {
 
     let bp = picker_total.bytes_sum as f64;
     let bb = bucket_total.bytes_sum as f64;
-    let total_delta_pct = if bb > 0.0 { (bp - bb) / bb * 100.0 } else { 0.0 };
+    let total_delta_pct = if bb > 0.0 {
+        (bp - bb) / bb * 100.0
+    } else {
+        0.0
+    };
     md.push_str(&format!(
         "\n## Total\n\n* Picker total bytes: **{}** (mean achieved zensim {:.2})\n* Bucket total bytes: **{}** (mean achieved zensim {:.2})\n* Δ bytes: **{:+.2}%** (picker − bucket)\n* Δ achieved zensim: **{:+.3}** pp\n",
         fmt_bytes(picker_total.bytes_sum),

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1461,7 +1461,12 @@ impl<'a> zencodec::decode::DecodeJob<'a> for WebpDecodeJob {
                     let native_info = crate::ImageInfo::from_webp(data_ref)?;
                     let w = native_info.width as u16;
                     let h = native_info.height as u16;
-                    let alpha_chunk = crate::decoder::extended::read_alpha_chunk(alpha_data, w, h)?;
+                    let alpha_chunk = crate::decoder::extended::read_alpha_chunk(
+                        alpha_data,
+                        w,
+                        h,
+                        &cfg.limits,
+                    )?;
 
                     // Apply alpha filtering to produce final alpha plane
                     let fw = usize::from(w);

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1461,12 +1461,8 @@ impl<'a> zencodec::decode::DecodeJob<'a> for WebpDecodeJob {
                     let native_info = crate::ImageInfo::from_webp(data_ref)?;
                     let w = native_info.width as u16;
                     let h = native_info.height as u16;
-                    let alpha_chunk = crate::decoder::extended::read_alpha_chunk(
-                        alpha_data,
-                        w,
-                        h,
-                        &cfg.limits,
-                    )?;
+                    let alpha_chunk =
+                        crate::decoder::extended::read_alpha_chunk(alpha_data, w, h, &cfg.limits)?;
 
                     // Apply alpha filtering to produce final alpha plane
                     let fw = usize::from(w);

--- a/src/decoder/api.rs
+++ b/src/decoder/api.rs
@@ -156,7 +156,7 @@ use core::ops::Range;
 
 use hashbrown::HashMap;
 
-use super::extended::{self, WebPExtendedInfo, get_alpha_predictor, read_alpha_chunk};
+use super::extended::{self, get_alpha_predictor, read_alpha_chunk, WebPExtendedInfo};
 use super::lossless::LosslessDecoder;
 use super::vp8v2::DecoderContext;
 use crate::slice_reader::SliceReader;

--- a/src/decoder/api.rs
+++ b/src/decoder/api.rs
@@ -622,7 +622,7 @@ impl<'a> DecodeRequest<'a> {
 
                 // Apply alpha channel if present
                 if let Some(alpha_data) = frame.alpha_data {
-                    let alpha_chunk = read_alpha_chunk(alpha_data, w, h)?;
+                    let alpha_chunk = read_alpha_chunk(alpha_data, w, h, &self.config.limits)?;
 
                     let fw = usize::from(w);
                     let fh = usize::from(h);
@@ -1185,6 +1185,7 @@ impl<'a> WebPDecoder<'a> {
             let data_slice = self.chunk_slice(range)?;
             let mut decoder = LosslessDecoder::new(data_slice);
             decoder.set_stop(self.stop);
+            decoder.set_limits(Some(&self.limits));
 
             if self.has_alpha {
                 decoder.decode_frame(self.width, self.height, false, buf)?;
@@ -1229,8 +1230,12 @@ impl<'a> WebPDecoder<'a> {
                     .ok_or_else(|| at!(DecodeError::ChunkMissing))?
                     .clone();
                 let alpha_slice = &data_buf[alpha_range.start as usize..alpha_range.end as usize];
-                let alpha_chunk =
-                    read_alpha_chunk(alpha_slice, self.width as u16, self.height as u16)?;
+                let alpha_chunk = read_alpha_chunk(
+                    alpha_slice,
+                    self.width as u16,
+                    self.height as u16,
+                    &self.limits,
+                )?;
 
                 let fw = usize::from(w);
                 let fh = usize::from(h);
@@ -1331,6 +1336,7 @@ impl<'a> WebPDecoder<'a> {
                 let data_slice = self.r.take_slice(chunk_size as usize)?;
                 let mut lossless_decoder = LosslessDecoder::new(data_slice);
                 lossless_decoder.set_stop(self.stop);
+                lossless_decoder.set_limits(Some(&self.limits));
                 let frame_alloc = frame_width as usize * frame_height as usize * 4;
                 self.limits.check_memory(frame_alloc)?;
                 self.animation.frame_scratch.resize(frame_alloc, 0);
@@ -1354,8 +1360,12 @@ impl<'a> WebPDecoder<'a> {
                     self.r
                         .seek_relative((chunk_size_rounded - chunk_size) as i64)?;
                 }
-                let alpha_chunk =
-                    read_alpha_chunk(alpha_slice, frame_width as u16, frame_height as u16)?;
+                let alpha_chunk = read_alpha_chunk(
+                    alpha_slice,
+                    frame_width as u16,
+                    frame_height as u16,
+                    &self.limits,
+                )?;
 
                 // read opaque — lossy decode with buffer reuse
                 let (next_chunk, next_chunk_size, _) = read_chunk_header(&mut self.r)?;

--- a/src/decoder/api.rs
+++ b/src/decoder/api.rs
@@ -156,7 +156,7 @@ use core::ops::Range;
 
 use hashbrown::HashMap;
 
-use super::extended::{self, get_alpha_predictor, read_alpha_chunk, WebPExtendedInfo};
+use super::extended::{self, WebPExtendedInfo, get_alpha_predictor, read_alpha_chunk};
 use super::lossless::LosslessDecoder;
 use super::vp8v2::DecoderContext;
 use crate::slice_reader::SliceReader;

--- a/src/decoder/extended.rs
+++ b/src/decoder/extended.rs
@@ -324,6 +324,7 @@ pub(crate) fn read_alpha_chunk(
     data: &[u8],
     width: u16,
     height: u16,
+    limits: &super::limits::Limits,
 ) -> Result<AlphaChunk, whereat::At<DecodeError>> {
     if data.is_empty() {
         return Err(at!(DecodeError::BitStreamError));
@@ -356,12 +357,18 @@ pub(crate) fn read_alpha_chunk(
 
     let alpha_data = &data[1..];
     let decoded_data = if lossless_compression {
-        let mut decoder = LosslessDecoder::new(alpha_data);
+        let rgba_size = usize::from(width) * usize::from(height) * 4;
+        limits.check_memory(rgba_size)?;
 
-        let mut rgba_data = vec![0; usize::from(width) * usize::from(height) * 4];
+        let mut decoder = LosslessDecoder::new(alpha_data);
+        decoder.set_limits(Some(limits));
+
+        let mut rgba_data = vec![0; rgba_size];
         decoder.decode_frame(u32::from(width), u32::from(height), true, &mut rgba_data)?;
 
-        let mut green = vec![0; usize::from(width) * usize::from(height)];
+        let green_size = usize::from(width) * usize::from(height);
+        limits.check_memory(green_size)?;
+        let mut green = vec![0; green_size];
         for (rgba_val, green_val) in rgba_data.chunks_exact(4).zip(green.iter_mut()) {
             *green_val = rgba_val[1];
         }

--- a/src/decoder/internal_error.rs
+++ b/src/decoder/internal_error.rs
@@ -34,6 +34,8 @@ pub(crate) enum InternalDecodeError {
     ChromaPredictionModeInvalid = 6,
     /// Decoding was cancelled via a cooperative stop token
     Cancelled = 7,
+    /// An intermediate allocation would exceed `Limits::max_memory`
+    MemoryLimitExceeded = 8,
 }
 
 impl From<InternalDecodeError> for DecodeError {
@@ -58,6 +60,7 @@ impl From<InternalDecodeError> for DecodeError {
                 DecodeError::ChromaPredictionModeInvalid(0)
             }
             InternalDecodeError::Cancelled => DecodeError::Cancelled(enough::StopReason::Cancelled),
+            InternalDecodeError::MemoryLimitExceeded => DecodeError::MemoryLimitExceeded,
         }
     }
 }

--- a/src/decoder/lossless.rs
+++ b/src/decoder/lossless.rs
@@ -10,6 +10,7 @@ use crate::slice_reader::SliceReader;
 
 use super::api::DecodeError;
 use super::internal_error::InternalDecodeError;
+use super::limits::Limits;
 use super::lossless_transform::{
     apply_color_indexing_transform, apply_color_transform, apply_predictor_transform,
     apply_subtract_green_transform,
@@ -71,6 +72,7 @@ pub(crate) struct LosslessDecoder<'a> {
     width: u16,
     height: u16,
     stop: Option<&'a dyn enough::Stop>,
+    limits: Option<&'a Limits>,
 }
 
 impl<'a> LosslessDecoder<'a> {
@@ -83,12 +85,35 @@ impl<'a> LosslessDecoder<'a> {
             width: 0,
             height: 0,
             stop: None,
+            limits: None,
         }
     }
 
     /// Set a cooperative cancellation token.
     pub(crate) fn set_stop(&mut self, stop: Option<&'a dyn enough::Stop>) {
         self.stop = stop;
+    }
+
+    /// Set the memory/resource limits used to gate intermediate allocations
+    /// (predictor/color transform sub-images, meta-Huffman entropy image, etc.).
+    ///
+    /// Without this set, intermediate transforms can allocate up to
+    /// `ceil(width / 4)^2 * 4` bytes per transform without bound. See
+    /// `Limits::check_memory` for the budgeting model.
+    pub(crate) fn set_limits(&mut self, limits: Option<&'a Limits>) {
+        self.limits = limits;
+    }
+
+    /// Allocate a `Vec<u8>` of length `size` after first checking it against
+    /// `Limits::check_memory`. Returns a `BitStreamError` mapped from the
+    /// limits check failure if the allocation would exceed the budget.
+    fn alloc_bytes_checked(&self, size: usize) -> Result<Vec<u8>, InternalDecodeError> {
+        if let Some(limits) = self.limits {
+            limits
+                .check_memory(size)
+                .map_err(|_| InternalDecodeError::MemoryLimitExceeded)?;
+        }
+        Ok(vec![0; size])
     }
 
     /// Decodes a frame.
@@ -236,8 +261,9 @@ impl<'a> LosslessDecoder<'a> {
                     let block_xsize = subsample_size(xsize, size_bits);
                     let block_ysize = subsample_size(self.height, size_bits);
 
-                    let mut predictor_data =
-                        vec![0; usize::from(block_xsize) * usize::from(block_ysize) * 4];
+                    let mut predictor_data = self.alloc_bytes_checked(
+                        usize::from(block_xsize) * usize::from(block_ysize) * 4,
+                    )?;
                     self.decode_image_stream(block_xsize, block_ysize, false, &mut predictor_data)?;
 
                     TransformType::PredictorTransform {
@@ -253,8 +279,9 @@ impl<'a> LosslessDecoder<'a> {
                     let block_xsize = subsample_size(xsize, size_bits);
                     let block_ysize = subsample_size(self.height, size_bits);
 
-                    let mut transform_data =
-                        vec![0; usize::from(block_xsize) * usize::from(block_ysize) * 4];
+                    let mut transform_data = self.alloc_bytes_checked(
+                        usize::from(block_xsize) * usize::from(block_ysize) * 4,
+                    )?;
                     self.decode_image_stream(block_xsize, block_ysize, false, &mut transform_data)?;
 
                     TransformType::ColorTransform {
@@ -270,7 +297,8 @@ impl<'a> LosslessDecoder<'a> {
                 3 => {
                     let color_table_size = self.bit_reader.read_bits::<u16>(8)? + 1;
 
-                    let mut color_map = vec![0; usize::from(color_table_size) * 4];
+                    let mut color_map =
+                        self.alloc_bytes_checked(usize::from(color_table_size) * 4)?;
                     self.decode_image_stream(color_table_size, 1, false, &mut color_map)?;
 
                     let bits = if color_table_size <= 2 {
@@ -329,7 +357,8 @@ impl<'a> LosslessDecoder<'a> {
             huffman_xsize = subsample_size(xsize, huffman_bits);
             huffman_ysize = subsample_size(ysize, huffman_bits);
 
-            let mut data = vec![0; usize::from(huffman_xsize) * usize::from(huffman_ysize) * 4];
+            let mut data = self
+                .alloc_bytes_checked(usize::from(huffman_xsize) * usize::from(huffman_ysize) * 4)?;
             self.decode_image_stream(huffman_xsize, huffman_ysize, false, &mut data)?;
 
             entropy_image = data

--- a/src/decoder/vp8v2/animation.rs
+++ b/src/decoder/vp8v2/animation.rs
@@ -13,6 +13,7 @@ use whereat::at;
 
 use crate::decoder::api::DecodeError;
 use crate::decoder::extended::{get_alpha_predictor, read_alpha_chunk};
+use crate::decoder::Limits;
 use crate::decoder::lossless::LosslessDecoder;
 use crate::mux::{BlendMethod, DemuxFrame, DisposeMethod, MuxError, WebPDemuxer};
 
@@ -66,6 +67,7 @@ impl DecoderContext {
         data: &[u8],
         mut callback: impl FnMut(AnimationFrame<'_>) -> bool,
     ) -> Result<(), whereat::At<DecodeError>> {
+        let limits = Limits::default();
         let demuxer = WebPDemuxer::new(data).map_err(|e| at!(mux_to_decode(e)))?;
 
         if !demuxer.is_animated() {
@@ -112,7 +114,8 @@ impl DecoderContext {
             }
 
             // Decode this frame's pixels
-            let frame_has_alpha = self.decode_single_frame(&demux_frame, &mut frame_scratch)?;
+            let frame_has_alpha =
+                self.decode_single_frame(&demux_frame, &mut frame_scratch, &limits)?;
 
             // Composite onto canvas
             crate::decoder::extended::composite_frame(
@@ -172,6 +175,7 @@ impl DecoderContext {
         &mut self,
         frame: &DemuxFrame<'_>,
         scratch: &mut Vec<u8>,
+        limits: &Limits,
     ) -> Result<bool, whereat::At<DecodeError>> {
         if frame.is_lossy {
             if let Some(alpha_data) = frame.alpha_data {
@@ -186,7 +190,7 @@ impl DecoderContext {
                     .height
                     .try_into()
                     .map_err(|_| at!(DecodeError::ImageTooLarge))?;
-                let alpha_chunk = read_alpha_chunk(alpha_data, alpha_w, alpha_h)?;
+                let alpha_chunk = read_alpha_chunk(alpha_data, alpha_w, alpha_h, limits)?;
 
                 let fw = frame.width as usize;
                 let fh = frame.height as usize;
@@ -214,8 +218,10 @@ impl DecoderContext {
                 .checked_mul(frame.height as usize)
                 .and_then(|n| n.checked_mul(4))
                 .ok_or_else(|| at!(DecodeError::ImageTooLarge))?;
+            limits.check_memory(alloc_size)?;
             scratch.resize(alloc_size, 0);
             let mut decoder = LosslessDecoder::new(frame.bitstream);
+            decoder.set_limits(Some(limits));
             decoder.decode_frame(frame.width, frame.height, false, scratch)?;
             Ok(true) // VP8L can always carry alpha
         }

--- a/src/decoder/vp8v2/animation.rs
+++ b/src/decoder/vp8v2/animation.rs
@@ -13,8 +13,8 @@ use whereat::at;
 
 use crate::decoder::api::DecodeError;
 use crate::decoder::extended::{get_alpha_predictor, read_alpha_chunk};
-use crate::decoder::Limits;
 use crate::decoder::lossless::LosslessDecoder;
+use crate::decoder::Limits;
 use crate::mux::{BlendMethod, DemuxFrame, DisposeMethod, MuxError, WebPDemuxer};
 
 use super::DecoderContext;

--- a/src/decoder/vp8v2/animation.rs
+++ b/src/decoder/vp8v2/animation.rs
@@ -11,10 +11,10 @@ use alloc::vec::Vec;
 #[allow(unused_imports)]
 use whereat::at;
 
+use crate::decoder::Limits;
 use crate::decoder::api::DecodeError;
 use crate::decoder::extended::{get_alpha_predictor, read_alpha_chunk};
 use crate::decoder::lossless::LosslessDecoder;
-use crate::decoder::Limits;
 use crate::mux::{BlendMethod, DemuxFrame, DisposeMethod, MuxError, WebPDemuxer};
 
 use super::DecoderContext;

--- a/src/mux/demux.rs
+++ b/src/mux/demux.rs
@@ -197,6 +197,14 @@ impl<'a> WebPDemuxer<'a> {
         let width = u32::from(w & 0x3FFF);
         let height = u32::from(h & 0x3FFF);
 
+        // Clamp the recorded bitstream range to the actual buffer length so
+        // a truncated file (chunk_size declared larger than remaining bytes)
+        // does not panic later when single_frame() slices into self.data.
+        let bitstream_end = bitstream_start
+            .checked_add(chunk_size)
+            .map(|end| end.min(data.len()))
+            .unwrap_or(data.len());
+
         Ok(Self {
             data,
             canvas_width: width,
@@ -209,7 +217,7 @@ impl<'a> WebPDemuxer<'a> {
             icc_range: None,
             exif_range: None,
             xmp_range: None,
-            single_bitstream_range: Some((bitstream_start, bitstream_start + chunk_size)),
+            single_bitstream_range: Some((bitstream_start, bitstream_end)),
             single_alpha_range: None,
             single_is_lossy: true,
             single_width: width,
@@ -241,6 +249,14 @@ impl<'a> WebPDemuxer<'a> {
         let height = (1 + (header >> 14)) & 0x3FFF;
         let has_alpha = (header >> 28) & 1 != 0;
 
+        // Clamp the recorded bitstream range to the actual buffer length so
+        // a truncated file (chunk_size declared larger than remaining bytes)
+        // does not panic later when single_frame() slices into self.data.
+        let bitstream_end = bitstream_start
+            .checked_add(chunk_size)
+            .map(|end| end.min(data.len()))
+            .unwrap_or(data.len());
+
         Ok(Self {
             data,
             canvas_width: width,
@@ -253,7 +269,7 @@ impl<'a> WebPDemuxer<'a> {
             icc_range: None,
             exif_range: None,
             xmp_range: None,
-            single_bitstream_range: Some((bitstream_start, bitstream_start + chunk_size)),
+            single_bitstream_range: Some((bitstream_start, bitstream_end)),
             single_alpha_range: None,
             single_is_lossy: false,
             single_width: width,
@@ -348,27 +364,55 @@ impl<'a> WebPDemuxer<'a> {
                     };
                 }
                 b"ANMF" if is_animated => {
-                    demuxer.frames.push(FrameRecord {
-                        anmf_payload_start: payload_start,
-                        anmf_payload_size: size,
-                    });
+                    // Only record the frame if its declared payload fits
+                    // within the available buffer. Otherwise the ANMF chunk
+                    // header is lying about its size (truncated file or
+                    // adversarial input) and parse_anmf_frame would panic.
+                    if let Some(end) = payload_start.checked_add(size)
+                        && end <= data.len()
+                    {
+                        demuxer.frames.push(FrameRecord {
+                            anmf_payload_start: payload_start,
+                            anmf_payload_size: size,
+                        });
+                    }
                 }
                 b"VP8 " if !is_animated => {
-                    demuxer.single_bitstream_range = Some((payload_start, payload_start + size));
+                    let end = payload_start
+                        .checked_add(size)
+                        .map(|e| e.min(data.len()))
+                        .unwrap_or(data.len());
+                    demuxer.single_bitstream_range = Some((payload_start, end));
                     demuxer.single_is_lossy = true;
                 }
                 b"VP8L" if !is_animated => {
-                    demuxer.single_bitstream_range = Some((payload_start, payload_start + size));
+                    let end = payload_start
+                        .checked_add(size)
+                        .map(|e| e.min(data.len()))
+                        .unwrap_or(data.len());
+                    demuxer.single_bitstream_range = Some((payload_start, end));
                     demuxer.single_is_lossy = false;
                 }
                 b"ALPH" if !is_animated => {
-                    demuxer.single_alpha_range = Some((payload_start, payload_start + size));
+                    let end = payload_start
+                        .checked_add(size)
+                        .map(|e| e.min(data.len()))
+                        .unwrap_or(data.len());
+                    demuxer.single_alpha_range = Some((payload_start, end));
                 }
                 b"EXIF" if has_exif => {
-                    demuxer.exif_range = Some((payload_start, payload_start + size));
+                    let end = payload_start
+                        .checked_add(size)
+                        .map(|e| e.min(data.len()))
+                        .unwrap_or(data.len());
+                    demuxer.exif_range = Some((payload_start, end));
                 }
                 b"XMP " if has_xmp => {
-                    demuxer.xmp_range = Some((payload_start, payload_start + size));
+                    let end = payload_start
+                        .checked_add(size)
+                        .map(|e| e.min(data.len()))
+                        .unwrap_or(data.len());
+                    demuxer.xmp_range = Some((payload_start, end));
                 }
                 _ => {}
             }
@@ -503,7 +547,11 @@ impl<'a> WebPDemuxer<'a> {
             return None;
         }
 
-        let d = &self.data[start..start + size];
+        // Defense in depth: even though parse_extended now validates ranges
+        // before recording a FrameRecord, prefer get() over indexing here so
+        // we cannot panic on a stale or future-corrupted record.
+        let end = start.checked_add(size)?;
+        let d = self.data.get(start..end)?;
 
         // ANMF payload layout:
         // 3 bytes: Frame X (in 2-pixel units)
@@ -539,11 +587,15 @@ impl<'a> WebPDemuxer<'a> {
 
         let sub_fourcc = &sub[0..4];
         let sub_size = u32::from_le_bytes([sub[4], sub[5], sub[6], sub[7]]) as usize;
-        let sub_payload_offset = start + 16 + 8; // absolute offset in data
+        let sub_payload_offset = start.checked_add(16 + 8)?; // absolute offset in data
 
         match sub_fourcc {
             b"VP8L" => {
-                let end = (sub_payload_offset + sub_size).min(self.data.len());
+                let end = sub_payload_offset
+                    .checked_add(sub_size)
+                    .map(|e| e.min(self.data.len()))
+                    .unwrap_or(self.data.len())
+                    .max(sub_payload_offset);
                 Some(DemuxFrame {
                     frame_num: idx as u32 + 1,
                     x_offset,
@@ -560,7 +612,11 @@ impl<'a> WebPDemuxer<'a> {
                 })
             }
             b"VP8 " => {
-                let end = (sub_payload_offset + sub_size).min(self.data.len());
+                let end = sub_payload_offset
+                    .checked_add(sub_size)
+                    .map(|e| e.min(self.data.len()))
+                    .unwrap_or(self.data.len())
+                    .max(sub_payload_offset);
                 Some(DemuxFrame {
                     frame_num: idx as u32 + 1,
                     x_offset,
@@ -577,28 +633,40 @@ impl<'a> WebPDemuxer<'a> {
                 })
             }
             b"ALPH" => {
-                // ALPH chunk followed by VP8 chunk
-                let alpha_end = (sub_payload_offset + sub_size).min(self.data.len());
-                let alpha_data = &self.data[sub_payload_offset..alpha_end];
+                // ALPH chunk followed by VP8 chunk. All offset arithmetic is
+                // attacker-controlled (sub_size, the trailing VP8 size) so use
+                // checked_add and bounded slicing to avoid panics.
+                let alpha_end = sub_payload_offset
+                    .checked_add(sub_size)
+                    .map(|e| e.min(self.data.len()))
+                    .unwrap_or(self.data.len())
+                    .max(sub_payload_offset);
+                let alpha_data = self.data.get(sub_payload_offset..alpha_end)?;
 
-                let sub_rounded = sub_size + (sub_size & 1);
-                let vp8_header_start = start + 16 + 8 + sub_rounded;
-                if vp8_header_start + 8 > start + size {
+                let sub_rounded = sub_size.checked_add(sub_size & 1)?;
+                let vp8_header_start = start.checked_add(16 + 8 + sub_rounded)?;
+                let frame_end = start.checked_add(size)?;
+                if vp8_header_start.checked_add(8)? > frame_end {
                     return None;
                 }
 
-                let vp8_fourcc = &self.data[vp8_header_start..vp8_header_start + 4];
+                let vp8_fourcc = self.data.get(vp8_header_start..vp8_header_start + 4)?;
                 if vp8_fourcc != b"VP8 " {
                     return None;
                 }
+                let header_bytes = self.data.get(vp8_header_start + 4..vp8_header_start + 8)?;
                 let vp8_size = u32::from_le_bytes([
-                    self.data[vp8_header_start + 4],
-                    self.data[vp8_header_start + 5],
-                    self.data[vp8_header_start + 6],
-                    self.data[vp8_header_start + 7],
+                    header_bytes[0],
+                    header_bytes[1],
+                    header_bytes[2],
+                    header_bytes[3],
                 ]) as usize;
-                let vp8_start = vp8_header_start + 8;
-                let vp8_end = (vp8_start + vp8_size).min(self.data.len());
+                let vp8_start = vp8_header_start.checked_add(8)?;
+                let vp8_end = vp8_start
+                    .checked_add(vp8_size)
+                    .map(|e| e.min(self.data.len()))
+                    .unwrap_or(self.data.len())
+                    .max(vp8_start);
 
                 Some(DemuxFrame {
                     frame_num: idx as u32 + 1,

--- a/src/mux/demux.rs
+++ b/src/mux/demux.rs
@@ -343,7 +343,11 @@ impl<'a> WebPDemuxer<'a> {
 
             match &fourcc {
                 b"ICCP" if has_icc => {
-                    demuxer.icc_range = Some((payload_start, payload_start + size));
+                    let end = payload_start
+                        .checked_add(size)
+                        .map(|e| e.min(data.len()))
+                        .unwrap_or(data.len());
+                    demuxer.icc_range = Some((payload_start, end));
                 }
                 b"ANIM"
                     if is_animated

--- a/tests/security_audit_2026_05_06.rs
+++ b/tests/security_audit_2026_05_06.rs
@@ -3,10 +3,10 @@
 //! Covers:
 //! * H1 — lossless transform sub-image allocations bypass `Limits::check_memory`
 //! * H2 — `WebPDemuxer` slice-indexing on attacker-controlled chunk sizes
-//!         (truncated ANMF / VP8 / VP8L)
+//!   (truncated ANMF / VP8 / VP8L)
 
-use zenwebp::{DecodeError, Limits, WebPDecoder};
 use zenwebp::mux::WebPDemuxer;
+use zenwebp::{DecodeError, Limits, WebPDecoder};
 
 /// Helper: bit-stream writer (LSB-first, matching VP8L's bitstream layout).
 struct BitWriter {
@@ -60,8 +60,8 @@ impl BitWriter {
 /// sub-image allocation happens *before* decode_image_stream is called on it.
 /// The test asserts that the limits check fires before any real decode work.
 fn build_amplifying_vp8l(width: u32, height: u32) -> Vec<u8> {
-    assert!(width >= 1 && width <= 16384);
-    assert!(height >= 1 && height <= 16384);
+    assert!((1..=16384).contains(&width));
+    assert!((1..=16384).contains(&height));
 
     let mut w = BitWriter::new();
     w.write(0x2f, 8);
@@ -72,8 +72,8 @@ fn build_amplifying_vp8l(width: u32, height: u32) -> Vec<u8> {
     w.write(1, 1); // transform present
     w.write(0, 2); // type = 0 (predictor)
     w.write(0, 3); // size_bits - 2 = 0 → size_bits = 2 (block_xsize = ceil(W/4))
-    // Stop here. Anything we add after won't be read because the allocation
-    // check should reject before decode_image_stream is reached.
+                   // Stop here. Anything we add after won't be read because the allocation
+                   // check should reject before decode_image_stream is reached.
     w.finish()
 }
 
@@ -213,7 +213,11 @@ fn h2_truncated_anmf_does_not_panic() {
             // Iterating must not panic.
             for f in d.frames() {
                 // Just touch fields to force any lazy panics.
-                let _ = (f.frame_num, f.bitstream.len(), f.alpha_data.map(|s| s.len()));
+                let _ = (
+                    f.frame_num,
+                    f.bitstream.len(),
+                    f.alpha_data.map(|s| s.len()),
+                );
             }
             // For truncated input we expect no usable frames.
             assert_eq!(
@@ -247,16 +251,11 @@ fn h2_truncated_simple_vp8l_does_not_panic() {
     let riff_size = (out.len() - 8) as u32;
     out[4..8].copy_from_slice(&riff_size.to_le_bytes());
 
-    match WebPDemuxer::new(&out) {
-        Ok(d) => {
-            // Calling frame(1) must not panic.
-            if let Some(frame) = d.frame(1) {
-                let _ = frame.bitstream.len();
-            }
-        }
-        Err(_) => {
-            // Returning an error is also fine.
-        }
+    // Calling frame(1) must not panic.
+    if let Ok(d) = WebPDemuxer::new(&out)
+        && let Some(frame) = d.frame(1)
+    {
+        let _ = frame.bitstream.len();
     }
 }
 
@@ -280,12 +279,9 @@ fn h2_truncated_simple_vp8_does_not_panic() {
     let riff_size = (out.len() - 8) as u32;
     out[4..8].copy_from_slice(&riff_size.to_le_bytes());
 
-    match WebPDemuxer::new(&out) {
-        Ok(d) => {
-            if let Some(frame) = d.frame(1) {
-                let _ = frame.bitstream.len();
-            }
-        }
-        Err(_) => {}
+    if let Ok(d) = WebPDemuxer::new(&out)
+        && let Some(frame) = d.frame(1)
+    {
+        let _ = frame.bitstream.len();
     }
 }

--- a/tests/security_audit_2026_05_06.rs
+++ b/tests/security_audit_2026_05_06.rs
@@ -72,8 +72,8 @@ fn build_amplifying_vp8l(width: u32, height: u32) -> Vec<u8> {
     w.write(1, 1); // transform present
     w.write(0, 2); // type = 0 (predictor)
     w.write(0, 3); // size_bits - 2 = 0 → size_bits = 2 (block_xsize = ceil(W/4))
-                   // Stop here. Anything we add after won't be read because the allocation
-                   // check should reject before decode_image_stream is reached.
+    // Stop here. Anything we add after won't be read because the allocation
+    // check should reject before decode_image_stream is reached.
     w.finish()
 }
 

--- a/tests/security_audit_2026_05_06.rs
+++ b/tests/security_audit_2026_05_06.rs
@@ -1,0 +1,291 @@
+//! Regression tests for the 2026-05-06 security audit.
+//!
+//! Covers:
+//! * H1 — lossless transform sub-image allocations bypass `Limits::check_memory`
+//! * H2 — `WebPDemuxer` slice-indexing on attacker-controlled chunk sizes
+//!         (truncated ANMF / VP8 / VP8L)
+
+use zenwebp::{DecodeError, Limits, WebPDecoder};
+use zenwebp::mux::WebPDemuxer;
+
+/// Helper: bit-stream writer (LSB-first, matching VP8L's bitstream layout).
+struct BitWriter {
+    buf: Vec<u8>,
+    cur: u64,
+    n: u32,
+}
+
+impl BitWriter {
+    fn new() -> Self {
+        Self {
+            buf: Vec::new(),
+            cur: 0,
+            n: 0,
+        }
+    }
+    fn write(&mut self, value: u64, bits: u32) {
+        debug_assert!(bits <= 32);
+        self.cur |= (value & ((1u64 << bits) - 1)) << self.n;
+        self.n += bits;
+        while self.n >= 8 {
+            self.buf.push((self.cur & 0xff) as u8);
+            self.cur >>= 8;
+            self.n -= 8;
+        }
+    }
+    fn finish(mut self) -> Vec<u8> {
+        if self.n > 0 {
+            self.buf.push((self.cur & 0xff) as u8);
+        }
+        self.buf
+    }
+}
+
+/// Build a VP8L bitstream with attacker-controlled width/height that triggers
+/// large predictor + color transform sub-image allocations before any of the
+/// decoder's normal Huffman-section work runs.
+///
+/// Layout (LSB-first):
+/// * 8-bit signature 0x2f
+/// * 14-bit width - 1
+/// * 14-bit height - 1
+/// * 1-bit alpha-used
+/// * 3-bit version (0)
+/// * 1-bit "transform present" = 1
+/// * 2-bit transform type = 0 (predictor)
+/// * 3-bit size_bits - 2 (we use size_bits = 2 → encoded value 0)
+/// * (decoder then allocates predictor sub-image, this is the gate we trip)
+///
+/// We don't need to provide a valid Huffman section because the predictor
+/// sub-image allocation happens *before* decode_image_stream is called on it.
+/// The test asserts that the limits check fires before any real decode work.
+fn build_amplifying_vp8l(width: u32, height: u32) -> Vec<u8> {
+    assert!(width >= 1 && width <= 16384);
+    assert!(height >= 1 && height <= 16384);
+
+    let mut w = BitWriter::new();
+    w.write(0x2f, 8);
+    w.write((width - 1) as u64, 14);
+    w.write((height - 1) as u64, 14);
+    w.write(0, 1); // alpha-used
+    w.write(0, 3); // version
+    w.write(1, 1); // transform present
+    w.write(0, 2); // type = 0 (predictor)
+    w.write(0, 3); // size_bits - 2 = 0 → size_bits = 2 (block_xsize = ceil(W/4))
+    // Stop here. Anything we add after won't be read because the allocation
+    // check should reject before decode_image_stream is reached.
+    w.finish()
+}
+
+/// Wrap raw VP8L bitstream in a RIFF/WEBP/VP8L container.
+fn wrap_vp8l(vp8l_payload: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"RIFF");
+    let chunk_size = vp8l_payload.len() as u32;
+    let chunk_size_padded = chunk_size + (chunk_size & 1);
+    let riff_size = 4 + 8 + chunk_size_padded; // "WEBP" + chunk header + payload
+    out.extend_from_slice(&riff_size.to_le_bytes());
+    out.extend_from_slice(b"WEBP");
+    out.extend_from_slice(b"VP8L");
+    out.extend_from_slice(&chunk_size.to_le_bytes());
+    out.extend_from_slice(vp8l_payload);
+    if chunk_size & 1 == 1 {
+        out.push(0); // RIFF padding byte
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// H1 — lossless transform allocations gated by Limits
+// ---------------------------------------------------------------------------
+
+#[test]
+fn h1_predictor_transform_allocation_rejected_when_over_memory_limit() {
+    // 8192 x 8192 → predictor sub-image with size_bits=2 = ceil(8192/4)^2 * 4
+    // = 2048^2 * 4 = 16 MB. We set max_memory to 4 MB so the predictor
+    // allocation must be rejected before any real decode work.
+    //
+    // 8192*8192 = 67 MP which fits within the default 100 MP total-pixels
+    // ceiling, so the constructor's dimension validation passes and we reach
+    // the lossless transform allocation site that this test is targeting.
+    let payload = build_amplifying_vp8l(8192, 8192);
+    let webp = wrap_vp8l(&payload);
+
+    let limits = Limits::default().max_memory(4 * 1024 * 1024);
+
+    let mut decoder = WebPDecoder::new(&webp).expect("header parse ok");
+    decoder.set_limits(limits);
+
+    let buf_size = decoder
+        .output_buffer_size()
+        .expect("output_buffer_size computable");
+    let mut out = vec![0u8; buf_size];
+
+    let err = decoder
+        .read_image(&mut out)
+        .expect_err("decode must reject due to memory limit");
+    assert!(
+        matches!(err.error(), DecodeError::MemoryLimitExceeded),
+        "expected MemoryLimitExceeded, got: {:?}",
+        err.error()
+    );
+}
+
+#[test]
+fn h1_predictor_transform_allocation_allowed_when_under_memory_limit() {
+    // Same shape, but with a memory limit that comfortably covers the
+    // intermediate predictor sub-image. We don't expect a clean decode (the
+    // bitstream is truncated after the transform header), but we *do* expect
+    // the failure to come from bitstream-shape checks downstream of the
+    // memory check — not from MemoryLimitExceeded.
+    let payload = build_amplifying_vp8l(64, 64);
+    let webp = wrap_vp8l(&payload);
+
+    let limits = Limits::default().max_memory(64 * 1024 * 1024);
+
+    let mut decoder = WebPDecoder::new(&webp).expect("header parse ok");
+    decoder.set_limits(limits);
+
+    let buf_size = decoder
+        .output_buffer_size()
+        .expect("output_buffer_size computable");
+    let mut out = vec![0u8; buf_size];
+
+    let err = decoder
+        .read_image(&mut out)
+        .expect_err("truncated bitstream must fail");
+    assert!(
+        !matches!(err.error(), DecodeError::MemoryLimitExceeded),
+        "memory limit should not fire for 64x64 / 64MB budget, got: {:?}",
+        err.error()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// H2 — demuxer slice indexing on attacker-controlled chunk sizes
+// ---------------------------------------------------------------------------
+
+/// Build a VP8X WebP container whose ANMF chunk header declares a payload
+/// size larger than the remaining file. Pre-fix this caused parse_anmf_frame
+/// to compute `&self.data[start..start + huge_size]` and panic.
+fn build_truncated_anmf_container() -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"RIFF");
+    // RIFF size will be patched after construction.
+    out.extend_from_slice(&0u32.to_le_bytes());
+    out.extend_from_slice(b"WEBP");
+
+    // VP8X chunk: 10-byte payload.
+    out.extend_from_slice(b"VP8X");
+    out.extend_from_slice(&10u32.to_le_bytes());
+    out.push(0b0000_0010); // is_animated = 1
+    out.extend_from_slice(&[0, 0, 0]); // reserved
+    // canvas_width - 1 = 9 (24-bit LE)
+    out.extend_from_slice(&[9, 0, 0]);
+    // canvas_height - 1 = 9
+    out.extend_from_slice(&[9, 0, 0]);
+
+    // ANMF chunk header lying about its size — claims it has 0xFFFF_FF00 bytes
+    // of payload (~4 GB). The actual file ends right here.
+    out.extend_from_slice(b"ANMF");
+    out.extend_from_slice(&0xFFFF_FF00u32.to_le_bytes());
+    // No payload follows. Demuxer should not register a FrameRecord whose
+    // declared range exceeds the remaining buffer.
+
+    // Patch RIFF size = total - 8.
+    let riff_size = (out.len() - 8) as u32;
+    out[4..8].copy_from_slice(&riff_size.to_le_bytes());
+
+    out
+}
+
+#[test]
+fn h2_truncated_anmf_does_not_panic() {
+    let data = build_truncated_anmf_container();
+
+    // Demuxer creation must not panic and must either reject the file or
+    // produce a demuxer whose frame iteration does not panic on truncated
+    // ANMF records.
+    match WebPDemuxer::new(&data) {
+        Ok(d) => {
+            // num_frames must reflect only frames whose declared range fits.
+            let n = d.num_frames();
+            // Iterating must not panic.
+            for f in d.frames() {
+                // Just touch fields to force any lazy panics.
+                let _ = (f.frame_num, f.bitstream.len(), f.alpha_data.map(|s| s.len()));
+            }
+            // For truncated input we expect no usable frames.
+            assert_eq!(
+                n, 0,
+                "truncated ANMF must not produce a usable frame record"
+            );
+        }
+        Err(_) => {
+            // Returning an error is also acceptable behavior.
+        }
+    }
+}
+
+#[test]
+fn h2_truncated_simple_vp8l_does_not_panic() {
+    // Build a RIFF/WEBP/VP8L header whose declared chunk_size exceeds the
+    // remaining file. parse_simple_lossless previously stored
+    // single_bitstream_range = (start, start + chunk_size) without bounds-
+    // checking, panicking later when single_frame() sliced &self.data[..].
+    let mut out = Vec::new();
+    out.extend_from_slice(b"RIFF");
+    out.extend_from_slice(&0u32.to_le_bytes()); // patched below
+    out.extend_from_slice(b"WEBP");
+    out.extend_from_slice(b"VP8L");
+    // Lie: claim 1 GB of payload.
+    out.extend_from_slice(&(1024u32 * 1024 * 1024).to_le_bytes());
+    // Provide just enough for the 5-byte VP8L header parse.
+    out.push(0x2f);
+    out.extend_from_slice(&[0u8; 4]);
+
+    let riff_size = (out.len() - 8) as u32;
+    out[4..8].copy_from_slice(&riff_size.to_le_bytes());
+
+    match WebPDemuxer::new(&out) {
+        Ok(d) => {
+            // Calling frame(1) must not panic.
+            if let Some(frame) = d.frame(1) {
+                let _ = frame.bitstream.len();
+            }
+        }
+        Err(_) => {
+            // Returning an error is also fine.
+        }
+    }
+}
+
+#[test]
+fn h2_truncated_simple_vp8_does_not_panic() {
+    // Build a RIFF/WEBP/VP8  header whose declared chunk_size exceeds the
+    // remaining file. Mirrors the VP8L test above for parse_simple_lossy.
+    let mut out = Vec::new();
+    out.extend_from_slice(b"RIFF");
+    out.extend_from_slice(&0u32.to_le_bytes());
+    out.extend_from_slice(b"WEBP");
+    out.extend_from_slice(b"VP8 ");
+    out.extend_from_slice(&(1024u32 * 1024 * 1024).to_le_bytes());
+    // Minimal VP8 keyframe header (10 bytes):
+    // frame_tag (3) + magic (3) + width (2) + height (2)
+    out.extend_from_slice(&[0, 0, 0]); // frame_tag, low bit 0 = keyframe
+    out.extend_from_slice(&[0x9D, 0x01, 0x2A]); // magic
+    out.extend_from_slice(&[16u8, 0]); // width = 16
+    out.extend_from_slice(&[16u8, 0]); // height = 16
+
+    let riff_size = (out.len() - 8) as u32;
+    out[4..8].copy_from_slice(&riff_size.to_le_bytes());
+
+    match WebPDemuxer::new(&out) {
+        Ok(d) => {
+            if let Some(frame) = d.frame(1) {
+                let _ = frame.bitstream.len();
+            }
+        }
+        Err(_) => {}
+    }
+}


### PR DESCRIPTION
Addresses the two HIGH findings from the 2026-05-06 security audit
(`~/work/feedback/security-audit-2026-05-06/zenwebp.md`). Both are
DoS / fragility class — no memory-corruption reachable from the public
API was confirmed in the audit, but both fixes close real panic /
amplification paths.

## H1 — `Limits::check_memory` now gates lossless transform sub-images

Pre-fix: a small (~few KB) crafted VP8L bitstream could trigger up to
~192 MB of intermediate `Vec<u8>` allocations (predictor sub-image +
color sub-image + meta-Huffman entropy image), all sized off attacker-
controlled `size_bits` (2..9), without going through `Limits`. Same
amplification applied to the ALPH chunk's RGBA scratch + green plane.

Fix:

* `LosslessDecoder::set_limits(Option<&Limits>)` and a new private
  `alloc_bytes_checked` helper. Every `vec![0; ...]` in
  `decoder/lossless.rs` (lines 240, 257, 273, 332) now goes through
  `Limits::check_memory` first.
* `read_alpha_chunk` now takes `&Limits`. The 1 GB-worst-case RGBA
  scratch and 256 MB green plane in `decoder/extended.rs:361,364` are
  gated, and the inner `LosslessDecoder` inherits the same budget.
* All call sites in `decoder/api.rs`, `decoder/vp8v2/animation.rs`,
  and `codec.rs` plumb the active `Limits` through.
* `InternalDecodeError::MemoryLimitExceeded` added so the hot-path
  error type can carry the new failure mode without re-introducing a
  `String` variant.

Audit lines: `src/decoder/lossless.rs:240,257,332`,
`src/decoder/extended.rs:361,364`.

## H2 — Demuxer chunk ranges are now bounded before recording or slicing

Pre-fix: `WebPDemuxer` stored byte ranges sourced directly from RIFF
chunk-size fields. A truncated or adversarial file whose chunk headers
lied about their size caused panics in
`parse_anmf_frame` (`src/mux/demux.rs:506`),
`single_frame` (line 492), and the ALPH sub-chunk path. On 32-bit
targets `start + size` could also wrap.

Fix:

* `parse_simple_lossy` / `parse_simple_lossless`: clamp the recorded
  bitstream end to `min(start + chunk_size, data.len())` via
  `checked_add`, so a near-`u32::MAX` chunk_size cannot wrap usize.
* `parse_extended` ANMF branch: only push a `FrameRecord` if its
  declared payload range fits within `data.len()`. The loop used to
  push before `seek_from_start` past the payload; if the seek failed
  the record stayed in `frames` with an out-of-bounds range. Same
  clamping applied to ICCP / EXIF / XMP / simple-form ALPH ranges.
* `parse_anmf_frame`: switch the outer slice to `self.data.get(...)?`
  (defense in depth) and route every sub-chunk offset (including the
  ALPH→VP8 sub-chunk handoff) through `checked_add`.

Audit lines: `src/mux/demux.rs:212,256,506`.

## Tests

`tests/security_audit_2026_05_06.rs` — five regression tests:

* `h1_predictor_transform_allocation_rejected_when_over_memory_limit`
  builds an 8192×8192 VP8L with `size_bits = 2` (16 MB sub-image) and
  asserts the decoder rejects under a 4 MB budget with
  `MemoryLimitExceeded`.
* `h1_predictor_transform_allocation_allowed_when_under_memory_limit`
  proves the limit doesn't false-positive on small inputs.
* `h2_truncated_anmf_does_not_panic`,
  `h2_truncated_simple_vp8l_does_not_panic`,
  `h2_truncated_simple_vp8_does_not_panic` — each constructs a
  container whose chunk header lies about its size and asserts the
  demuxer either rejects or returns without panicking.

## Validation

* `cargo fmt` (changed files only — pre-existing whitespace in `dev/`
  is unrelated)
* `cargo clippy --lib --tests -- -D warnings` clean
* `cargo test --lib` — 258 passed
* `cargo test --tests` — full suite passes
* `cargo test --doc` — 33 passed

Out of scope: the audit's MEDIUM/LOW findings (M1 32-bit
`SliceReader`, M2 predictor entry-bound guards, M4 mux assemble
amplification, H4 frame-count off-by-one, H5 animation buffer churn,
…) — those need separate PRs.