### PR TITLE
feat(anim)!: preserve whereat trace through the AnimationDecoder API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ earlier history lives in git log and LOG.md.)
 
 ## [Unreleased]
 
+### QUEUED BREAKING CHANGES
+<!-- Batch into the next 0.x minor. -->
+- `mux::AnimationDecoder`'s fallible methods (`new`, `next_frame`, `decode_next`,
+  `decode_all`, `reset`, `set_background_color`, `icc_profile`, `exif_metadata`,
+  `xmp_metadata`) and its `Iterator::Item` now carry `whereat::At<DecodeError>`
+  instead of bare `DecodeError`, so animation-decode errors keep their `file:line`
+  source location (the one-shot decode path already returned `At<DecodeError>` —
+  this brings the animation API in line). The trace was previously stripped via
+  `From<At<DecodeError>> for DecodeError`. Get the inner error with `e.error()` /
+  `e.decompose().0`.
+
 ### Changed
 - Decoder `Limits::default()` raises `max_total_pixels` from 100 MP to 120 MP so
   common ~108 MP camera photos decode under the default policy.

--- a/docs/public-api/zenwebp.features.txt
+++ b/docs/public-api/zenwebp.features.txt
@@ -14,7 +14,7 @@
 #   pub consts/statics                          1
 #   free functions                              6
 #   inherent methods                           41
-#   struct fields                              51
+#   struct fields                              53
 #   enum variants                              18
 #   re-exports                                  8
 #   trait roster entries (type × trait)        42
@@ -26,10 +26,10 @@
 #   decoder                           1
 #   encoder                          22
 #   pixel                             2
-#   sweep                            65
+#   sweep                            67
 #   zencodec                         42
 
-## items (148 lines)
+## items (150 lines)
 
 pub use AblationToggles
 pub use InternalParams
@@ -81,6 +81,7 @@ pub struct sweep::LosslessVariant
 pub sweep::LosslessVariant::method: u8
 pub sweep::LosslessVariant::quality: f32
 pub struct sweep::LossyAxes
+pub sweep::LossyAxes::filter_sharpness: alloc::vec::Vec<core::option::Option<u8>>
 pub sweep::LossyAxes::filter_strength: alloc::vec::Vec<core::option::Option<u8>>
 pub sweep::LossyAxes::internal: alloc::vec::Vec<sweep::NamedLossyProbe>
 pub sweep::LossyAxes::methods: alloc::vec::Vec<u8>
@@ -88,6 +89,7 @@ pub sweep::LossyAxes::segments: alloc::vec::Vec<core::option::Option<u8>>
 pub sweep::LossyAxes::sharp_yuv: alloc::vec::Vec<bool>
 pub sweep::LossyAxes::sns_strength: alloc::vec::Vec<core::option::Option<u8>>
 pub struct sweep::LossyVariant
+pub sweep::LossyVariant::filter_sharpness: core::option::Option<u8>
 pub sweep::LossyVariant::filter_strength: core::option::Option<u8>
 pub sweep::LossyVariant::internal: sweep::NamedLossyProbe
 pub sweep::LossyVariant::method: u8

--- a/docs/public-api/zenwebp.txt
+++ b/docs/public-api/zenwebp.txt
@@ -6,7 +6,7 @@
 # impls omitted; re-export duplicates annotated `[also: path]`.
 # DO NOT EDIT BY HAND — commit regenerated changes with the code.
 #
-# files: zenwebp.txt 790 lines (supported surface) | zenwebp.features.txt 179 added (features: ablation,analyzer,avx512,cms,fast-yuv,imgref,mode_debug,picker,pixel-types,std,target-zensim,testable_dispatch,zencodec) | zenwebp.internal.txt 940 lines (1408 hidden + 0 excluded-feature)
+# files: zenwebp.txt 790 lines (supported surface) | zenwebp.features.txt 181 added (features: ablation,analyzer,avx512,cms,fast-yuv,imgref,mode_debug,picker,pixel-types,std,target-zensim,testable_dispatch,zencodec) | zenwebp.internal.txt 940 lines (1408 hidden + 0 excluded-feature)
 
 ## summary
 #
@@ -451,23 +451,23 @@ pub mux::AnimationConfig::loop_count: decoder::LoopCount
 pub mux::AnimationConfig::minimize_size: bool
 pub struct mux::AnimationDecoder<'a>
 pub fn mux::AnimationDecoder<'a>::current_frame_data(&self) -> &[u8]
-pub fn mux::AnimationDecoder<'a>::decode_all(&mut self) -> core::result::Result<alloc::vec::Vec<mux::AnimFrame>, DecodeError>
-pub fn mux::AnimationDecoder<'a>::decode_next(&mut self) -> core::result::Result<core::option::Option<mux::FrameInfo>, DecodeError>
-pub fn mux::AnimationDecoder<'a>::exif_metadata(&mut self) -> core::result::Result<core::option::Option<alloc::vec::Vec<u8>>, DecodeError>
+pub fn mux::AnimationDecoder<'a>::decode_all(&mut self) -> core::result::Result<alloc::vec::Vec<mux::AnimFrame>, whereat::at::At<DecodeError>>
+pub fn mux::AnimationDecoder<'a>::decode_next(&mut self) -> core::result::Result<core::option::Option<mux::FrameInfo>, whereat::at::At<DecodeError>>
+pub fn mux::AnimationDecoder<'a>::exif_metadata(&mut self) -> core::result::Result<core::option::Option<alloc::vec::Vec<u8>>, whereat::at::At<DecodeError>>
 pub fn mux::AnimationDecoder<'a>::frames_read(&self) -> u32
 pub fn mux::AnimationDecoder<'a>::has_more_frames(&self) -> bool
-pub fn mux::AnimationDecoder<'a>::icc_profile(&mut self) -> core::result::Result<core::option::Option<alloc::vec::Vec<u8>>, DecodeError>
+pub fn mux::AnimationDecoder<'a>::icc_profile(&mut self) -> core::result::Result<core::option::Option<alloc::vec::Vec<u8>>, whereat::at::At<DecodeError>>
 pub fn mux::AnimationDecoder<'a>::info(&self) -> mux::AnimationInfo
 pub fn mux::AnimationDecoder<'a>::loop_duration(&self) -> u64
-pub fn mux::AnimationDecoder<'a>::new(&'a [u8]) -> core::result::Result<Self, DecodeError>
+pub fn mux::AnimationDecoder<'a>::new(&'a [u8]) -> core::result::Result<Self, whereat::at::At<DecodeError>>
 pub fn mux::AnimationDecoder<'a>::new_with_config(&'a [u8], &DecodeConfig) -> core::result::Result<Self, whereat::at::At<DecodeError>>
-pub fn mux::AnimationDecoder<'a>::next_frame(&mut self) -> core::result::Result<core::option::Option<mux::AnimFrame>, DecodeError>
-pub fn mux::AnimationDecoder<'a>::reset(&mut self) -> core::result::Result<(), DecodeError>
-pub fn mux::AnimationDecoder<'a>::set_background_color(&mut self, [u8; 4]) -> core::result::Result<(), DecodeError>
+pub fn mux::AnimationDecoder<'a>::next_frame(&mut self) -> core::result::Result<core::option::Option<mux::AnimFrame>, whereat::at::At<DecodeError>>
+pub fn mux::AnimationDecoder<'a>::reset(&mut self) -> core::result::Result<(), whereat::at::At<DecodeError>>
+pub fn mux::AnimationDecoder<'a>::set_background_color(&mut self, [u8; 4]) -> core::result::Result<(), whereat::at::At<DecodeError>>
 pub fn mux::AnimationDecoder<'a>::set_lossy_upsampling(&mut self, decoder::UpsamplingMethod)
 pub fn mux::AnimationDecoder<'a>::set_memory_limit(&mut self, usize)
 pub fn mux::AnimationDecoder<'a>::set_stop(&mut self, &'a dyn enough::Stop)
-pub fn mux::AnimationDecoder<'a>::xmp_metadata(&mut self) -> core::result::Result<core::option::Option<alloc::vec::Vec<u8>>, DecodeError>
+pub fn mux::AnimationDecoder<'a>::xmp_metadata(&mut self) -> core::result::Result<core::option::Option<alloc::vec::Vec<u8>>, whereat::at::At<DecodeError>>
 pub struct mux::AnimationEncoder
 pub fn mux::AnimationEncoder::add_frame(&mut self, &[u8], PixelLayout, u32, &EncoderConfig) -> mux::MuxResult<()>
 pub fn mux::AnimationEncoder::add_frame_advanced(&mut self, &[u8], PixelLayout, u32, u32, u32, u32, u32, &EncoderConfig, mux::DisposeMethod, mux::BlendMethod) -> mux::MuxResult<()>

--- a/src/mux/anim_decode.rs
+++ b/src/mux/anim_decode.rs
@@ -88,8 +88,8 @@ impl<'a> AnimationDecoder<'a> {
     /// Create a new animation decoder from WebP data.
     ///
     /// Returns an error if the data is not a valid animated WebP.
-    pub fn new(data: &'a [u8]) -> Result<Self, DecodeError> {
-        Ok(Self::new_with_config(data, &DecodeConfig::default())?)
+    pub fn new(data: &'a [u8]) -> Result<Self, whereat::At<DecodeError>> {
+        Self::new_with_config(data, &DecodeConfig::default())
     }
 
     /// Create a new animation decoder with custom decode configuration.
@@ -150,8 +150,8 @@ impl<'a> AnimationDecoder<'a> {
     }
 
     /// Set background color for compositing.
-    pub fn set_background_color(&mut self, color: [u8; 4]) -> Result<(), DecodeError> {
-        Ok(self.decoder.set_background_color(color)?)
+    pub fn set_background_color(&mut self, color: [u8; 4]) -> Result<(), whereat::At<DecodeError>> {
+        self.decoder.set_background_color(color)
     }
 
     /// Set a cooperative cancellation token.
@@ -166,18 +166,18 @@ impl<'a> AnimationDecoder<'a> {
     }
 
     /// Read the embedded ICC profile, if any.
-    pub fn icc_profile(&mut self) -> Result<Option<Vec<u8>>, DecodeError> {
-        Ok(self.decoder.icc_profile()?)
+    pub fn icc_profile(&mut self) -> Result<Option<Vec<u8>>, whereat::At<DecodeError>> {
+        self.decoder.icc_profile()
     }
 
     /// Read the embedded EXIF metadata, if any.
-    pub fn exif_metadata(&mut self) -> Result<Option<Vec<u8>>, DecodeError> {
-        Ok(self.decoder.exif_metadata()?)
+    pub fn exif_metadata(&mut self) -> Result<Option<Vec<u8>>, whereat::At<DecodeError>> {
+        self.decoder.exif_metadata()
     }
 
     /// Read the embedded XMP metadata, if any.
-    pub fn xmp_metadata(&mut self) -> Result<Option<Vec<u8>>, DecodeError> {
-        Ok(self.decoder.xmp_metadata()?)
+    pub fn xmp_metadata(&mut self) -> Result<Option<Vec<u8>>, whereat::At<DecodeError>> {
+        self.decoder.xmp_metadata()
     }
 
     /// Total duration of all frames in milliseconds.
@@ -189,7 +189,7 @@ impl<'a> AnimationDecoder<'a> {
     }
 
     /// Decode the next frame, returning `None` when all frames have been read.
-    pub fn next_frame(&mut self) -> Result<Option<AnimFrame>, DecodeError> {
+    pub fn next_frame(&mut self) -> Result<Option<AnimFrame>, whereat::At<DecodeError>> {
         let info = match self.decode_next()? {
             Some(info) => info,
             None => return Ok(None),
@@ -208,9 +208,9 @@ impl<'a> AnimationDecoder<'a> {
     /// Returns frame metadata on success. The composited pixel data is
     /// available via [`current_frame_data()`](Self::current_frame_data)
     /// until the next call to `decode_next` or `next_frame`.
-    pub fn decode_next(&mut self) -> Result<Option<FrameInfo>, DecodeError> {
+    pub fn decode_next(&mut self) -> Result<Option<FrameInfo>, whereat::At<DecodeError>> {
         if let Some(stop) = self.stop {
-            stop.check()?;
+            stop.check().map_err(|e| at!(DecodeError::from(e)))?;
         }
         match self.decoder.read_frame(&mut self.buf) {
             Ok(duration_ms) => {
@@ -226,7 +226,7 @@ impl<'a> AnimationDecoder<'a> {
                 }))
             }
             Err(ref e) if matches!(e.error(), DecodeError::NoMoreFrames) => Ok(None),
-            Err(e) => Err(e.into()),
+            Err(e) => Err(e),
         }
     }
 
@@ -241,7 +241,7 @@ impl<'a> AnimationDecoder<'a> {
     }
 
     /// Reset the decoder to the first frame.
-    pub fn reset(&mut self) -> Result<(), DecodeError> {
+    pub fn reset(&mut self) -> Result<(), whereat::At<DecodeError>> {
         self.decoder.reset_animation()?;
         self.cumulative_ms = 0;
         self.frames_read = 0;
@@ -249,7 +249,7 @@ impl<'a> AnimationDecoder<'a> {
     }
 
     /// Decode all remaining frames at once.
-    pub fn decode_all(&mut self) -> Result<Vec<AnimFrame>, DecodeError> {
+    pub fn decode_all(&mut self) -> Result<Vec<AnimFrame>, whereat::At<DecodeError>> {
         self.reset()?;
         let mut frames = Vec::with_capacity(self.total_frames as usize);
         while let Some(frame) = self.next_frame()? {
@@ -260,7 +260,7 @@ impl<'a> AnimationDecoder<'a> {
 }
 
 impl Iterator for AnimationDecoder<'_> {
-    type Item = Result<AnimFrame, DecodeError>;
+    type Item = Result<AnimFrame, whereat::At<DecodeError>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.next_frame() {


### PR DESCRIPTION
## What

Part of the whereat rollout. Closes the partial-lossy gap the audit flagged: zenwebp's one-shot decode path already returns `At<DecodeError>` (location-tagged), but the **animation API silently discarded the trace**.

**BREAKING:** `mux::AnimationDecoder`'s fallible methods (`new`, `next_frame`, `decode_next`, `decode_all`, `reset`, `set_background_color`, `icc_profile`, `exif_metadata`, `xmp_metadata`) and its `Iterator::Item` now return `whereat::At<DecodeError>` instead of bare `DecodeError`. Get the cause with `e.error()` / `e.decompose().0`.

## Why

These methods previously stripped the source location — `decode_next` did `Err(e.into())` (via `From<At<DecodeError>> for DecodeError`), and the metadata methods did `Ok(self.decoder.X()?)` where the inner `WebPDecoder` already produced `At<DecodeError>`. So an animation-decode failure reached the caller with no `file:line` for server logs. Now the trace propagates unchanged.

## Verified

- `cargo build --lib --tests` + `cargo clippy --lib` clean (clippy's `needless_question_mark` auto-applied where the `Ok(?)` became redundant).
- `cargo test --lib` → **259 passed / 0 failed**; `cargo test --doc` → **33 passed / 0 failed**.
- Public-API snapshot regenerated (`docs/public-api/zenwebp.txt`).

zenwebp has no external users (CLAUDE.md), so the breaking error-type change is fine.
