### PR TITLE
fix(error): preserve MuxError At trace via map_err_at (no more stringify/flatten)

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1120,8 +1120,7 @@ impl WebpAnimationFrameEncoder {
                 loop_count: self.loop_count,
                 ..AnimationConfig::default()
             };
-            let enc = AnimationEncoder::new(cw, ch, config)
-                .map_err(|e| at!(mux_to_encode_err(e.decompose().0)))?;
+            let enc = AnimationEncoder::new(cw, ch, config).map_err_at(mux_to_encode_err)?;
             self.anim_enc = Some(enc);
         }
         Ok(())
@@ -1169,7 +1168,7 @@ impl zencodec::encode::AnimationFrameEncoder for WebpAnimationFrameEncoder {
         let timestamp_ms = self.cumulative_ms;
         let enc = self.anim_enc.as_mut().unwrap();
         enc.add_frame(&buf, layout, timestamp_ms, &self.inner_config)
-            .map_err(|e| at!(mux_to_encode_err(e.decompose().0)))?;
+            .map_err_at(mux_to_encode_err)?;
         self.cumulative_ms = self.cumulative_ms.saturating_add(duration_ms);
         self.last_frame_duration_ms = duration_ms;
         Ok(())
@@ -1185,7 +1184,7 @@ impl zencodec::encode::AnimationFrameEncoder for WebpAnimationFrameEncoder {
             .map_err(|e| at!(e))?;
         let data = enc
             .finalize(self.last_frame_duration_ms)
-            .map_err(|e| at!(mux_to_encode_err(e.decompose().0)))?;
+            .map_err_at(mux_to_encode_err)?;
         self.limits
             .check_output_size(data.len() as u64)
             .map_err(|e| at!(EncodeError::LimitExceeded(alloc::format!("{e}"))))?;
@@ -1574,10 +1573,8 @@ impl<'a> zencodec::decode::DecodeJob<'a> for WebpDecodeJob {
             }
             b"VP8X" => {
                 use crate::mux::WebPDemuxer;
-                let demuxer = WebPDemuxer::new(data_ref).map_err(|e| {
-                    at!(DecodeError::InvalidParameter(alloc::format!(
-                        "demux error: {e}"
-                    )))
+                let demuxer = WebPDemuxer::new(data_ref).map_err_at(|inner| {
+                    DecodeError::InvalidParameter(alloc::format!("demux error: {inner}"))
                 })?;
 
                 if demuxer.is_animated() {
@@ -2355,7 +2352,7 @@ impl WebpAnimationFrameDecoder {
                     Ok(None) => Ok(true),
                     Err(e) => Err(e),
                 })
-                .map_err(|e| at!(e))?;
+                .at()?;
             if done {
                 break;
             }
@@ -2388,7 +2385,7 @@ impl WebpAnimationFrameDecoder {
                     Err(e) => Err(e),
                 }
             })
-            .map_err(|e| at!(e))?;
+            .at()?;
 
         match result {
             Some(duration_ms) => {

--- a/src/decoder/api.rs
+++ b/src/decoder/api.rs
@@ -1,6 +1,6 @@
 use alloc::string::String;
 use thiserror::Error;
-use whereat::at;
+use whereat::{ResultAtExt, at};
 
 /// Errors that can occur when attempting to decode a WebP image
 #[derive(Debug, Error)]
@@ -597,10 +597,8 @@ impl<'a> DecodeRequest<'a> {
                 // Extended format — use the demuxer to find the VP8 bitstream
                 use crate::mux::WebPDemuxer;
 
-                let demuxer = WebPDemuxer::new(data).map_err(|e| {
-                    whereat::at!(DecodeError::InvalidParameter(alloc::format!(
-                        "demux error: {e}"
-                    )))
+                let demuxer = WebPDemuxer::new(data).map_err_at(|inner| {
+                    DecodeError::InvalidParameter(alloc::format!("demux error: {inner}"))
                 })?;
 
                 if demuxer.is_animated() {

--- a/src/decoder/vp8v2/animation.rs
+++ b/src/decoder/vp8v2/animation.rs
@@ -8,6 +8,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
+use whereat::ResultAtExt;
 #[allow(unused_imports)]
 use whereat::at;
 
@@ -68,7 +69,7 @@ impl DecoderContext {
         mut callback: impl FnMut(AnimationFrame<'_>) -> bool,
     ) -> Result<(), whereat::At<DecodeError>> {
         let limits = Limits::default();
-        let demuxer = WebPDemuxer::new(data).map_err(|e| at!(mux_to_decode(e)))?;
+        let demuxer = WebPDemuxer::new(data).map_err_at(mux_to_decode)?;
 
         if !demuxer.is_animated() {
             return Err(at!(DecodeError::InvalidParameter(
@@ -252,6 +253,6 @@ fn clear_rect(
 }
 
 /// Convert a `MuxError` to a `DecodeError`.
-fn mux_to_decode(e: whereat::At<MuxError>) -> DecodeError {
+fn mux_to_decode(e: MuxError) -> DecodeError {
     DecodeError::InvalidParameter(alloc::format!("demux error: {e}"))
 }


### PR DESCRIPTION
## Summary

Trace-loss cleanup for the whereat `At<MuxError>` -> `At<DecodeError>`/`At<EncodeError>` conversions in the zencodec/mux glue, plus a **pre-existing CI-red compile fix** (the `zencodec` feature did not build on main).

### Trace-loss fixes (the assigned task)

Each site below consumed an `At<MuxError>` (carries a location trace; `MuxResult<T> = Result<T, At<MuxError>>`) and either stringified it or flattened it before re-wrapping, discarding the demuxer's trace:

| Site | Before | After |
|---|---|---|
| `decoder/vp8v2/animation.rs:255` + callsite `:71` | helper `mux_to_decode(e: At<MuxError>)` stringified the whole `At`; callsite `.map_err(\|e\| at!(mux_to_decode(e)))` | helper takes bare `MuxError`; `.map_err_at(mux_to_decode)?` |
| `decoder/api.rs:600` (VP8X demuxer) | `.map_err(\|e\| at!(DecodeError::InvalidParameter(format!("demux error: {e}"))))` | `.map_err_at(\|inner\| DecodeError::InvalidParameter(format!("demux error: {inner}")))?` |
| `codec.rs:1577` (streaming VP8X demuxer, dup) | same flatten | same `.map_err_at` |
| `codec.rs:1124 / 1172 / 1188` (animation encoder) | `.map_err(\|e\| at!(mux_to_encode_err(e.decompose().0)))?` — `decompose().0` drops the trace, `at!` resets it | `.map_err_at(mux_to_encode_err)?` (converts `MuxError`->`EncodeError` in place) |

Human-readable messages are unchanged; the inner `At` trace is now preserved through each boundary.

### Bonus: pre-existing CI-red fix

main's CI is currently **failing** because the `zencodec` feature does not compile: two `WebpAnimationDecoder` self_cell `with_dependent_mut(...)` closures return `Result<_, At<DecodeError>>`, but `.map_err(\|e\| at!(e))?` double-wrapped them into `At<At<DecodeError>>`, which `?` cannot flatten (`codec.rs:2356` and `:2389`). Replaced both with `.at()?`, which adds a caller frame to the existing trace instead of nesting — fixes the compile error and preserves the trace.

### Left alone (correctly bare, NOT trace-loss)

- `limits.check_dimensions/check_memory/check_output_size` consume `zencodec::ResourceLimits`, which returns a **bare** `LimitExceeded` (not an `At`) — so `at!(EncodeError::LimitExceeded(format!("{e}")))` loses no trace. (The original audit mislabeled these as `At<DecodeError>`; they're a different type than the local `decoder::Limits`.)
- Bare `SinkError` mapping sites in `codec.rs`.

## Verification (all GREEN, under run-heavy, no target-cpu=native)

- `cargo clippy --features zencodec --all-targets -- -D warnings` ✓
- `cargo test --features zencodec` ✓ (all unit/integration/doctests, 0 failed)
- `cargo test` (default features) ✓ (0 failed)
- `cargo fmt --check` ✓

Built in an isolated jj workspace off `main@origin`; 3 files changed.