### PR TITLE
docs(limits): fix stale 100MP comment after the 120MP default bump

### DIFF
--- a/tests/security_audit_2026_05_06.rs
+++ b/tests/security_audit_2026_05_06.rs
@@ -105,7 +105,7 @@ fn h1_predictor_transform_allocation_rejected_when_over_memory_limit() {
     // = 2048^2 * 4 = 16 MB. We set max_memory to 4 MB so the predictor
     // allocation must be rejected before any real decode work.
     //
-    // 8192*8192 = 67 MP which fits within the default 100 MP total-pixels
+    // 8192*8192 = 67 MP which fits within the default 120 MP total-pixels
     // ceiling, so the constructor's dimension validation passes and we reach
     // the lossless transform allocation site that this test is targeting.
     let payload = build_amplifying_vp8l(8192, 8192);


### PR DESCRIPTION
## Context

The user-directed change — raise zenwebp's decoder default `max_total_pixels` from **100 MP → 120 MP** so common ~108 MP camera photos decode under the default policy — **was already landed on `main`** in commit `e02c7b3` ("limits: raise decoder default max_total_pixels 100MP->120MP", 2026-06-13). That commit already covers:

- `src/decoder/limits.rs:63` — `max_total_pixels: Some(120_000_000)`
- `src/decoder/limits.rs:55` — doc comment "Max total pixels: 120 megapixels"
- `CHANGELOG.md` `### Changed` — entry citing "~108 MP camera photos"

A crate-wide sweep of `main` confirms **no remaining 100 MP pixel-limit** anywhere (the `100 * 1024 * 1024` value at `limits.rs:65` is `max_file_size`, a byte cap — correctly left untouched).

## What this PR changes

The prior bump missed one stale **comment** in a test:

- `tests/security_audit_2026_05_06.rs:108` — referenced "the default **100 MP** total-pixels ceiling" → corrected to **120 MP**.

The test value (8192×8192 = 67 MP) fits under both the old and new limit, so the assertion is unaffected — this is a **comment-only correction**, non-breaking, no behavior change.

No CHANGELOG entry added: the substantive bump's entry is already present, and a stale-comment fix isn't user-visible.