### PR TITLE
feat(error): adopt CategorizedError + map variants to ErrorCategory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,16 +120,15 @@ jobs:
         run: cargo test --no-default-features --lib
       - name: std only
         run: cargo test --no-default-features --features std --lib
-      - name: zencodec
-        run: cargo test --features zencodec
-      - name: zencodec + imgref
-        run: cargo test --features "zencodec,imgref"
-      - name: zencodec + cms
-        run: cargo test --features "zencodec,cms"
+      # zencodec is now an always-on hard dep (no longer a feature), so the
+      # default `cargo test` / `cargo test --features imgref` in the main Test
+      # job already cover it. Only the cms (icc-db) permutation is unique here.
+      - name: cms
+        run: cargo test --features cms
       - name: avx512
         run: cargo check --features avx512
       - name: All public features
-        run: cargo test --features "std,pixel-types,imgref,avx512,zencodec,cms"
+        run: cargo test --features "std,pixel-types,imgref,avx512,cms"
 
   simd-tier-parity:
     name: SIMD tier parity (${{ matrix.name }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,20 @@ earlier history lives in git log and LOG.md.)
   mechanical once the break is approved.
 
 ### Changed
+- **`zencodec` is now a required, always-on dependency — the codec-trait
+  integration is no longer behind the optional `zencodec` cargo feature**
+  (#69). `zencodec` is `#![no_std] + alloc`, so the `EncoderConfig` /
+  `DecoderConfig` adapters, the `StreamingDecode` / animation-frame jobs, the
+  color-emit (ICC-synthesis) path, and the `CategorizedError` impls on
+  `DecodeError` / `EncodeError` / `mux::MuxError` / `ValidationError` /
+  `detect::ProbeError` now build unconditionally. Removed the `zencodec` cargo
+  feature; `self_cell` and `zenpixels-convert` (kept `default-features = false`)
+  became unconditional dependencies. `cms` now enables
+  `zenpixels-convert/icc-db` directly (was the weak `zenpixels-convert?/icc-db`
+  passthrough). no_std and wasm32 builds are unaffected — the integration is
+  no_std-clean; the only `std`-genuine arm (`DecodeError::IoError`) stays gated
+  on `feature = "std"`. Also dropped the now-redundant `zencodec` dev-dependency
+  (the EXIF-parity unit test reaches it through the regular dep).
 - **deps: migrate to published `zencodec 0.1.24` estimate API; drop the temporary
   git-rev patch.** Removed the `[patch.crates-io]` zencodec git-rev pin (0f71295)
   now that `zencodec 0.1.24` is on crates.io. Updated the
@@ -51,7 +65,7 @@ earlier history lives in git log and LOG.md.)
 - **Adopt the `zencodec` `CategorizedError` taxonomy (PR #103).** The public
   encode/decode error types — `DecodeError`, `EncodeError`, `mux::MuxError`,
   `ValidationError`, and `detect::ProbeError` — now `impl
-  zencodec::CategorizedError` (gated on the `zencodec` feature) with
+  zencodec::CategorizedError` with
   `codec_name() = Some("zenwebp")` and a `category()` mapping every variant to one
   coarse `ErrorCategory`, so consumers route on the category (HTTP status,
   retry policy, logging) without naming the concrete enum. Bitstream errors map
@@ -74,7 +88,7 @@ earlier history lives in git log and LOG.md.)
   representative `Memory` kind (see QUEUED BREAKING CHANGES).
 
 - **Honor `zencodec::AllocPreference` (3-mode, per-site) at untrusted decode
-  allocations** (zencodec feature): the big buffers sized from decoded header
+  allocations**: the big buffers sized from decoded header
   dimensions — the final RGB/RGBA output, the VP8 row cache, the streaming
   strip buffer, the lossless ARGB plane / RGBA-expansion scratch, and the
   animation canvas — now route through a per-site fallibility policy
@@ -86,8 +100,8 @@ earlier history lives in git log and LOG.md.)
   native decode API is unchanged (always `CodecDefault`). Added `checked_mul`
   guards on the streaming strip-buffer size. No public API change.
 
-- **`estimate_decode_resources` override on `WebpDecoderConfig`** (zencodec
-  feature): implements zencodec's unified
+- **`estimate_decode_resources` override on `WebpDecoderConfig`**: implements
+  zencodec's unified
   `DecoderConfig::estimate_decode_resources` via the existing
   `heuristics::estimate_decode` model — peak = output buffer + VP8 working set
   (decoder state + ~12 B/px for the row cache, reconstruction buffer and
@@ -95,8 +109,8 @@ earlier history lives in git log and LOG.md.)
   (zenwebp decode is single-threaded). Returns a
   `zencodec::estimate::ResourceEstimate`.
 
-- **`estimate_encode_resources` override on `WebpEncoderConfig`** (zencodec
-  feature): implements zencodec's unified `EncoderConfig::estimate_encode_resources`
+- **`estimate_encode_resources` override on `WebpEncoderConfig`**: implements
+  zencodec's unified `EncoderConfig::estimate_encode_resources`
   via the existing `heuristics::estimate_encode` model, returning a
   `zencodec::estimate::ResourceEstimate` (typical/max peak memory, wall time).
   WebP encode is single-threaded, so threading is reported as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ earlier history lives in git log and LOG.md.)
   already returned `At<DecodeError>`. `build` no longer silently strips the trace
   through the removed `From<At<DecodeError>> for DecodeError` dropper. Get the
   inner error with `e.error()` / `e.decompose().0`.
+- `EncodeError::LimitExceeded(String)` would become a kind-carrying variant
+  (e.g. `LimitExceeded { kind: LimitKind, message: String }`) so its
+  `CategorizedError::category()` can report the exact `LimitKind` instead of the
+  representative `Memory` it returns today. Deferred — changing the tuple
+  variant's shape is a breaking change; its construction sites
+  (`src/codec.rs`) already hold the typed `Limits`-check error, so the rewire is
+  mechanical once the break is approved.
 
 ### Changed
 - **deps: migrate to published `zencodec 0.1.24` estimate API; drop the temporary
@@ -40,6 +47,31 @@ earlier history lives in git log and LOG.md.)
   fair-benchmark methodology and exact repro. No code or public-API change.
 
 ### Added
+
+- **Adopt the `zencodec` `CategorizedError` taxonomy (PR #103).** The public
+  encode/decode error types — `DecodeError`, `EncodeError`, `mux::MuxError`,
+  `ValidationError`, and `detect::ProbeError` — now `impl
+  zencodec::CategorizedError` (gated on the `zencodec` feature) with
+  `codec_name() = Some("zenwebp")` and a `category()` mapping every variant to one
+  coarse `ErrorCategory`, so consumers route on the category (HTTP status,
+  retry policy, logging) without naming the concrete enum. Bitstream errors map
+  to `MalformedImage`; `NotEnoughInitData`/`NoMoreFrames`→`UnexpectedEof`;
+  `UnsupportedFeature`→`UnsupportedImageFeature`;
+  `IccSynthesisUnavailable`→`CmsRequired`; `InvalidBufferSize`→`InvalidBuffer`;
+  validation/dimension/layout errors→`InvalidParameters`. Limit variants map to
+  the closest `LimitKind` (`ImageTooLarge`→`Pixels`,
+  `MemoryLimitExceeded`→`Memory`, `Partition0Overflow`→`OutputSize`); the
+  `Cancelled`/`UnsupportedOperation` arms delegate to the zencodec cause types
+  (`StopReason`/`UnsupportedOperation`), preserving timeout-vs-cancel; `MuxError`
+  delegates its wrapped `EncodeError`/`DecodeError`. The `At<E>` blanket impl
+  forwards both category and codec name. Additive (opt-in trait on
+  `#[non_exhaustive]` enums; no public-API break). Behind a **temporary
+  `[patch.crates-io]` pin** to the unreleased `cancellation-classification-99`
+  branch — remove the patch and bump the `zencodec` dependency once
+  `zencodec 0.1.26` ships. `EncodeError::LimitExceeded(String)` is stringly and
+  can't carry the exact `LimitKind` (its construction sites collapse the
+  dimensions/memory/output-size limit checks into a message), so it maps to a
+  representative `Memory` kind (see QUEUED BREAKING CHANGES).
 
 - **Honor `zencodec::AllocPreference` (3-mode, per-site) at untrusted decode
   allocations** (zencodec feature): the big buffers sized from decoded header
@@ -104,6 +136,21 @@ earlier history lives in git log and LOG.md.)
   to their own `Cargo.toml` (#65).
 
 ### Fixed
+
+- **Restore the `wasm32`/`i686`, `no_std`-test, and default-feature clippy
+  builds** (pre-existing on `main`, unrelated to the taxonomy work; CI red since
+  2026-06-23, run `28284349117`). Three independent breakages, fixed as one
+  clearly-labeled fix-forward commit so this PR's CI can be green: (1)
+  `predictor_avg_body_wide` in `src/decoder/lossless_transform_simd.rs` was
+  missing the `#[cfg(target_arch = "x86_64")]` gate its sibling
+  `predictor_add_body_wide` carries, so its x86_64-only `chunk32`/`chunk32_ref`
+  helpers fell out of scope on `wasm32`/`i686` (`E0425 cannot find function
+  chunk32_ref`); (2) the `src/decoder/extended.rs` `#[cfg(test)]` module used the
+  `vec!` macro without `use alloc::vec;`, breaking
+  `cargo test --no-default-features --lib`; (3) `AllocPreference::{Fallible,
+  Infallible}` (`src/decoder/alloc_util.rs`) are only constructed via the
+  `zencodec` adapter, so the default-feature clippy build flagged them
+  `dead_code` under `-D warnings` — now `allow`ed only when `zencodec` is off.
 
 - **Fuzz timeout in the `decode_v2` target on a decompression-bomb input**
   (closes #68) — a 104-byte WebP declaring a 12801×4097 (52 MP / 210 MB) VP8L

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ earlier history lives in git log and LOG.md.)
 
 ### QUEUED BREAKING CHANGES
 <!-- Batch into the next 0.x minor. -->
+- **zencodec trait impls now return `At<zencodec::CodecError>` (the envelope,
+  Pattern B) instead of the native `At<EncodeError>` / `At<DecodeError>`** (#69).
+  Every `zencodec::{encode,decode}` trait `type Error` on the WebP adapters
+  (`WebpEncoderConfig`/`WebpEncodeJob`/`WebpEncoder`/`WebpAnimationFrameEncoder`,
+  `WebpDecoderConfig`/`WebpDecodeJob`/`WebpDecoder`/`WebpStreamingDecoder`/
+  `WebpAnimationFrameDecoder`) plus the inherent `WebpDecoderConfig::probe_header`
+  / `decode` convenience methods now surface `At<zencodec::CodecError>`. This lets
+  a generic consumer recover the `ErrorCategory` **and** the codec name
+  (`Some("zenwebp")`) **through `Dyn*` dispatch** — once a result is erased to a
+  `BoxedError` the native error is no longer downcastable, so Pattern A lost both.
+  The five native error types (`DecodeError`, `EncodeError`, `MuxError`,
+  `ValidationError`, `ProbeError`) keep their `CategorizedError` impls and remain
+  the envelope's *detail* + category source (reachable via
+  `CodecErrorExt`/`find_cause::<DecodeError>()`); the native `EncodeRequest` /
+  `DecodeRequest` / `oneshot` APIs are unchanged. Corrects a prior Pattern A
+  surfacing (the envelope was always the intent).
 - `mux::AnimationDecoder`'s fallible methods (`new`, `next_frame`, `decode_next`,
   `decode_all`, `reset`, `set_background_color`, `icc_profile`, `exif_metadata`,
   `xmp_metadata`) and its `Iterator::Item` now carry `whereat::At<DecodeError>`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,8 +2127,7 @@ dependencies = [
 [[package]]
 name = "zencodec"
 version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9328427935f563e3cc12aaab76ad4afe946d1a60611a74047184682afc20ed"
+source = "git+https://github.com/imazen/zencodec?branch=cancellation-classification-99#2c7fb39840ed03c02423554f8fe621b07055267f"
 dependencies = [
  "almost-enough",
  "enough",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -422,3 +422,9 @@ opt-level = 2
 
 [profile.test]
 opt-level = 2
+
+[patch.crates-io]
+# TEMP: until zencodec 0.1.26 ships (PR #103) — provides the unreleased
+# `CategorizedError` taxonomy (trait + `ErrorCategory` + `LimitKind`). Remove
+# this patch and bump the `zencodec` version dependency once 0.1.26 is published.
+zencodec = { git = "https://github.com/imazen/zencodec", branch = "cancellation-classification-99" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,16 +33,19 @@ hashbrown = { version = "0.16", default-features = false, features = ["default-h
 thiserror = { version = "2.0.18", default-features = false }
 whereat = { version = "0.1.5", default-features = false }
 libm = "0.2.16"
-zencodec = { version = "0.1.25", optional = true }
+zencodec = { version = "0.1.25" }
 # zennode = { path = "../zennode/zennode", optional = true, default-features = false, features = ["derive"] }
 zenpixels = { version = "0.2.11", default-features = false }
 # Used by the zencodec encode path to synthesize an ICC profile from a
 # CICP-only source (WebP has no CICP carrier, so an embedded ICC is the only
 # way to retain non-sRGB primaries). `synthesize_icc_for_cicp` is a transfer-
-# aware lookup — no CMS, no_std-safe. Gated on `zencodec`; `default-features
-# = false` keeps the wasm32 (no_std) build clean.
-zenpixels-convert = { version = "0.2.13", default-features = false, optional = true }
-self_cell = { version = "1.2", optional = true }
+# aware lookup — no CMS, no_std-safe. Unconditional (the zencodec integration
+# is always-on); `default-features = false` keeps the wasm32 (no_std) build
+# clean.
+zenpixels-convert = { version = "0.2.13", default-features = false }
+# self_cell backs the owned-data animation decoder in the zencodec adapter
+# (codec.rs). no_std-clean, so it rides the always-on integration.
+self_cell = { version = "1.2" }
 bytemuck = { version = "1", default-features = false, features = ["extern_crate_alloc"] }
 garb = { version = "0.2.5", default-features = false, features = ["experimental"] }
 linear-srgb = { version = "0.6.7"}
@@ -85,9 +88,6 @@ rayon = "1.10"
 rgb = "0.8"
 zenpng = "0.1.4"
 zenpixels-convert = { version = "0.2.13", features = ["rgb"] }
-# Parity oracle for the deliberately-local EXIF orientation parser
-# (src/exif_orientation.rs, zenwebp#58) — dev-only, consumers pay nothing.
-zencodec = "0.1.25"
 jpeg-decoder = "0.3"
 # zenanalyze / zenpredict as path-pinned dev-deps were removed: CI
 # regression-test runs (`cargo build` then `cargo test --test
@@ -152,17 +152,19 @@ _wasm_profiling = ["std"]
 # Kept for backwards compatibility so existing Cargo.toml entries
 # with `features = ["fast-yuv"]` don't break.
 fast-yuv = []
-# Enable zencodec trait integration
-zencodec = ["dep:zencodec", "dep:self_cell", "dep:zenpixels-convert"]
+# NOTE: `zencodec` is no longer an optional feature — the codec-trait
+# integration is now an always-on hard dependency (zencodec is
+# `#![no_std] + alloc`, so it builds on wasm32/no_std). `self_cell` and
+# `zenpixels-convert` are likewise unconditional deps now. See the
+# `[dependencies]` section above.
 # ICC synthesis for the zencodec color-emit path, via zenpixels-convert's
 # `icc-db` feature: a bundled LZ4 profile blob + the pure-Rust lz4_flex
 # decoder — far lighter than pulling moxcms (which is no longer involved in
 # synthesis). Covers the full ITU-T H.273 grid incl PQ/HLG. Without it only
 # the bundled Display-P3 / SDR BT.2020 / AdobeRGB consts synthesize, and an
 # unsynthesizable (off-grid) CICP is an encode error (WebP has no CICP
-# carrier — never a silently mislabeled image). Weak passthrough: only takes
-# effect with `zencodec` enabled.
-cms = ["zenpixels-convert?/icc-db"]
+# carrier — never a silently mislabeled image).
+cms = ["zenpixels-convert/icc-db"]
 # Enable target_zensim closed-loop adaptive encoder.
 # Pulls in zensim for perceptual measurement; iteration loop encodes →
 # decodes → measures → adjusts global VP8 quality until it lands in
@@ -329,15 +331,14 @@ required-features = ["analyzer"]
 
 [[example]]
 name = "hrtb_test"
-required-features = ["zencodec"]
 
 [[example]]
 name = "lossless_anim_path_test"
-required-features = ["zencodec", "std"]
+required-features = ["std"]
 
 [[example]]
 name = "heap_strip_pipeline"
-required-features = ["zencodec", "std"]
+required-features = ["std"]
 
 # Standalone encode+decode hot-path profiling driver (perf-friendly tight
 # loops, no criterion warmup). Takes a PNG path from argv/ZENWEBP_PROF_IMG.

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ zero-cost. For a ready-made, thread-safe cancel/deadline token see
 - **Metadata module** — `zenwebp::metadata` extracts/embeds/removes ICC, EXIF, and
   XMP in encoded WebP bytes without decoding pixels
 - **Server-safe** — memory/pixel limits and cooperative cancellation for untrusted input
-- **zencodec integration** — optional `zencodec` feature for unified codec traits,
+- **zencodec integration** — always-available unified codec traits (no feature flag),
   streaming decode, color/metadata policy, and resource estimation
 
 ### Safe SIMD
@@ -434,7 +434,7 @@ Tested across 14 images (CLIC2025 photos, screenshots, CID22):
 | Screenshots (1K–4K) | 1.06–1.14x |
 | Small photos (512–576px) | 1.10–1.15x |
 
-Streaming via zencodec's `StreamingDecode` trait (feature `zencodec`) yields 16-row
+Streaming via zencodec's `StreamingDecode` trait yields 16-row
 RGB strips — the full decoded image never needs to exist in memory:
 
 | Decode mode | Peak memory (2940×1912) |

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -55,6 +55,62 @@ fn alloc_pref_from_zencodec(
     }
 }
 
+// ── Error envelope bridges (Pattern B) ───────────────────────────────────────
+//
+// The zencodec trait impls below surface `At<zencodec::CodecError>` — the
+// codec-agnostic envelope — so a generic consumer recovers the
+// [`ErrorCategory`](zencodec::ErrorCategory) **and** the codec name *through
+// `Dyn*` dispatch*. Once a result is erased to a `BoxedError`
+// (`Box<dyn Error + Send + Sync>`), the concrete native error is no longer
+// downcastable, so a native `type Error` would lose its category; the envelope
+// is a single concrete type a consumer can recover after any erasure.
+//
+// The native [`EncodeError`] / [`DecodeError`] stay as the *detail* and the
+// *category source*: [`CodecError::of`](zencodec::CodecError::of) reads both the
+// category and `codec_name()` (`Some("zenwebp")`) from the value and keeps the
+// `At` location trace on the outside.
+//
+// Only `EncodeError` and `DecodeError` flow out of a zencodec trait method, so
+// only they need a bridge: `MuxError` is mapped to `EncodeError` before it exits,
+// `ValidationError` is config-only (not on any trait path), and `ProbeError` is
+// discarded on the `source_encoding_details` probe.
+//
+// Two conversion shapes appear below:
+// - A **bare** native value (`EncodeError::from(op)`) → these `From` impls give a
+//   plain `.into()` / `?` (used by the `reject` / policy-decline stubs).
+// - An **already-located** `At<native>` (the common case: every `at!(...)` site
+//   and every helper that returns `At<native>`) → converted explicitly with
+//   [`CodecError::of`](zencodec::CodecError::of), which keeps the existing `at!`
+//   location trace on the *outside* as `At<CodecError>`. `At` is a foreign,
+//   non-`#[fundamental]` type, so `From<At<native>> for At<CodecError>` is
+//   forbidden by the orphan rule — hence the explicit `.map_err(CodecError::of)`
+//   rather than a blanket `?`.
+
+impl From<EncodeError> for At<zencodec::CodecError> {
+    #[track_caller]
+    fn from(e: EncodeError) -> Self {
+        use whereat::ErrorAtExt;
+        zencodec::CodecError::of(e.start_at())
+    }
+}
+
+impl From<DecodeError> for At<zencodec::CodecError> {
+    #[track_caller]
+    fn from(e: DecodeError) -> Self {
+        use whereat::ErrorAtExt;
+        zencodec::CodecError::of(e.start_at())
+    }
+}
+
+/// Bridge a decode-sink error into the envelope. [`copy_decode_to_sink`] wants a
+/// `fn(SinkError) -> J::Error` pointer, so this is a named function rather than a
+/// closure.
+///
+/// [`copy_decode_to_sink`]: zencodec::helpers::copy_decode_to_sink
+fn wrap_sink_to_codec(e: SinkError) -> At<zencodec::CodecError> {
+    zencodec::CodecError::of(at!(DecodeError::InvalidParameter(alloc::format!("{e}"))))
+}
+
 // ── Encoding ────────────────────────────────────────────────────────────────
 
 /// WebP encoder configuration implementing [`zencodec::encode::EncoderConfig`].
@@ -367,7 +423,7 @@ fn interp_quality(table: &[(f32, f32)], x: f32) -> f32 {
 }
 
 impl zencodec::encode::EncoderConfig for WebpEncoderConfig {
-    type Error = At<EncodeError>;
+    type Error = At<zencodec::CodecError>;
     type Job = WebpEncodeJob;
 
     fn format() -> ImageFormat {
@@ -612,7 +668,7 @@ impl WebpEncodeJob {
 }
 
 impl zencodec::encode::EncodeJob for WebpEncodeJob {
-    type Error = At<EncodeError>;
+    type Error = At<zencodec::CodecError>;
     type Enc = WebpEncoder;
     type AnimationFrameEnc = WebpAnimationFrameEncoder;
 
@@ -657,7 +713,7 @@ impl zencodec::encode::EncodeJob for WebpEncodeJob {
         self
     }
 
-    fn encoder(self) -> Result<WebpEncoder, At<EncodeError>> {
+    fn encoder(self) -> Result<WebpEncoder, At<zencodec::CodecError>> {
         let inner_config = self.build_inner_config();
         let policy = self.policy.unwrap_or_default();
         // Metadata retention is no longer gated here with a coarse all-or-nothing
@@ -684,7 +740,9 @@ impl zencodec::encode::EncodeJob for WebpEncodeJob {
         })
     }
 
-    fn animation_frame_encoder(self) -> Result<WebpAnimationFrameEncoder, At<EncodeError>> {
+    fn animation_frame_encoder(
+        self,
+    ) -> Result<WebpAnimationFrameEncoder, At<zencodec::CodecError>> {
         let inner_config = self.build_inner_config();
         let loop_count = match self.loop_count {
             Some(Some(0)) | None => crate::decoder::LoopCount::Forever,
@@ -1043,10 +1101,10 @@ fn convert_single_row_to_yuv(
 }
 
 impl zencodec::encode::Encoder for WebpEncoder {
-    type Error = At<EncodeError>;
+    type Error = At<zencodec::CodecError>;
 
-    fn reject(op: UnsupportedOperation) -> At<EncodeError> {
-        At::from(EncodeError::from(op))
+    fn reject(op: UnsupportedOperation) -> At<zencodec::CodecError> {
+        EncodeError::from(op).into()
     }
 
     fn preferred_strip_height(&self) -> u32 {
@@ -1058,12 +1116,14 @@ impl zencodec::encode::Encoder for WebpEncoder {
         }
     }
 
-    fn encode(self, pixels: PixelSlice<'_>) -> Result<EncodeOutput, At<EncodeError>> {
-        let (buf, layout, w, h, stride) = pixels_to_webp_input(&pixels)?;
+    fn encode(self, pixels: PixelSlice<'_>) -> Result<EncodeOutput, At<zencodec::CodecError>> {
+        let (buf, layout, w, h, stride) =
+            pixels_to_webp_input(&pixels).map_err(zencodec::CodecError::of)?;
         self.do_encode(&buf, layout, w, h, stride)
+            .map_err(zencodec::CodecError::of)
     }
 
-    fn push_rows(&mut self, rows: PixelSlice<'_>) -> Result<(), At<EncodeError>> {
+    fn push_rows(&mut self, rows: PixelSlice<'_>) -> Result<(), At<zencodec::CodecError>> {
         let desc = rows.descriptor();
         let strip_w = rows.width();
         let strip_h = rows.rows();
@@ -1097,7 +1157,8 @@ impl zencodec::encode::Encoder for WebpEncoder {
                 });
             } else {
                 // Generic path: convert per-strip, accumulate bytes
-                let (_, layout, _, _, _) = pixels_to_webp_input(&rows)?;
+                let (_, layout, _, _, _) =
+                    pixels_to_webp_input(&rows).map_err(zencodec::CodecError::of)?;
                 let (cw, ch) = self.canvas_size.unwrap_or((strip_w, 0));
                 let bpp = layout.bytes_per_pixel();
                 let cap = cw as usize * ch as usize * bpp;
@@ -1113,7 +1174,8 @@ impl zencodec::encode::Encoder for WebpEncoder {
                     pixels, total_rows, ..
                 } = stream
                 {
-                    let (buf, _, _, _, _) = pixels_to_webp_input(&rows)?;
+                    let (buf, _, _, _, _) =
+                        pixels_to_webp_input(&rows).map_err(zencodec::CodecError::of)?;
                     pixels.extend_from_slice(&buf);
                     *total_rows += strip_h;
                 }
@@ -1165,7 +1227,8 @@ impl zencodec::encode::Encoder for WebpEncoder {
             StreamAccum::Raw {
                 pixels, total_rows, ..
             } => {
-                let (buf, _, _, _, _) = pixels_to_webp_input(&rows)?;
+                let (buf, _, _, _, _) =
+                    pixels_to_webp_input(&rows).map_err(zencodec::CodecError::of)?;
                 pixels.extend_from_slice(&buf);
                 *total_rows += strip_h;
             }
@@ -1174,11 +1237,10 @@ impl zencodec::encode::Encoder for WebpEncoder {
         Ok(())
     }
 
-    fn finish(mut self) -> Result<EncodeOutput, At<EncodeError>> {
-        let stream = self
-            .stream
-            .take()
-            .ok_or_else(|| at!(EncodeError::InvalidBufferSize("no rows pushed".into())))?;
+    fn finish(mut self) -> Result<EncodeOutput, At<zencodec::CodecError>> {
+        let stream = self.stream.take().ok_or_else(|| {
+            zencodec::CodecError::of(at!(EncodeError::InvalidBufferSize("no rows pushed".into())))
+        })?;
 
         match stream {
             StreamAccum::Yuv {
@@ -1213,13 +1275,16 @@ impl zencodec::encode::Encoder for WebpEncoder {
                     total_rows,
                     width as usize,
                 )
+                .map_err(zencodec::CodecError::of)
             }
             StreamAccum::Raw {
                 pixels,
                 layout,
                 width,
                 total_rows,
-            } => self.do_encode(&pixels, layout, width, total_rows, width as usize),
+            } => self
+                .do_encode(&pixels, layout, width, total_rows, width as usize)
+                .map_err(zencodec::CodecError::of),
         }
     }
 }
@@ -1266,10 +1331,10 @@ impl WebpAnimationFrameEncoder {
 }
 
 impl zencodec::encode::AnimationFrameEncoder for WebpAnimationFrameEncoder {
-    type Error = At<EncodeError>;
+    type Error = At<zencodec::CodecError>;
 
-    fn reject(op: UnsupportedOperation) -> At<EncodeError> {
-        At::from(EncodeError::from(op))
+    fn reject(op: UnsupportedOperation) -> At<zencodec::CodecError> {
+        EncodeError::from(op).into()
     }
 
     fn push_frame(
@@ -1277,11 +1342,13 @@ impl zencodec::encode::AnimationFrameEncoder for WebpAnimationFrameEncoder {
         pixels: PixelSlice<'_>,
         duration_ms: u32,
         stop: Option<&dyn enough::Stop>,
-    ) -> Result<(), At<EncodeError>> {
+    ) -> Result<(), At<zencodec::CodecError>> {
         if let Some(s) = stop {
-            s.check().map_err(|e| at!(EncodeError::from(e)))?;
+            s.check()
+                .map_err(|e| zencodec::CodecError::of(at!(EncodeError::from(e))))?;
         }
-        let (buf, layout, w, h, stride_pixels) = pixels_to_webp_input(&pixels)?;
+        let (buf, layout, w, h, stride_pixels) =
+            pixels_to_webp_input(&pixels).map_err(zencodec::CodecError::of)?;
         // AnimationEncoder::add_frame assumes tightly-packed rows
         // (stride == width). Pack to contiguous if the caller's PixelSlice has
         // padded rows — e.g. imageflow's SIMD-aligned bitmaps, where the t_stride
@@ -1302,30 +1369,39 @@ impl zencodec::encode::AnimationFrameEncoder for WebpAnimationFrameEncoder {
             }
             alloc::borrow::Cow::Owned(packed)
         };
-        self.ensure_encoder(w, h)?;
+        self.ensure_encoder(w, h)
+            .map_err(zencodec::CodecError::of)?;
         let timestamp_ms = self.cumulative_ms;
         let enc = self.anim_enc.as_mut().unwrap();
         enc.add_frame(&buf, layout, timestamp_ms, &self.inner_config)
-            .map_err_at(mux_to_encode_err)?;
+            .map_err_at(mux_to_encode_err)
+            .map_err(zencodec::CodecError::of)?;
         self.cumulative_ms = self.cumulative_ms.saturating_add(duration_ms);
         self.last_frame_duration_ms = duration_ms;
         Ok(())
     }
 
-    fn finish(self, stop: Option<&dyn enough::Stop>) -> Result<EncodeOutput, At<EncodeError>> {
+    fn finish(
+        self,
+        stop: Option<&dyn enough::Stop>,
+    ) -> Result<EncodeOutput, At<zencodec::CodecError>> {
         if let Some(s) = stop {
-            s.check().map_err(|e| at!(EncodeError::from(e)))?;
+            s.check()
+                .map_err(|e| zencodec::CodecError::of(at!(EncodeError::from(e))))?;
         }
         let enc = self
             .anim_enc
             .ok_or_else(|| EncodeError::InvalidBufferSize("no frames added".into()))
-            .map_err(|e| at!(e))?;
+            .map_err(|e| zencodec::CodecError::of(at!(e)))?;
         let data = enc
             .finalize(self.last_frame_duration_ms)
-            .map_err_at(mux_to_encode_err)?;
+            .map_err_at(mux_to_encode_err)
+            .map_err(zencodec::CodecError::of)?;
         self.limits
             .check_output_size(data.len() as u64)
-            .map_err(|e| at!(EncodeError::LimitExceeded(alloc::format!("{e}"))))?;
+            .map_err(|e| {
+                zencodec::CodecError::of(at!(EncodeError::LimitExceeded(alloc::format!("{e}"))))
+            })?;
         Ok(EncodeOutput::new(data, ImageFormat::WebP))
     }
 }
@@ -1393,13 +1469,13 @@ impl WebpDecoderConfig {
     }
 
     /// Convenience: probe image header.
-    pub fn probe_header(&self, data: &[u8]) -> Result<ImageInfo, At<DecodeError>> {
+    pub fn probe_header(&self, data: &[u8]) -> Result<ImageInfo, At<zencodec::CodecError>> {
         use zencodec::decode::{DecodeJob, DecoderConfig};
         <Self as DecoderConfig>::job(self.clone()).probe(data)
     }
 
     /// Convenience: decode image with this config.
-    pub fn decode(&self, data: &[u8]) -> Result<DecodeOutput, At<DecodeError>> {
+    pub fn decode(&self, data: &[u8]) -> Result<DecodeOutput, At<zencodec::CodecError>> {
         use zencodec::decode::{Decode, DecodeJob, DecoderConfig};
         <Self as DecoderConfig>::job(self.clone())
             .decoder(Cow::Borrowed(data), &[])
@@ -1435,7 +1511,7 @@ static DECODE_CAPABILITIES: zencodec::decode::DecodeCapabilities =
         .with_enforces_max_input_bytes(true);
 
 impl zencodec::decode::DecoderConfig for WebpDecoderConfig {
-    type Error = At<DecodeError>;
+    type Error = At<zencodec::CodecError>;
     type Job<'a> = WebpDecodeJob;
 
     fn formats() -> &'static [ImageFormat] {
@@ -1572,7 +1648,7 @@ impl WebpDecodeJob {
 }
 
 impl<'a> zencodec::decode::DecodeJob<'a> for WebpDecodeJob {
-    type Error = At<DecodeError>;
+    type Error = At<zencodec::CodecError>;
     type Dec = WebpDecoder<'a>;
     type StreamDec = WebpStreamingDecoder;
     type AnimationFrameDec = WebpAnimationFrameDecoder;
@@ -1602,8 +1678,8 @@ impl<'a> zencodec::decode::DecodeJob<'a> for WebpDecodeJob {
         self
     }
 
-    fn probe(&self, data: &[u8]) -> Result<ImageInfo, At<DecodeError>> {
-        let native = crate::ImageInfo::from_webp(data)?;
+    fn probe(&self, data: &[u8]) -> Result<ImageInfo, At<zencodec::CodecError>> {
+        let native = crate::ImageInfo::from_webp(data).map_err(zencodec::CodecError::of)?;
         let mut info = to_image_info(&native, None);
         // Report consistently with what `decode()` will produce. `Preserve`
         // (default) keeps `to_image_info`'s stored dims + intrinsic EXIF tag.
@@ -1615,8 +1691,8 @@ impl<'a> zencodec::decode::DecodeJob<'a> for WebpDecodeJob {
         Ok(self.apply_policy_to_info(info))
     }
 
-    fn output_info(&self, data: &[u8]) -> Result<OutputInfo, At<DecodeError>> {
-        let native = crate::ImageInfo::from_webp(data)?;
+    fn output_info(&self, data: &[u8]) -> Result<OutputInfo, At<zencodec::CodecError>> {
+        let native = crate::ImageInfo::from_webp(data).map_err(zencodec::CodecError::of)?;
         let mut desc = if native.has_alpha {
             PixelDescriptor::RGBA8_SRGB
         } else {
@@ -1651,7 +1727,7 @@ impl<'a> zencodec::decode::DecodeJob<'a> for WebpDecodeJob {
         mut self,
         data: Cow<'a, [u8]>,
         preferred: &[PixelDescriptor],
-    ) -> Result<WebpDecoder<'a>, At<DecodeError>> {
+    ) -> Result<WebpDecoder<'a>, At<zencodec::CodecError>> {
         let cfg = self.build_config();
         let stop = self.stop.take();
         Ok(WebpDecoder {
@@ -1670,15 +1746,17 @@ impl<'a> zencodec::decode::DecodeJob<'a> for WebpDecodeJob {
         self,
         data: Cow<'a, [u8]>,
         preferred: &[PixelDescriptor],
-    ) -> Result<WebpStreamingDecoder, At<DecodeError>> {
+    ) -> Result<WebpStreamingDecoder, At<zencodec::CodecError>> {
         if let Some(max) = self.effective_input_size_limit()
             && data.len() as u64 > max
         {
-            return Err(at!(DecodeError::InvalidParameter(alloc::format!(
-                "input size {} exceeds limit {}",
-                data.len(),
-                max
-            ))));
+            return Err(zencodec::CodecError::of(at!(
+                DecodeError::InvalidParameter(alloc::format!(
+                    "input size {} exceeds limit {}",
+                    data.len(),
+                    max
+                ))
+            )));
         }
 
         let cfg = self.build_config();
@@ -1692,17 +1770,23 @@ impl<'a> zencodec::decode::DecodeJob<'a> for WebpDecodeJob {
         // Parse RIFF/WebP container
         let data_ref: &[u8] = &data;
         if data_ref.len() < 20 {
-            return Err(at!(DecodeError::NotEnoughInitData));
+            return Err(zencodec::CodecError::of(at!(
+                DecodeError::NotEnoughInitData
+            )));
         }
         if &data_ref[..4] != b"RIFF" {
             let mut sig = [0u8; 4];
             sig.copy_from_slice(&data_ref[..4]);
-            return Err(at!(DecodeError::RiffSignatureInvalid(sig)));
+            return Err(zencodec::CodecError::of(at!(
+                DecodeError::RiffSignatureInvalid(sig)
+            )));
         }
         if &data_ref[8..12] != b"WEBP" {
             let mut sig = [0u8; 4];
             sig.copy_from_slice(&data_ref[8..12]);
-            return Err(at!(DecodeError::WebpSignatureInvalid(sig)));
+            return Err(zencodec::CodecError::of(at!(
+                DecodeError::WebpSignatureInvalid(sig)
+            )));
         }
 
         let first_chunk = &data_ref[12..16];
@@ -1734,36 +1818,45 @@ impl<'a> zencodec::decode::DecodeJob<'a> for WebpDecodeJob {
                     dither_strength,
                     cfg.limits.alloc_pref,
                 )
+                .map_err(zencodec::CodecError::of)
             }
             b"VP8X" => {
                 use crate::mux::WebPDemuxer;
-                let demuxer = WebPDemuxer::new(data_ref).map_err_at(|inner| {
-                    DecodeError::InvalidParameter(alloc::format!("demux error: {inner}"))
-                })?;
+                let demuxer = WebPDemuxer::new(data_ref)
+                    .map_err_at(|inner| {
+                        DecodeError::InvalidParameter(alloc::format!("demux error: {inner}"))
+                    })
+                    .map_err(zencodec::CodecError::of)?;
 
                 if demuxer.is_animated() {
-                    return Err(at!(DecodeError::UnsupportedFeature(
-                        "streaming decode does not support animation".into()
+                    return Err(zencodec::CodecError::of(at!(
+                        DecodeError::UnsupportedFeature(
+                            "streaming decode does not support animation".into()
+                        )
                     )));
                 }
 
                 let frame = demuxer
                     .frame(1)
-                    .ok_or_else(|| at!(DecodeError::ChunkMissing))?;
+                    .ok_or_else(|| zencodec::CodecError::of(at!(DecodeError::ChunkMissing)))?;
 
                 if !frame.is_lossy {
-                    return Err(at!(DecodeError::UnsupportedFeature(
-                        "streaming decode only supports lossy VP8, got VP8L".into()
+                    return Err(zencodec::CodecError::of(at!(
+                        DecodeError::UnsupportedFeature(
+                            "streaming decode only supports lossy VP8, got VP8L".into()
+                        )
                     )));
                 }
 
                 // Decode alpha plane up front (it's small: width*height bytes)
                 let alpha_plane = if let Some(alpha_data) = frame.alpha_data {
-                    let native_info = crate::ImageInfo::from_webp(data_ref)?;
+                    let native_info =
+                        crate::ImageInfo::from_webp(data_ref).map_err(zencodec::CodecError::of)?;
                     let w = native_info.width as u16;
                     let h = native_info.height as u16;
                     let alpha_chunk =
-                        crate::decoder::extended::read_alpha_chunk(alpha_data, w, h, &cfg.limits)?;
+                        crate::decoder::extended::read_alpha_chunk(alpha_data, w, h, &cfg.limits)
+                            .map_err(zencodec::CodecError::of)?;
 
                     // Apply alpha filtering to produce final alpha plane
                     let fw = usize::from(w);
@@ -1810,14 +1903,18 @@ impl<'a> zencodec::decode::DecodeJob<'a> for WebpDecodeJob {
                     dither_strength,
                     cfg.limits.alloc_pref,
                 )
+                .map_err(zencodec::CodecError::of)
             }
-            b"VP8L" => Err(at!(DecodeError::UnsupportedFeature(
-                "streaming decode does not support lossless VP8L".into()
+            b"VP8L" => Err(zencodec::CodecError::of(at!(
+                DecodeError::UnsupportedFeature(
+                    "streaming decode does not support lossless VP8L".into()
+                )
             ))),
-            _ => Err(at!(DecodeError::UnsupportedFeature(alloc::format!(
-                "streaming decode: unsupported chunk type {:?}",
-                first_chunk
-            )))),
+            _ => Err(zencodec::CodecError::of(at!(
+                DecodeError::UnsupportedFeature(alloc::format!(
+                    "streaming decode: unsupported chunk type {first_chunk:?}"
+                ))
+            ))),
         }
     }
 
@@ -1834,24 +1931,24 @@ impl<'a> zencodec::decode::DecodeJob<'a> for WebpDecodeJob {
         self,
         data: Cow<'a, [u8]>,
         preferred: &[PixelDescriptor],
-    ) -> Result<WebpAnimationFrameDecoder, At<DecodeError>> {
+    ) -> Result<WebpAnimationFrameDecoder, At<zencodec::CodecError>> {
         // Block animation if policy denies it.
         if let Some(ref policy) = self.policy
             && !policy.resolve_animation(true)
         {
-            return Err(At::from(DecodeError::from(
-                UnsupportedOperation::AnimationDecode,
-            )));
+            return Err(DecodeError::from(UnsupportedOperation::AnimationDecode).into());
         }
 
         if let Some(max) = self.effective_input_size_limit()
             && data.len() as u64 > max
         {
-            return Err(at!(DecodeError::InvalidParameter(alloc::format!(
-                "input size {} exceeds limit {}",
-                data.len(),
-                max
-            ))));
+            return Err(zencodec::CodecError::of(at!(
+                DecodeError::InvalidParameter(alloc::format!(
+                    "input size {} exceeds limit {}",
+                    data.len(),
+                    max
+                ))
+            )));
         }
 
         let cfg = self.build_config();
@@ -1860,7 +1957,8 @@ impl<'a> zencodec::decode::DecodeJob<'a> for WebpDecodeJob {
         let native_info = crate::ImageInfo::from_webp(&data).ok();
 
         // Probe animation metadata with a temporary decoder.
-        let probe_anim = AnimationDecoder::new_with_config(&data, &cfg)?;
+        let probe_anim =
+            AnimationDecoder::new_with_config(&data, &cfg).map_err(zencodec::CodecError::of)?;
         let anim_info = probe_anim.info();
         let total_frames = anim_info.frame_count;
         let anim_loop_count = match anim_info.loop_count {
@@ -1898,7 +1996,8 @@ impl<'a> zencodec::decode::DecodeJob<'a> for WebpDecodeJob {
                 config: cfg,
             },
             |owner| AnimationDecoder::new_with_config(&owner.data, &owner.config),
-        )?;
+        )
+        .map_err(zencodec::CodecError::of)?;
 
         let has_alpha = anim_info.has_alpha;
         let canvas_width = anim_info.canvas_width;
@@ -2128,10 +2227,12 @@ fn negotiate_format(pixels: PixelBuffer, preferred: &[PixelDescriptor]) -> Pixel
 }
 
 impl zencodec::decode::Decode for WebpDecoder<'_> {
-    type Error = At<DecodeError>;
+    type Error = At<zencodec::CodecError>;
 
-    fn decode(self) -> Result<DecodeOutput, At<DecodeError>> {
-        let output = self.do_decode(&self.data)?;
+    fn decode(self) -> Result<DecodeOutput, At<zencodec::CodecError>> {
+        let output = self
+            .do_decode(&self.data)
+            .map_err(zencodec::CodecError::of)?;
         let output = if self.preferred.is_empty() {
             output
         } else {
@@ -2181,23 +2282,27 @@ fn push_decoder_impl<'a>(
     data: Cow<'a, [u8]>,
     sink: &mut dyn zencodec::decode::DecodeRowSink,
     preferred: &[PixelDescriptor],
-) -> Result<OutputInfo, At<DecodeError>> {
-    let wrap_sink = |e: SinkError| at!(DecodeError::InvalidParameter(alloc::format!("{e}")));
-
+) -> Result<OutputInfo, At<zencodec::CodecError>> {
     // Fast path only applies to lossy single-image VP8. For VP8L, animation,
     // or anything the container scanner can't classify, fall back to the
     // helper-driven full decode — it handles all the same cases `decode()` does.
     if !is_lossy_streaming_candidate(&data) {
-        return zencodec::helpers::copy_decode_to_sink(job, data, sink, preferred, |e| {
-            at!(DecodeError::InvalidParameter(alloc::format!("{e}")))
-        });
+        return zencodec::helpers::copy_decode_to_sink(
+            job,
+            data,
+            sink,
+            preferred,
+            wrap_sink_to_codec,
+        );
     }
 
     // Dimension limit enforcement (matches `WebpDecoder::do_decode`).
     if let Ok(info) = crate::ImageInfo::from_webp(&data) {
         job.limits
             .check_dimensions(info.width, info.height)
-            .map_err(|e| at!(DecodeError::InvalidParameter(alloc::format!("{e}"))))?;
+            .map_err(|e| {
+                zencodec::CodecError::of(at!(DecodeError::InvalidParameter(alloc::format!("{e}"))))
+            })?;
     }
 
     use zencodec::decode::{DecodeJob, StreamingDecode};
@@ -2219,7 +2324,7 @@ fn push_decoder_impl<'a>(
                 data,
                 sink,
                 preferred,
-                |e| at!(DecodeError::InvalidParameter(alloc::format!("{e}"))),
+                wrap_sink_to_codec,
             );
         }
     };
@@ -2231,7 +2336,8 @@ fn push_decoder_impl<'a>(
 
     // Tell the sink what's coming. After this, any error path must not
     // call `sink.finish()`.
-    sink.begin(width, height, descriptor).map_err(wrap_sink)?;
+    sink.begin(width, height, descriptor)
+        .map_err(wrap_sink_to_codec)?;
 
     let row_bytes = width as usize * bpp;
 
@@ -2239,7 +2345,8 @@ fn push_decoder_impl<'a>(
         // Cooperative cancellation between strips.
         if let Some(ref s) = stop {
             use enough::Stop;
-            s.check().map_err(|e| at!(DecodeError::from(e)))?;
+            s.check()
+                .map_err(|e| zencodec::CodecError::of(at!(DecodeError::from(e))))?;
         }
 
         let num_rows: u32 = pixel_slice.rows();
@@ -2249,7 +2356,7 @@ fn push_decoder_impl<'a>(
 
         let mut dst = sink
             .provide_next_buffer(y_start, num_rows, width, descriptor)
-            .map_err(wrap_sink)?;
+            .map_err(wrap_sink_to_codec)?;
 
         for row in 0..num_rows {
             let src = pixel_slice.row(row);
@@ -2261,7 +2368,7 @@ fn push_decoder_impl<'a>(
         drop(dst);
     }
 
-    sink.finish().map_err(wrap_sink)?;
+    sink.finish().map_err(wrap_sink_to_codec)?;
 
     Ok(OutputInfo::full_decode(width, height, descriptor))
 }
@@ -2384,9 +2491,9 @@ impl WebpStreamingDecoder {
 }
 
 impl zencodec::decode::StreamingDecode for WebpStreamingDecoder {
-    type Error = At<DecodeError>;
+    type Error = At<zencodec::CodecError>;
 
-    fn next_batch(&mut self) -> Result<Option<(u32, PixelSlice<'_>)>, At<DecodeError>> {
+    fn next_batch(&mut self) -> Result<Option<(u32, PixelSlice<'_>)>, At<zencodec::CodecError>> {
         if self.current_mby >= self.mbheight {
             return Ok(None);
         }
@@ -2395,7 +2502,7 @@ impl zencodec::decode::StreamingDecode for WebpStreamingDecoder {
         let (y_start, num_rows) = self
             .ctx
             .decode_strip_mb_row(mby, &mut self.strip_buf, self.bpp)
-            .map_err(|e| at!(DecodeError::from(e)))?;
+            .map_err(|e| zencodec::CodecError::of(at!(DecodeError::from(e))))?;
 
         self.current_mby += 1;
 
@@ -2440,7 +2547,11 @@ impl zencodec::decode::StreamingDecode for WebpStreamingDecoder {
             row_bytes,
             self.descriptor,
         )
-        .map_err(|_| at!(DecodeError::InvalidParameter("strip slice mismatch".into())))?;
+        .map_err(|_| {
+            zencodec::CodecError::of(at!(DecodeError::InvalidParameter(
+                "strip slice mismatch".into()
+            )))
+        })?;
 
         Ok(Some((y_start as u32, slice)))
     }
@@ -2605,10 +2716,10 @@ fn negotiate_format_inplace(
 }
 
 impl zencodec::decode::AnimationFrameDecoder for WebpAnimationFrameDecoder {
-    type Error = At<DecodeError>;
+    type Error = At<zencodec::CodecError>;
 
-    fn wrap_sink_error(err: SinkError) -> At<DecodeError> {
-        at!(DecodeError::InvalidParameter(alloc::format!("{err}")))
+    fn wrap_sink_error(err: SinkError) -> At<zencodec::CodecError> {
+        zencodec::CodecError::of(at!(DecodeError::InvalidParameter(alloc::format!("{err}"))))
     }
 
     fn info(&self) -> &ImageInfo {
@@ -2626,13 +2737,17 @@ impl zencodec::decode::AnimationFrameDecoder for WebpAnimationFrameDecoder {
     fn render_next_frame(
         &mut self,
         stop: Option<&dyn enough::Stop>,
-    ) -> Result<Option<AnimationFrame<'_>>, At<DecodeError>> {
+    ) -> Result<Option<AnimationFrame<'_>>, At<zencodec::CodecError>> {
         if let Some(s) = stop {
-            s.check().map_err(|e| at!(DecodeError::from(e)))?;
+            s.check()
+                .map_err(|e| zencodec::CodecError::of(at!(DecodeError::from(e))))?;
         }
-        self.skip_to_start()?;
+        self.skip_to_start().map_err(zencodec::CodecError::of)?;
 
-        if !self.decode_next_into_buf()? {
+        if !self
+            .decode_next_into_buf()
+            .map_err(zencodec::CodecError::of)?
+        {
             return Ok(None);
         }
         let idx = self.next_frame_index;
@@ -2641,7 +2756,9 @@ impl zencodec::decode::AnimationFrameDecoder for WebpAnimationFrameDecoder {
         // Enforce max_frames limit.
         self.limits
             .check_frames(self.next_frame_index)
-            .map_err(|e| at!(DecodeError::InvalidParameter(alloc::format!("{e}"))))?;
+            .map_err(|e| {
+                zencodec::CodecError::of(at!(DecodeError::InvalidParameter(alloc::format!("{e}"))))
+            })?;
 
         // Enforce max_animation_ms limit.
         self.accumulated_duration_ms = self
@@ -2649,7 +2766,9 @@ impl zencodec::decode::AnimationFrameDecoder for WebpAnimationFrameDecoder {
             .saturating_add(self.current_duration_ms as u64);
         self.limits
             .check_animation_ms(self.accumulated_duration_ms)
-            .map_err(|e| at!(DecodeError::InvalidParameter(alloc::format!("{e}"))))?;
+            .map_err(|e| {
+                zencodec::CodecError::of(at!(DecodeError::InvalidParameter(alloc::format!("{e}"))))
+            })?;
 
         // Zero-alloc: create PixelSlice directly from the reusable frame_buf.
         let stride = self.stride();
@@ -2661,9 +2780,9 @@ impl zencodec::decode::AnimationFrameDecoder for WebpAnimationFrameDecoder {
             self.current_descriptor,
         )
         .map_err(|_| {
-            at!(DecodeError::InvalidParameter(
+            zencodec::CodecError::of(at!(DecodeError::InvalidParameter(
                 "frame buffer mismatch".into(),
-            ))
+            )))
         })?;
         Ok(Some(AnimationFrame::new(
             slice,
@@ -2675,13 +2794,17 @@ impl zencodec::decode::AnimationFrameDecoder for WebpAnimationFrameDecoder {
     fn render_next_frame_owned(
         &mut self,
         stop: Option<&dyn enough::Stop>,
-    ) -> Result<Option<OwnedAnimationFrame>, At<DecodeError>> {
+    ) -> Result<Option<OwnedAnimationFrame>, At<zencodec::CodecError>> {
         if let Some(s) = stop {
-            s.check().map_err(|e| at!(DecodeError::from(e)))?;
+            s.check()
+                .map_err(|e| zencodec::CodecError::of(at!(DecodeError::from(e))))?;
         }
-        self.skip_to_start()?;
+        self.skip_to_start().map_err(zencodec::CodecError::of)?;
 
-        if !self.decode_next_into_buf()? {
+        if !self
+            .decode_next_into_buf()
+            .map_err(zencodec::CodecError::of)?
+        {
             return Ok(None);
         }
         let idx = self.next_frame_index;
@@ -2690,7 +2813,9 @@ impl zencodec::decode::AnimationFrameDecoder for WebpAnimationFrameDecoder {
         // Enforce max_frames limit.
         self.limits
             .check_frames(self.next_frame_index)
-            .map_err(|e| at!(DecodeError::InvalidParameter(alloc::format!("{e}"))))?;
+            .map_err(|e| {
+                zencodec::CodecError::of(at!(DecodeError::InvalidParameter(alloc::format!("{e}"))))
+            })?;
 
         // Enforce max_animation_ms limit.
         self.accumulated_duration_ms = self
@@ -2698,7 +2823,9 @@ impl zencodec::decode::AnimationFrameDecoder for WebpAnimationFrameDecoder {
             .saturating_add(self.current_duration_ms as u64);
         self.limits
             .check_animation_ms(self.accumulated_duration_ms)
-            .map_err(|e| at!(DecodeError::InvalidParameter(alloc::format!("{e}"))))?;
+            .map_err(|e| {
+                zencodec::CodecError::of(at!(DecodeError::InvalidParameter(alloc::format!("{e}"))))
+            })?;
 
         // Take the frame_buf for the owned PixelBuffer. A fresh buffer will
         // be allocated on the next call (unavoidable for owned output).
@@ -2709,7 +2836,11 @@ impl zencodec::decode::AnimationFrameDecoder for WebpAnimationFrameDecoder {
             self.canvas_height,
             self.current_descriptor,
         )
-        .map_err(|_| at!(DecodeError::InvalidParameter("frame size mismatch".into())))?;
+        .map_err(|_| {
+            zencodec::CodecError::of(at!(DecodeError::InvalidParameter(
+                "frame size mismatch".into()
+            )))
+        })?;
         Ok(Some(OwnedAnimationFrame::new(
             buf,
             self.current_duration_ms,
@@ -3142,6 +3273,62 @@ mod tests {
         let output = dyn_enc.encode(buf.as_slice()).unwrap();
         assert!(!output.is_empty());
         assert_eq!(output.format(), ImageFormat::WebP);
+    }
+
+    // ── Error envelope (Pattern B): category + codec name survive Dyn erasure ──
+
+    /// The forcing test for Pattern B. Drive the decoder through **`Dyn`**
+    /// dispatch, where the error is erased to a `BoxedError`
+    /// (`Box<dyn Error + Send + Sync>`). Under Pattern A (a native `type Error`)
+    /// the concrete error is no longer downcastable, so both lookups return
+    /// `None`; under Pattern B the single concrete `At<CodecError>` envelope
+    /// survives the erasure and a generic consumer recovers the category and the
+    /// originating codec name. Models the testkit's
+    /// `minimal_envelope_category_survives_dyn_erasure`.
+    #[test]
+    fn envelope_category_survives_dyn_erasure() {
+        use zencodec::decode::DynDecoderConfig;
+        use zencodec::{CodecError, CodecErrorExt, ErrorCategory};
+
+        let cfg = WebpDecoderConfig::new();
+        let dyn_cfg: &dyn DynDecoderConfig = &cfg;
+        // A non-RIFF buffer past the 20-byte length guard fails the RIFF
+        // signature check → `DecodeError::RiffSignatureInvalid` → `MalformedImage`.
+        let erased = dyn_cfg
+            .dyn_job()
+            .probe(b"not a valid webp file")
+            .expect_err("malformed input must fail to probe");
+
+        assert_eq!(erased.error_category(), Some(ErrorCategory::MalformedImage));
+        assert_eq!(
+            erased.codec_error().and_then(CodecError::codec),
+            Some("zenwebp")
+        );
+    }
+
+    /// On the typed (non-erased) path the `At<CodecError>` answers the category
+    /// and codec name directly, and the native `DecodeError` is still reachable
+    /// as the envelope's detail via the source chain.
+    #[test]
+    fn envelope_on_typed_decode_path() {
+        use zencodec::decode::{DecodeJob, DecoderConfig};
+        use zencodec::{CodecError, CodecErrorExt, ErrorCategory};
+
+        let err = <WebpDecoderConfig as DecoderConfig>::job(WebpDecoderConfig::new())
+            .probe(b"not a valid webp file")
+            .expect_err("malformed input must fail to probe");
+
+        // The concrete envelope answers both axes without any downcast.
+        assert_eq!(err.error().category(), ErrorCategory::MalformedImage);
+        assert_eq!(err.error().codec(), Some("zenwebp"));
+        // ...and the extension trait recovers them by walking the chain too.
+        assert_eq!(err.error_category(), Some(ErrorCategory::MalformedImage));
+        assert_eq!(
+            err.codec_error().and_then(CodecError::codec),
+            Some("zenwebp")
+        );
+        // The native DecodeError detail is still reachable for its message.
+        assert!(err.find_cause::<DecodeError>().is_some());
     }
 
     #[test]

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -2880,6 +2880,8 @@ fn report_probe_for_hint(mut info: ImageInfo, hint: OrientationHint) -> ImageInf
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use super::*;
     use zencodec::decode::{Decode, DecodeJob, DecoderConfig};
     use zencodec::encode::{EncodeJob, Encoder, EncoderConfig};

--- a/src/decoder/alloc_util.rs
+++ b/src/decoder/alloc_util.rs
@@ -45,13 +45,10 @@ pub(crate) enum AllocPreference {
     CodecDefault,
     /// Force every site onto the fallible (`try_reserve`) path.
     //
-    // Only ever *constructed* via the `zencodec::AllocPreference` adapter
-    // (`src/codec.rs`); without the optional `zencodec` feature nothing builds
-    // this variant, so suppress the unused-variant lint in that configuration.
-    #[cfg_attr(not(feature = "zencodec"), allow(dead_code))]
+    // Constructed via the `zencodec::AllocPreference` adapter (`src/codec.rs`),
+    // which is now an always-on integration.
     Fallible,
     /// Force every site onto the infallible (`vec!`) path.
-    #[cfg_attr(not(feature = "zencodec"), allow(dead_code))]
     Infallible,
 }
 

--- a/src/decoder/alloc_util.rs
+++ b/src/decoder/alloc_util.rs
@@ -44,8 +44,14 @@ pub(crate) enum AllocPreference {
     #[default]
     CodecDefault,
     /// Force every site onto the fallible (`try_reserve`) path.
+    //
+    // Only ever *constructed* via the `zencodec::AllocPreference` adapter
+    // (`src/codec.rs`); without the optional `zencodec` feature nothing builds
+    // this variant, so suppress the unused-variant lint in that configuration.
+    #[cfg_attr(not(feature = "zencodec"), allow(dead_code))]
     Fallible,
     /// Force every site onto the infallible (`vec!`) path.
+    #[cfg_attr(not(feature = "zencodec"), allow(dead_code))]
     Infallible,
 }
 

--- a/src/decoder/api.rs
+++ b/src/decoder/api.rs
@@ -141,6 +141,152 @@ impl From<enough::StopReason> for DecodeError {
     }
 }
 
+// Codec-agnostic error taxonomy (zencodec PR #103). Maps every `DecodeError`
+// variant to exactly one coarse `ErrorCategory` so consumers can route on the
+// category (HTTP status, retry policy, logging) without naming this enum.
+#[cfg(feature = "zencodec")]
+impl zencodec::CategorizedError for DecodeError {
+    fn codec_name(&self) -> Option<&'static str> {
+        Some("zenwebp")
+    }
+
+    fn category(&self) -> zencodec::ErrorCategory {
+        use zencodec::ErrorCategory as C;
+        use zencodec::LimitKind as L;
+        match self {
+            // === I/O ===
+            #[cfg(feature = "std")]
+            DecodeError::IoError(_) => C::Io(zencodec::CodecIoKind::opaque()),
+
+            // === Malformed / corrupt bitstream content ===
+            DecodeError::RiffSignatureInvalid(_)
+            | DecodeError::WebpSignatureInvalid(_)
+            | DecodeError::ChunkMissing
+            | DecodeError::ChunkHeaderInvalid(_)
+            | DecodeError::InvalidAlphaPreprocessing
+            | DecodeError::InvalidCompressionMethod
+            | DecodeError::AlphaChunkSizeMismatch
+            | DecodeError::FrameOutsideImage
+            | DecodeError::LosslessSignatureInvalid(_)
+            | DecodeError::VersionNumberInvalid(_)
+            | DecodeError::InvalidColorCacheBits(_)
+            | DecodeError::HuffmanError
+            | DecodeError::BitStreamError
+            | DecodeError::TransformError
+            | DecodeError::Vp8MagicInvalid(_)
+            | DecodeError::ColorSpaceInvalid(_)
+            | DecodeError::LumaPredictionModeInvalid(_)
+            | DecodeError::IntraPredictionModeInvalid(_)
+            | DecodeError::ChromaPredictionModeInvalid(_)
+            | DecodeError::InconsistentImageSizes
+            | DecodeError::InvalidChunkSize => C::MalformedImage,
+
+            // === Truncated / insufficient input ===
+            DecodeError::NotEnoughInitData => C::UnexpectedEof,
+            // Animation-iteration end: a control-flow signal that no further
+            // frame exists, surfaced as end-of-input rather than its own category.
+            DecodeError::NoMoreFrames => C::UnexpectedEof,
+
+            // === Format handled, but the bitstream uses an unimplemented feature ===
+            DecodeError::UnsupportedFeature(_) => C::UnsupportedImageFeature,
+
+            // === Caller-supplied parameter invalid (not the image's fault) ===
+            DecodeError::InvalidParameter(_) => C::InvalidParameters,
+
+            // === Resource limits (closest LimitKind) ===
+            // "Image too large" caps total image extent, so Pixels is the fit.
+            DecodeError::ImageTooLarge => C::LimitsExceeded(L::Pixels),
+            DecodeError::MemoryLimitExceeded => C::LimitsExceeded(L::Memory),
+
+            // === Cancellation — delegate to the StopReason cause type ===
+            // (TimedOut vs Cancelled is preserved through the delegation.)
+            DecodeError::Cancelled(reason) => reason.category(),
+
+            // === Unsupported codec operation — delegate to the zencodec cause type ===
+            DecodeError::UnsupportedOperation(op) => op.category(),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "zencodec"))]
+mod decode_category_tests {
+    use super::DecodeError;
+    use zencodec::{CategorizedError, ErrorCategory as C, LimitKind as L};
+
+    #[test]
+    fn decode_error_category_mapping() {
+        assert_eq!(DecodeError::HuffmanError.codec_name(), Some("zenwebp"));
+
+        // Malformed bitstream content.
+        assert_eq!(
+            DecodeError::RiffSignatureInvalid([0; 4]).category(),
+            C::MalformedImage
+        );
+        assert_eq!(DecodeError::HuffmanError.category(), C::MalformedImage);
+        assert_eq!(DecodeError::BitStreamError.category(), C::MalformedImage);
+        assert_eq!(DecodeError::InvalidChunkSize.category(), C::MalformedImage);
+        assert_eq!(
+            DecodeError::ChromaPredictionModeInvalid(9).category(),
+            C::MalformedImage
+        );
+
+        // Truncated / end-of-input.
+        assert_eq!(DecodeError::NotEnoughInitData.category(), C::UnexpectedEof);
+        assert_eq!(DecodeError::NoMoreFrames.category(), C::UnexpectedEof);
+
+        // Unimplemented feature / caller params.
+        assert_eq!(
+            DecodeError::UnsupportedFeature("x".into()).category(),
+            C::UnsupportedImageFeature
+        );
+        assert_eq!(
+            DecodeError::InvalidParameter("x".into()).category(),
+            C::InvalidParameters
+        );
+
+        // Resource limits.
+        assert_eq!(
+            DecodeError::ImageTooLarge.category(),
+            C::LimitsExceeded(L::Pixels)
+        );
+        assert_eq!(
+            DecodeError::MemoryLimitExceeded.category(),
+            C::LimitsExceeded(L::Memory)
+        );
+
+        // Cancellation delegates to StopReason (cancel vs timeout preserved).
+        assert_eq!(
+            DecodeError::Cancelled(enough::StopReason::Cancelled).category(),
+            C::Cancelled
+        );
+        assert_eq!(
+            DecodeError::Cancelled(enough::StopReason::TimedOut).category(),
+            C::TimedOut
+        );
+
+        // Unsupported operation delegates to the zencodec cause type.
+        assert_eq!(
+            DecodeError::UnsupportedOperation(zencodec::UnsupportedOperation::AnimationDecode)
+                .category(),
+            C::UnsupportedOperation
+        );
+
+        // The At<E> blanket impl forwards both category and codec name.
+        let traced = whereat::at!(DecodeError::HuffmanError);
+        assert_eq!(traced.category(), C::MalformedImage);
+        assert_eq!(traced.codec_name(), Some("zenwebp"));
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn decode_io_error_is_io() {
+        assert_eq!(
+            DecodeError::IoError(std::io::Error::other("boom")).category(),
+            C::Io(zencodec::CodecIoKind::opaque())
+        );
+    }
+}
+
 // Core decoder implementation using SliceReader for no_std compatibility
 use alloc::format;
 use alloc::vec;

--- a/src/decoder/api.rs
+++ b/src/decoder/api.rs
@@ -124,7 +124,6 @@ pub enum DecodeError {
     Cancelled(enough::StopReason),
 
     /// Unsupported codec operation.
-    #[cfg(feature = "zencodec")]
     #[error(transparent)]
     UnsupportedOperation(#[from] zencodec::UnsupportedOperation),
 }
@@ -144,7 +143,6 @@ impl From<enough::StopReason> for DecodeError {
 // Codec-agnostic error taxonomy (zencodec PR #103). Maps every `DecodeError`
 // variant to exactly one coarse `ErrorCategory` so consumers can route on the
 // category (HTTP status, retry policy, logging) without naming this enum.
-#[cfg(feature = "zencodec")]
 impl zencodec::CategorizedError for DecodeError {
     fn codec_name(&self) -> Option<&'static str> {
         Some("zenwebp")
@@ -205,85 +203,6 @@ impl zencodec::CategorizedError for DecodeError {
             // === Unsupported codec operation — delegate to the zencodec cause type ===
             DecodeError::UnsupportedOperation(op) => op.category(),
         }
-    }
-}
-
-#[cfg(all(test, feature = "zencodec"))]
-mod decode_category_tests {
-    use super::DecodeError;
-    use zencodec::{CategorizedError, ErrorCategory as C, LimitKind as L};
-
-    #[test]
-    fn decode_error_category_mapping() {
-        assert_eq!(DecodeError::HuffmanError.codec_name(), Some("zenwebp"));
-
-        // Malformed bitstream content.
-        assert_eq!(
-            DecodeError::RiffSignatureInvalid([0; 4]).category(),
-            C::MalformedImage
-        );
-        assert_eq!(DecodeError::HuffmanError.category(), C::MalformedImage);
-        assert_eq!(DecodeError::BitStreamError.category(), C::MalformedImage);
-        assert_eq!(DecodeError::InvalidChunkSize.category(), C::MalformedImage);
-        assert_eq!(
-            DecodeError::ChromaPredictionModeInvalid(9).category(),
-            C::MalformedImage
-        );
-
-        // Truncated / end-of-input.
-        assert_eq!(DecodeError::NotEnoughInitData.category(), C::UnexpectedEof);
-        assert_eq!(DecodeError::NoMoreFrames.category(), C::UnexpectedEof);
-
-        // Unimplemented feature / caller params.
-        assert_eq!(
-            DecodeError::UnsupportedFeature("x".into()).category(),
-            C::UnsupportedImageFeature
-        );
-        assert_eq!(
-            DecodeError::InvalidParameter("x".into()).category(),
-            C::InvalidParameters
-        );
-
-        // Resource limits.
-        assert_eq!(
-            DecodeError::ImageTooLarge.category(),
-            C::LimitsExceeded(L::Pixels)
-        );
-        assert_eq!(
-            DecodeError::MemoryLimitExceeded.category(),
-            C::LimitsExceeded(L::Memory)
-        );
-
-        // Cancellation delegates to StopReason (cancel vs timeout preserved).
-        assert_eq!(
-            DecodeError::Cancelled(enough::StopReason::Cancelled).category(),
-            C::Cancelled
-        );
-        assert_eq!(
-            DecodeError::Cancelled(enough::StopReason::TimedOut).category(),
-            C::TimedOut
-        );
-
-        // Unsupported operation delegates to the zencodec cause type.
-        assert_eq!(
-            DecodeError::UnsupportedOperation(zencodec::UnsupportedOperation::AnimationDecode)
-                .category(),
-            C::UnsupportedOperation
-        );
-
-        // The At<E> blanket impl forwards both category and codec name.
-        let traced = whereat::at!(DecodeError::HuffmanError);
-        assert_eq!(traced.category(), C::MalformedImage);
-        assert_eq!(traced.codec_name(), Some("zenwebp"));
-    }
-
-    #[cfg(feature = "std")]
-    #[test]
-    fn decode_io_error_is_io() {
-        assert_eq!(
-            DecodeError::IoError(std::io::Error::other("boom")).category(),
-            C::Io(zencodec::CodecIoKind::opaque())
-        );
     }
 }
 
@@ -2348,5 +2267,84 @@ mod tests {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod decode_category_tests {
+    use super::DecodeError;
+    use zencodec::{CategorizedError, ErrorCategory as C, LimitKind as L};
+
+    #[test]
+    fn decode_error_category_mapping() {
+        assert_eq!(DecodeError::HuffmanError.codec_name(), Some("zenwebp"));
+
+        // Malformed bitstream content.
+        assert_eq!(
+            DecodeError::RiffSignatureInvalid([0; 4]).category(),
+            C::MalformedImage
+        );
+        assert_eq!(DecodeError::HuffmanError.category(), C::MalformedImage);
+        assert_eq!(DecodeError::BitStreamError.category(), C::MalformedImage);
+        assert_eq!(DecodeError::InvalidChunkSize.category(), C::MalformedImage);
+        assert_eq!(
+            DecodeError::ChromaPredictionModeInvalid(9).category(),
+            C::MalformedImage
+        );
+
+        // Truncated / end-of-input.
+        assert_eq!(DecodeError::NotEnoughInitData.category(), C::UnexpectedEof);
+        assert_eq!(DecodeError::NoMoreFrames.category(), C::UnexpectedEof);
+
+        // Unimplemented feature / caller params.
+        assert_eq!(
+            DecodeError::UnsupportedFeature("x".into()).category(),
+            C::UnsupportedImageFeature
+        );
+        assert_eq!(
+            DecodeError::InvalidParameter("x".into()).category(),
+            C::InvalidParameters
+        );
+
+        // Resource limits.
+        assert_eq!(
+            DecodeError::ImageTooLarge.category(),
+            C::LimitsExceeded(L::Pixels)
+        );
+        assert_eq!(
+            DecodeError::MemoryLimitExceeded.category(),
+            C::LimitsExceeded(L::Memory)
+        );
+
+        // Cancellation delegates to StopReason (cancel vs timeout preserved).
+        assert_eq!(
+            DecodeError::Cancelled(enough::StopReason::Cancelled).category(),
+            C::Cancelled
+        );
+        assert_eq!(
+            DecodeError::Cancelled(enough::StopReason::TimedOut).category(),
+            C::TimedOut
+        );
+
+        // Unsupported operation delegates to the zencodec cause type.
+        assert_eq!(
+            DecodeError::UnsupportedOperation(zencodec::UnsupportedOperation::AnimationDecode)
+                .category(),
+            C::UnsupportedOperation
+        );
+
+        // The At<E> blanket impl forwards both category and codec name.
+        let traced = whereat::at!(DecodeError::HuffmanError);
+        assert_eq!(traced.category(), C::MalformedImage);
+        assert_eq!(traced.codec_name(), Some("zenwebp"));
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn decode_io_error_is_io() {
+        assert_eq!(
+            DecodeError::IoError(std::io::Error::other("boom")).category(),
+            C::Io(zencodec::CodecIoKind::opaque())
+        );
     }
 }

--- a/src/decoder/extended.rs
+++ b/src/decoder/extended.rs
@@ -398,6 +398,9 @@ pub(crate) fn read_alpha_chunk(
 #[cfg(test)]
 mod tests {
     use super::*;
+    // `vec!` is not in the `no_std` prelude; the glob above re-imports `Vec`
+    // (a type) but not the macro, so bring it in explicitly for the test bodies.
+    use alloc::vec;
 
     /// Before the fix, clearing the canvas for a non-alpha frame used 3-byte
     /// stride on the always-RGBA canvas, corrupting pixel alignment.

--- a/src/decoder/limits.rs
+++ b/src/decoder/limits.rs
@@ -101,10 +101,10 @@ impl Limits {
     /// Set the per-site allocation fallibility policy (internal).
     ///
     /// Used by the `zencodec` adapter to honor
-    /// `ResourceLimits::prefer_fallible_allocations`. Only the `zencodec` layer
-    /// sets a non-default policy, so this is dead code without that feature.
+    /// `ResourceLimits::prefer_fallible_allocations`. Only the zencodec
+    /// adapter sets a non-default policy (native decode is always
+    /// `CodecDefault`).
     #[must_use]
-    #[cfg_attr(not(feature = "zencodec"), allow(dead_code))]
     pub(crate) fn with_alloc_pref(mut self, pref: super::alloc_util::AllocPreference) -> Self {
         self.alloc_pref = pref;
         self

--- a/src/decoder/lossless_transform_simd.rs
+++ b/src/decoder/lossless_transform_simd.rs
@@ -813,6 +813,13 @@ fn predictor_add_body_wide<
 }
 
 /// Wide (32-byte) floor-average predictor body using u8x32.
+///
+/// Only dispatched on x86_64 (AVX2-native 256-bit); aarch64/wasm use the
+/// native-128-bit `predictor_avg_body` (`u8x16`) instead, so this is gated to
+/// match its `apply_predictor_*_v3` callers — otherwise it (and its `chunk32`
+/// helpers) are out of scope on non-x86_64 targets. Mirrors the gate on the
+/// sibling `predictor_add_body_wide`.
+#[cfg(target_arch = "x86_64")]
 fn predictor_avg_body_wide<
     T: magetypes::simd::backends::U8x32Backend + magetypes::simd::backends::U8x16Backend,
 >(

--- a/src/decoder/yuv.rs
+++ b/src/decoder/yuv.rs
@@ -645,7 +645,6 @@ pub(crate) fn rgb_to_v_single(r: u8, g: u8, b: u8) -> u8 {
 ///
 /// Each R/G/B channel is averaged in linear^0.80 space before the YUV
 /// matrix is applied to the averaged RGB values.
-#[allow(dead_code)] // Used by codec.rs (behind `zencodec` feature)
 pub(crate) fn rgb_to_u_avg(rgb1: &[u8], rgb2: &[u8], rgb3: &[u8], rgb4: &[u8]) -> u8 {
     let r = gamma_avg_4(rgb1[0], rgb2[0], rgb3[0], rgb4[0]);
     let g = gamma_avg_4(rgb1[1], rgb2[1], rgb3[1], rgb4[1]);
@@ -655,7 +654,6 @@ pub(crate) fn rgb_to_u_avg(rgb1: &[u8], rgb2: &[u8], rgb3: &[u8], rgb4: &[u8]) -
 
 /// Get the chroma-downsampled V value for a 2x2 pixel block using
 /// gamma-corrected averaging (gamma=0.80, matching libwebp).
-#[allow(dead_code)] // Used by codec.rs (behind `zencodec` feature)
 pub(crate) fn rgb_to_v_avg(rgb1: &[u8], rgb2: &[u8], rgb3: &[u8], rgb4: &[u8]) -> u8 {
     let r = gamma_avg_4(rgb1[0], rgb2[0], rgb3[0], rgb4[0]);
     let g = gamma_avg_4(rgb1[1], rgb2[1], rgb3[1], rgb4[1]);

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -105,7 +105,6 @@ impl std::error::Error for ProbeError {}
 // Codec-agnostic error taxonomy (zencodec PR #103). Maps every `ProbeError`
 // variant to exactly one coarse `ErrorCategory` so consumers can route on the
 // category without naming this enum.
-#[cfg(feature = "zencodec")]
 impl zencodec::CategorizedError for ProbeError {
     fn codec_name(&self) -> Option<&'static str> {
         Some("zenwebp")
@@ -121,26 +120,6 @@ impl zencodec::CategorizedError for ProbeError {
             // Container is WebP-shaped but the VP8 magic is wrong — corrupt.
             ProbeError::InvalidVP8Magic => C::MalformedImage,
         }
-    }
-}
-
-#[cfg(all(test, feature = "zencodec"))]
-mod probe_category_tests {
-    use super::ProbeError;
-    use zencodec::{CategorizedError, ErrorCategory as C};
-
-    #[test]
-    fn probe_error_category_mapping() {
-        assert_eq!(ProbeError::NotWebP.codec_name(), Some("zenwebp"));
-        assert_eq!(ProbeError::TooShort.category(), C::UnexpectedEof);
-        assert_eq!(ProbeError::Truncated.category(), C::UnexpectedEof);
-        assert_eq!(ProbeError::NotWebP.category(), C::UnsupportedImageType);
-        assert_eq!(ProbeError::InvalidVP8Magic.category(), C::MalformedImage);
-
-        // The At<E> blanket impl forwards both category and codec name.
-        let traced = whereat::at!(ProbeError::NotWebP);
-        assert_eq!(traced.category(), C::UnsupportedImageType);
-        assert_eq!(traced.codec_name(), Some("zenwebp"));
     }
 }
 
@@ -608,7 +587,6 @@ impl<'a> MiniBoolReader<'a> {
     }
 }
 
-#[cfg(feature = "zencodec")]
 impl zencodec::SourceEncodingDetails for WebPProbe {
     fn source_generic_quality(&self) -> Option<f32> {
         self.estimated_quality()
@@ -659,5 +637,25 @@ mod tests {
     fn test_probe_not_webp() {
         let bad = b"RIFF\x00\x00\x00\x00NOPE";
         assert_eq!(probe(bad).unwrap_err(), ProbeError::NotWebP);
+    }
+}
+
+#[cfg(test)]
+mod probe_category_tests {
+    use super::ProbeError;
+    use zencodec::{CategorizedError, ErrorCategory as C};
+
+    #[test]
+    fn probe_error_category_mapping() {
+        assert_eq!(ProbeError::NotWebP.codec_name(), Some("zenwebp"));
+        assert_eq!(ProbeError::TooShort.category(), C::UnexpectedEof);
+        assert_eq!(ProbeError::Truncated.category(), C::UnexpectedEof);
+        assert_eq!(ProbeError::NotWebP.category(), C::UnsupportedImageType);
+        assert_eq!(ProbeError::InvalidVP8Magic.category(), C::MalformedImage);
+
+        // The At<E> blanket impl forwards both category and codec name.
+        let traced = whereat::at!(ProbeError::NotWebP);
+        assert_eq!(traced.category(), C::UnsupportedImageType);
+        assert_eq!(traced.codec_name(), Some("zenwebp"));
     }
 }

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -102,6 +102,48 @@ impl core::fmt::Display for ProbeError {
 #[cfg(feature = "std")]
 impl std::error::Error for ProbeError {}
 
+// Codec-agnostic error taxonomy (zencodec PR #103). Maps every `ProbeError`
+// variant to exactly one coarse `ErrorCategory` so consumers can route on the
+// category without naming this enum.
+#[cfg(feature = "zencodec")]
+impl zencodec::CategorizedError for ProbeError {
+    fn codec_name(&self) -> Option<&'static str> {
+        Some("zenwebp")
+    }
+
+    fn category(&self) -> zencodec::ErrorCategory {
+        use zencodec::ErrorCategory as C;
+        match self {
+            // Not enough bytes / truncated header — the input ended early.
+            ProbeError::TooShort | ProbeError::Truncated => C::UnexpectedEof,
+            // Missing RIFF/WEBP signature: this isn't a WebP file at all.
+            ProbeError::NotWebP => C::UnsupportedImageType,
+            // Container is WebP-shaped but the VP8 magic is wrong — corrupt.
+            ProbeError::InvalidVP8Magic => C::MalformedImage,
+        }
+    }
+}
+
+#[cfg(all(test, feature = "zencodec"))]
+mod probe_category_tests {
+    use super::ProbeError;
+    use zencodec::{CategorizedError, ErrorCategory as C};
+
+    #[test]
+    fn probe_error_category_mapping() {
+        assert_eq!(ProbeError::NotWebP.codec_name(), Some("zenwebp"));
+        assert_eq!(ProbeError::TooShort.category(), C::UnexpectedEof);
+        assert_eq!(ProbeError::Truncated.category(), C::UnexpectedEof);
+        assert_eq!(ProbeError::NotWebP.category(), C::UnsupportedImageType);
+        assert_eq!(ProbeError::InvalidVP8Magic.category(), C::MalformedImage);
+
+        // The At<E> blanket impl forwards both category and codec name.
+        let traced = whereat::at!(ProbeError::NotWebP);
+        assert_eq!(traced.category(), C::UnsupportedImageType);
+        assert_eq!(traced.codec_name(), Some("zenwebp"));
+    }
+}
+
 /// Probe a WebP file from its raw bytes.
 ///
 /// Reads only container and bitstream headers. No pixel decoding is performed.

--- a/src/encoder/api.rs
+++ b/src/encoder/api.rs
@@ -109,6 +109,134 @@ impl From<enough::StopReason> for EncodeError {
     }
 }
 
+// Codec-agnostic error taxonomy (zencodec PR #103). Maps every `EncodeError`
+// variant to exactly one coarse `ErrorCategory` so consumers can route on the
+// category (HTTP status, retry policy, logging) without naming this enum.
+#[cfg(feature = "zencodec")]
+impl zencodec::CategorizedError for EncodeError {
+    fn codec_name(&self) -> Option<&'static str> {
+        Some("zenwebp")
+    }
+
+    fn category(&self) -> zencodec::ErrorCategory {
+        use zencodec::ErrorCategory as C;
+        use zencodec::LimitKind as L;
+        match self {
+            // === I/O ===
+            #[cfg(feature = "std")]
+            EncodeError::IoError(_) => C::Io(zencodec::CodecIoKind::opaque()),
+
+            // === Caller-supplied configuration / parameters invalid ===
+            EncodeError::InvalidDimensions => C::InvalidParameters,
+            EncodeError::TargetZensimUnsupportedLayout(_) => C::InvalidParameters,
+
+            // === Caller-supplied pixel buffer has the wrong geometry ===
+            EncodeError::InvalidBufferSize(_) => C::InvalidBuffer,
+
+            // === Colour-management transform the codec won't perform itself ===
+            // WebP has no CICP carrier, so a non-sRGB source needs a synthesized
+            // ICC; when that can't be produced, the caller must supply the CMS.
+            EncodeError::IccSynthesisUnavailable(_) => C::CmsRequired,
+
+            // === Resource limits ===
+            // `LimitExceeded` is stringly: its construction sites collapse the
+            // dimensions / memory / output-size `Limits` checks (which return
+            // typed `At<DecodeError>` limit errors) into a formatted message, so
+            // the exact `LimitKind` is not recoverable here. We report a
+            // representative `Memory` kind; carrying the precise kind would
+            // require a breaking change to this variant's shape (see CHANGELOG).
+            EncodeError::LimitExceeded(_) => C::LimitsExceeded(L::Memory),
+            // Partition 0 (the compressed VP8 header) exceeds the format's
+            // 19-bit byte cap — an output-size limit of the bitstream.
+            EncodeError::Partition0Overflow { .. } => C::LimitsExceeded(L::OutputSize),
+
+            // === Cancellation — delegate to the StopReason cause type ===
+            EncodeError::Cancelled(reason) => reason.category(),
+
+            // === Unsupported codec operation — delegate to the zencodec cause type ===
+            EncodeError::UnsupportedOperation(op) => op.category(),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "zencodec"))]
+mod encode_category_tests {
+    use super::{EncodeError, PixelLayout};
+    use zencodec::{CategorizedError, ErrorCategory as C, LimitKind as L};
+
+    #[test]
+    fn encode_error_category_mapping() {
+        assert_eq!(EncodeError::InvalidDimensions.codec_name(), Some("zenwebp"));
+
+        // Caller config / parameters.
+        assert_eq!(
+            EncodeError::InvalidDimensions.category(),
+            C::InvalidParameters
+        );
+        assert_eq!(
+            EncodeError::TargetZensimUnsupportedLayout(PixelLayout::Yuv420).category(),
+            C::InvalidParameters
+        );
+
+        // Caller pixel buffer geometry.
+        assert_eq!(
+            EncodeError::InvalidBufferSize("x".into()).category(),
+            C::InvalidBuffer
+        );
+
+        // Colour-management transform required (no CICP carrier in WebP).
+        assert_eq!(
+            EncodeError::IccSynthesisUnavailable("x".into()).category(),
+            C::CmsRequired
+        );
+
+        // Resource limits. `LimitExceeded` is stringly → representative Memory.
+        assert_eq!(
+            EncodeError::LimitExceeded("x".into()).category(),
+            C::LimitsExceeded(L::Memory)
+        );
+        assert_eq!(
+            EncodeError::Partition0Overflow {
+                size: 600_000,
+                max: 524_287,
+            }
+            .category(),
+            C::LimitsExceeded(L::OutputSize)
+        );
+
+        // Cancellation delegates to StopReason (cancel vs timeout preserved).
+        assert_eq!(
+            EncodeError::Cancelled(enough::StopReason::Cancelled).category(),
+            C::Cancelled
+        );
+        assert_eq!(
+            EncodeError::Cancelled(enough::StopReason::TimedOut).category(),
+            C::TimedOut
+        );
+
+        // Unsupported operation delegates to the zencodec cause type.
+        assert_eq!(
+            EncodeError::UnsupportedOperation(zencodec::UnsupportedOperation::AnimationEncode)
+                .category(),
+            C::UnsupportedOperation
+        );
+
+        // The At<E> blanket impl forwards both category and codec name.
+        let traced = whereat::at!(EncodeError::InvalidDimensions);
+        assert_eq!(traced.category(), C::InvalidParameters);
+        assert_eq!(traced.codec_name(), Some("zenwebp"));
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn encode_io_error_is_io() {
+        assert_eq!(
+            EncodeError::IoError(std::io::Error::other("boom")).category(),
+            C::Io(zencodec::CodecIoKind::opaque())
+        );
+    }
+}
+
 /// Content-aware encoding presets.
 ///
 /// These presets configure the encoder for different types of content,

--- a/src/encoder/api.rs
+++ b/src/encoder/api.rs
@@ -75,7 +75,6 @@ pub enum EncodeError {
     },
 
     /// Unsupported codec operation.
-    #[cfg(feature = "zencodec")]
     #[error(transparent)]
     UnsupportedOperation(#[from] zencodec::UnsupportedOperation),
 
@@ -112,7 +111,6 @@ impl From<enough::StopReason> for EncodeError {
 // Codec-agnostic error taxonomy (zencodec PR #103). Maps every `EncodeError`
 // variant to exactly one coarse `ErrorCategory` so consumers can route on the
 // category (HTTP status, retry policy, logging) without naming this enum.
-#[cfg(feature = "zencodec")]
 impl zencodec::CategorizedError for EncodeError {
     fn codec_name(&self) -> Option<&'static str> {
         Some("zenwebp")
@@ -156,84 +154,6 @@ impl zencodec::CategorizedError for EncodeError {
             // === Unsupported codec operation — delegate to the zencodec cause type ===
             EncodeError::UnsupportedOperation(op) => op.category(),
         }
-    }
-}
-
-#[cfg(all(test, feature = "zencodec"))]
-mod encode_category_tests {
-    use super::{EncodeError, PixelLayout};
-    use zencodec::{CategorizedError, ErrorCategory as C, LimitKind as L};
-
-    #[test]
-    fn encode_error_category_mapping() {
-        assert_eq!(EncodeError::InvalidDimensions.codec_name(), Some("zenwebp"));
-
-        // Caller config / parameters.
-        assert_eq!(
-            EncodeError::InvalidDimensions.category(),
-            C::InvalidParameters
-        );
-        assert_eq!(
-            EncodeError::TargetZensimUnsupportedLayout(PixelLayout::Yuv420).category(),
-            C::InvalidParameters
-        );
-
-        // Caller pixel buffer geometry.
-        assert_eq!(
-            EncodeError::InvalidBufferSize("x".into()).category(),
-            C::InvalidBuffer
-        );
-
-        // Colour-management transform required (no CICP carrier in WebP).
-        assert_eq!(
-            EncodeError::IccSynthesisUnavailable("x".into()).category(),
-            C::CmsRequired
-        );
-
-        // Resource limits. `LimitExceeded` is stringly → representative Memory.
-        assert_eq!(
-            EncodeError::LimitExceeded("x".into()).category(),
-            C::LimitsExceeded(L::Memory)
-        );
-        assert_eq!(
-            EncodeError::Partition0Overflow {
-                size: 600_000,
-                max: 524_287,
-            }
-            .category(),
-            C::LimitsExceeded(L::OutputSize)
-        );
-
-        // Cancellation delegates to StopReason (cancel vs timeout preserved).
-        assert_eq!(
-            EncodeError::Cancelled(enough::StopReason::Cancelled).category(),
-            C::Cancelled
-        );
-        assert_eq!(
-            EncodeError::Cancelled(enough::StopReason::TimedOut).category(),
-            C::TimedOut
-        );
-
-        // Unsupported operation delegates to the zencodec cause type.
-        assert_eq!(
-            EncodeError::UnsupportedOperation(zencodec::UnsupportedOperation::AnimationEncode)
-                .category(),
-            C::UnsupportedOperation
-        );
-
-        // The At<E> blanket impl forwards both category and codec name.
-        let traced = whereat::at!(EncodeError::InvalidDimensions);
-        assert_eq!(traced.category(), C::InvalidParameters);
-        assert_eq!(traced.codec_name(), Some("zenwebp"));
-    }
-
-    #[cfg(feature = "std")]
-    #[test]
-    fn encode_io_error_is_io() {
-        assert_eq!(
-            EncodeError::IoError(std::io::Error::other("boom")).category(),
-            C::Io(zencodec::CodecIoKind::opaque())
-        );
     }
 }
 
@@ -3038,5 +2958,83 @@ mod tests {
             let mut img2 = vec![0u8; 64 * 64 * 3];
             decoder.read_image(&mut img2).unwrap();
         }
+    }
+}
+
+#[cfg(test)]
+mod encode_category_tests {
+    use super::{EncodeError, PixelLayout};
+    use zencodec::{CategorizedError, ErrorCategory as C, LimitKind as L};
+
+    #[test]
+    fn encode_error_category_mapping() {
+        assert_eq!(EncodeError::InvalidDimensions.codec_name(), Some("zenwebp"));
+
+        // Caller config / parameters.
+        assert_eq!(
+            EncodeError::InvalidDimensions.category(),
+            C::InvalidParameters
+        );
+        assert_eq!(
+            EncodeError::TargetZensimUnsupportedLayout(PixelLayout::Yuv420).category(),
+            C::InvalidParameters
+        );
+
+        // Caller pixel buffer geometry.
+        assert_eq!(
+            EncodeError::InvalidBufferSize("x".into()).category(),
+            C::InvalidBuffer
+        );
+
+        // Colour-management transform required (no CICP carrier in WebP).
+        assert_eq!(
+            EncodeError::IccSynthesisUnavailable("x".into()).category(),
+            C::CmsRequired
+        );
+
+        // Resource limits. `LimitExceeded` is stringly → representative Memory.
+        assert_eq!(
+            EncodeError::LimitExceeded("x".into()).category(),
+            C::LimitsExceeded(L::Memory)
+        );
+        assert_eq!(
+            EncodeError::Partition0Overflow {
+                size: 600_000,
+                max: 524_287,
+            }
+            .category(),
+            C::LimitsExceeded(L::OutputSize)
+        );
+
+        // Cancellation delegates to StopReason (cancel vs timeout preserved).
+        assert_eq!(
+            EncodeError::Cancelled(enough::StopReason::Cancelled).category(),
+            C::Cancelled
+        );
+        assert_eq!(
+            EncodeError::Cancelled(enough::StopReason::TimedOut).category(),
+            C::TimedOut
+        );
+
+        // Unsupported operation delegates to the zencodec cause type.
+        assert_eq!(
+            EncodeError::UnsupportedOperation(zencodec::UnsupportedOperation::AnimationEncode)
+                .category(),
+            C::UnsupportedOperation
+        );
+
+        // The At<E> blanket impl forwards both category and codec name.
+        let traced = whereat::at!(EncodeError::InvalidDimensions);
+        assert_eq!(traced.category(), C::InvalidParameters);
+        assert_eq!(traced.codec_name(), Some("zenwebp"));
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn encode_io_error_is_io() {
+        assert_eq!(
+            EncodeError::IoError(std::io::Error::other("boom")).category(),
+            C::Io(zencodec::CodecIoKind::opaque())
+        );
     }
 }

--- a/src/encoder/validation.rs
+++ b/src/encoder/validation.rs
@@ -208,7 +208,6 @@ pub enum ValidationError {
 
 // Codec-agnostic error taxonomy (zencodec PR #103) so consumers can route on the
 // coarse category without naming this enum.
-#[cfg(feature = "zencodec")]
 impl zencodec::CategorizedError for ValidationError {
     fn codec_name(&self) -> Option<&'static str> {
         Some("zenwebp")
@@ -221,41 +220,6 @@ impl zencodec::CategorizedError for ValidationError {
         // maps to `InvalidParameters` (future variants are validation failures by
         // construction and share this mapping).
         zencodec::ErrorCategory::InvalidParameters
-    }
-}
-
-#[cfg(all(test, feature = "zencodec"))]
-mod validation_category_tests {
-    use super::ValidationError;
-    use zencodec::{CategorizedError, ErrorCategory as C};
-
-    #[test]
-    fn validation_error_category_is_invalid_parameters() {
-        assert_eq!(
-            ValidationError::QualityNotFinite { value: f32::NAN }.codec_name(),
-            Some("zenwebp")
-        );
-        assert_eq!(
-            ValidationError::QualityOutOfRange {
-                value: 150.0,
-                valid: 0.0..=100.0,
-            }
-            .category(),
-            C::InvalidParameters
-        );
-        assert_eq!(
-            ValidationError::TargetMutuallyExclusive {
-                first: "target_size",
-                second: "target_psnr",
-            }
-            .category(),
-            C::InvalidParameters
-        );
-
-        // The At<E> blanket impl forwards both category and codec name.
-        let traced = whereat::at!(ValidationError::QualityNotFinite { value: f32::NAN });
-        assert_eq!(traced.category(), C::InvalidParameters);
-        assert_eq!(traced.codec_name(), Some("zenwebp"));
     }
 }
 
@@ -347,4 +311,39 @@ pub(super) fn check_target_psnr(p: f32) -> Result<(), ValidationError> {
         });
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod validation_category_tests {
+    use super::ValidationError;
+    use zencodec::{CategorizedError, ErrorCategory as C};
+
+    #[test]
+    fn validation_error_category_is_invalid_parameters() {
+        assert_eq!(
+            ValidationError::QualityNotFinite { value: f32::NAN }.codec_name(),
+            Some("zenwebp")
+        );
+        assert_eq!(
+            ValidationError::QualityOutOfRange {
+                value: 150.0,
+                valid: 0.0..=100.0,
+            }
+            .category(),
+            C::InvalidParameters
+        );
+        assert_eq!(
+            ValidationError::TargetMutuallyExclusive {
+                first: "target_size",
+                second: "target_psnr",
+            }
+            .category(),
+            C::InvalidParameters
+        );
+
+        // The At<E> blanket impl forwards both category and codec name.
+        let traced = whereat::at!(ValidationError::QualityNotFinite { value: f32::NAN });
+        assert_eq!(traced.category(), C::InvalidParameters);
+        assert_eq!(traced.codec_name(), Some("zenwebp"));
+    }
 }

--- a/src/encoder/validation.rs
+++ b/src/encoder/validation.rs
@@ -206,6 +206,59 @@ pub enum ValidationError {
     },
 }
 
+// Codec-agnostic error taxonomy (zencodec PR #103) so consumers can route on the
+// coarse category without naming this enum.
+#[cfg(feature = "zencodec")]
+impl zencodec::CategorizedError for ValidationError {
+    fn codec_name(&self) -> Option<&'static str> {
+        Some("zenwebp")
+    }
+
+    fn category(&self) -> zencodec::ErrorCategory {
+        // Every `ValidationError` variant reports a caller-supplied configuration
+        // value that failed a documented range or cross-parameter invariant — the
+        // type's entire contract is "invalid configuration", so the whole type
+        // maps to `InvalidParameters` (future variants are validation failures by
+        // construction and share this mapping).
+        zencodec::ErrorCategory::InvalidParameters
+    }
+}
+
+#[cfg(all(test, feature = "zencodec"))]
+mod validation_category_tests {
+    use super::ValidationError;
+    use zencodec::{CategorizedError, ErrorCategory as C};
+
+    #[test]
+    fn validation_error_category_is_invalid_parameters() {
+        assert_eq!(
+            ValidationError::QualityNotFinite { value: f32::NAN }.codec_name(),
+            Some("zenwebp")
+        );
+        assert_eq!(
+            ValidationError::QualityOutOfRange {
+                value: 150.0,
+                valid: 0.0..=100.0,
+            }
+            .category(),
+            C::InvalidParameters
+        );
+        assert_eq!(
+            ValidationError::TargetMutuallyExclusive {
+                first: "target_size",
+                second: "target_psnr",
+            }
+            .category(),
+            C::InvalidParameters
+        );
+
+        // The At<E> blanket impl forwards both category and codec name.
+        let traced = whereat::at!(ValidationError::QualityNotFinite { value: f32::NAN });
+        assert_eq!(traced.category(), C::InvalidParameters);
+        assert_eq!(traced.codec_name(), Some("zenwebp"));
+    }
+}
+
 // ============================================================================
 // Range constants. Centralised so callers can also introspect the
 // valid range without round-tripping through `validate()`.

--- a/src/exif_orientation.rs
+++ b/src/exif_orientation.rs
@@ -7,13 +7,11 @@
 //! This is intentionally minimal — just orientation, nothing else.
 //!
 //! **Deliberately local** (zenwebp#58, resolved 2026-06-11): the canonical
-//! home is `zencodec::helpers::parse_exif_orientation`, but this parser
-//! runs in the *core* decoder path, and zencodec is an optional feature —
-//! delegating would make zencodec (and its zenpixels+ICC-table baggage) a
-//! required dependency of every zenwebp build for ~80 lines of TIFF walk.
-//! Instead the implementations are pinned against each other by the
-//! `parity_with_zencodec_helper` differential test below (zencodec is a
-//! dev-dependency, costing consumers nothing).
+//! home is `zencodec::helpers::parse_exif_orientation`, but this parser runs
+//! in the *core* decoder path and is kept as a small standalone TIFF walk
+//! (~80 lines) rather than reaching into the `zencodec` adapter module. The
+//! two implementations are pinned against each other by the
+//! `parity_with_zencodec_helper` differential test below.
 
 /// EXIF Orientation tag number (TIFF tag 274).
 const TAG_ORIENTATION: u16 = 0x0112;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,11 +202,9 @@ pub use enough::{Stop, StopReason, Unstoppable};
 // #[cfg(feature = "zennode")]
 // pub mod zennode_defs;
 
-#[cfg(feature = "zencodec")]
 mod codec;
 
 /// zencodec trait implementations for WebP encoding and decoding.
-#[cfg(feature = "zencodec")]
 pub mod zencodec {
     pub use crate::codec::{
         WebpAnimationFrameDecoder, WebpAnimationFrameEncoder, WebpDecodeJob, WebpDecoder,

--- a/src/mux/error.rs
+++ b/src/mux/error.rs
@@ -75,3 +75,104 @@ pub enum MuxError {
         canvas_height: u32,
     },
 }
+
+// Codec-agnostic error taxonomy (zencodec PR #103). Maps every `MuxError`
+// variant to exactly one coarse `ErrorCategory` so consumers can route on the
+// category (HTTP status, retry policy, logging) without naming this enum. The
+// wrapped `EncodeError`/`DecodeError` arms delegate to their own mappings.
+#[cfg(feature = "zencodec")]
+impl zencodec::CategorizedError for MuxError {
+    fn codec_name(&self) -> Option<&'static str> {
+        Some("zenwebp")
+    }
+
+    fn category(&self) -> zencodec::ErrorCategory {
+        use zencodec::ErrorCategory as C;
+        match self {
+            // Demux/parse failure: the bytes are not a valid WebP container.
+            MuxError::InvalidFormat(_) => C::MalformedImage,
+
+            // Assembly-side caller parameters: the caller-supplied frame
+            // geometry/offsets violate the WebP spec when building an animation.
+            MuxError::InvalidDimensions { .. }
+            | MuxError::OddFrameOffset { .. }
+            | MuxError::FrameOutsideCanvas { .. }
+            // Caller asked for a frame index past the end of the sequence.
+            | MuxError::FrameOutOfBounds { .. } => C::InvalidParameters,
+
+            // API-protocol violation: assembly requested before any frame added.
+            MuxError::NoFrames => C::InvalidState,
+
+            // Delegate to the wrapped codec error's own mapping.
+            MuxError::EncodeError(e) => e.category(),
+            MuxError::DecodeError(e) => e.category(),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "zencodec"))]
+mod mux_category_tests {
+    use super::MuxError;
+    use crate::decoder::DecodeError;
+    use crate::encoder::EncodeError;
+    use zencodec::{CategorizedError, ErrorCategory as C};
+
+    #[test]
+    fn mux_error_category_mapping() {
+        assert_eq!(MuxError::NoFrames.codec_name(), Some("zenwebp"));
+
+        // Demux parse failure.
+        assert_eq!(
+            MuxError::InvalidFormat("bad".into()).category(),
+            C::MalformedImage
+        );
+
+        // Assembly-side caller parameters.
+        assert_eq!(
+            MuxError::InvalidDimensions {
+                width: 0,
+                height: 0
+            }
+            .category(),
+            C::InvalidParameters
+        );
+        assert_eq!(
+            MuxError::OddFrameOffset { x: 1, y: 1 }.category(),
+            C::InvalidParameters
+        );
+        assert_eq!(
+            MuxError::FrameOutsideCanvas {
+                x: 0,
+                y: 0,
+                width: 9,
+                height: 9,
+                canvas_width: 4,
+                canvas_height: 4,
+            }
+            .category(),
+            C::InvalidParameters
+        );
+        assert_eq!(
+            MuxError::FrameOutOfBounds { index: 9, total: 2 }.category(),
+            C::InvalidParameters
+        );
+
+        // API-protocol violation.
+        assert_eq!(MuxError::NoFrames.category(), C::InvalidState);
+
+        // Delegation to the wrapped codec error's own mapping.
+        assert_eq!(
+            MuxError::EncodeError(EncodeError::InvalidDimensions).category(),
+            C::InvalidParameters
+        );
+        assert_eq!(
+            MuxError::DecodeError(DecodeError::HuffmanError).category(),
+            C::MalformedImage
+        );
+
+        // The At<E> blanket impl forwards both category and codec name.
+        let traced = whereat::at!(MuxError::NoFrames);
+        assert_eq!(traced.category(), C::InvalidState);
+        assert_eq!(traced.codec_name(), Some("zenwebp"));
+    }
+}

--- a/src/mux/error.rs
+++ b/src/mux/error.rs
@@ -80,7 +80,6 @@ pub enum MuxError {
 // variant to exactly one coarse `ErrorCategory` so consumers can route on the
 // category (HTTP status, retry policy, logging) without naming this enum. The
 // wrapped `EncodeError`/`DecodeError` arms delegate to their own mappings.
-#[cfg(feature = "zencodec")]
 impl zencodec::CategorizedError for MuxError {
     fn codec_name(&self) -> Option<&'static str> {
         Some("zenwebp")
@@ -110,7 +109,7 @@ impl zencodec::CategorizedError for MuxError {
     }
 }
 
-#[cfg(all(test, feature = "zencodec"))]
+#[cfg(test)]
 mod mux_category_tests {
     use super::MuxError;
     use crate::decoder::DecodeError;

--- a/tests/decoder_vs_libwebp.rs
+++ b/tests/decoder_vs_libwebp.rs
@@ -131,7 +131,6 @@ fn zenwebp_decoder_matches_libwebp_on_rose_rgba() {
 /// Reproduce imageflow's exact decode path: zencodec dyn-dispatch with
 /// `preferred=[BGRA8_SRGB, RGBA8_SRGB, ...]`, then compare the BGRA output
 /// (after swizzling to RGBA for comparison) against libwebp's RGBA decode.
-#[cfg(feature = "zencodec")]
 #[test]
 fn zenwebp_bgra_dyn_dispatch_matches_libwebp_on_rose() {
     use zencodec::decode::DynDecoderConfig;

--- a/tests/float_input_descriptors.rs
+++ b/tests/float_input_descriptors.rs
@@ -13,7 +13,7 @@
 //!    input (within lossless tolerance for lossless / lossy quant
 //!    tolerance for lossy).
 
-#![cfg(all(feature = "std", feature = "zencodec", not(target_arch = "wasm32")))]
+#![cfg(all(feature = "std", not(target_arch = "wasm32")))]
 
 use zencodec::encode::{EncodeJob, Encoder, EncoderConfig as _};
 use zenpixels::{PixelDescriptor, PixelSlice};

--- a/tests/gray8_input.rs
+++ b/tests/gray8_input.rs
@@ -18,7 +18,7 @@
 //!   gray→RGB-expanded — guards against the `convert_image_y` chroma plane
 //!   regressing back to a non-neutral fill that would cost extra DC bits.
 
-#![cfg(all(feature = "std", feature = "zencodec", not(target_arch = "wasm32")))]
+#![cfg(all(feature = "std", not(target_arch = "wasm32")))]
 
 use zencodec::encode::{EncodeJob, Encoder, EncoderConfig as _};
 use zenpixels::{PixelDescriptor, PixelSlice};

--- a/tests/imageflow_bgra_reproducer.rs
+++ b/tests/imageflow_bgra_reproducer.rs
@@ -7,7 +7,7 @@
 //! with `PixelDescriptor::BGRA8_SRGB`. This test mimics that exact call
 //! chain to surface bugs that the `EncodeRequest::lossless(... PixelLayout::Rgba8 ...)`
 //! golden-regression tests don't exercise (because they pass RGBA directly).
-#![cfg(all(feature = "std", feature = "zencodec", not(target_arch = "wasm32")))]
+#![cfg(all(feature = "std", not(target_arch = "wasm32")))]
 
 use zencodec::encode::DynEncoderConfig as _;
 use zenpixels::{PixelDescriptor, PixelSlice};

--- a/tests/imageflow_full_pipeline_reproducer.rs
+++ b/tests/imageflow_full_pipeline_reproducer.rs
@@ -2,7 +2,7 @@
 //! mimicking the full pipeline: decode 1_webp_ll.webp, (no resize — the
 //! `_native` variant of the failing imageflow test), re-encode via the
 //! zencodec dyn-dispatch path with BGRA8_SRGB, and decode back for comparison.
-#![cfg(all(feature = "std", feature = "zencodec", not(target_arch = "wasm32")))]
+#![cfg(all(feature = "std", not(target_arch = "wasm32")))]
 
 use zencodec::encode::DynEncoderConfig as _;
 use zenpixels::{PixelDescriptor, PixelSlice};

--- a/tests/lossless_alpha_padded_stride.rs
+++ b/tests/lossless_alpha_padded_stride.rs
@@ -13,7 +13,7 @@
 //!     → `WebpEncoderConfig::lossless().encode(PixelSlice)`
 //!     → decode again, compare pixel-for-pixel.
 
-#![cfg(all(feature = "std", feature = "zencodec", not(target_arch = "wasm32")))]
+#![cfg(all(feature = "std", not(target_arch = "wasm32")))]
 
 use std::borrow::Cow;
 

--- a/tests/orientation.rs
+++ b/tests/orientation.rs
@@ -11,7 +11,7 @@
 //!     display dims + `Orientation::Identity`, and the pixels are physically
 //!     rotated.
 
-#![cfg(feature = "zencodec")]
+#![cfg(all(feature = "std", not(target_arch = "wasm32")))]
 
 use std::borrow::Cow;
 

--- a/tests/rgbx_bgrx_descriptor.rs
+++ b/tests/rgbx_bgrx_descriptor.rs
@@ -4,7 +4,7 @@
 //! must take the RGB fast path and ignore the padding byte. Confirms that
 //! descriptor dispatch accepts these formats and that the padding byte does
 //! not leak into encoded output.
-#![cfg(all(feature = "std", feature = "zencodec", not(target_arch = "wasm32")))]
+#![cfg(all(feature = "std", not(target_arch = "wasm32")))]
 
 use zencodec::encode::{DynEncoderConfig, EncoderConfig};
 use zenpixels::{PixelDescriptor, PixelSlice};

--- a/tests/whereat_trace_propagation.rs
+++ b/tests/whereat_trace_propagation.rs
@@ -14,7 +14,7 @@
 //! `err.frame_count() >= 1`. If a future change reintroduces a trace-dropping
 //! boundary on this path, the frame count collapses to 0 and this test fails.
 
-#![cfg(all(feature = "std", feature = "zencodec", not(target_arch = "wasm32")))]
+#![cfg(all(feature = "std", not(target_arch = "wasm32")))]
 
 use zenwebp::zencodec::WebpDecoderConfig;
 


### PR DESCRIPTION
Adopts the `zencodec` `CategorizedError` taxonomy (zencodec PR #103) in zenwebp, matching the pattern shipped in zengif #13 and zenbitmaps #18.

## What

`impl zencodec::CategorizedError` (gated on the `zencodec` feature, `CODEC_NAME = "zenwebp"`) on every public error type a caller can receive:

| type | reachable as | notes |
|---|---|---|
| `DecodeError` | `type Error` of all decode trait impls (`At<DecodeError>`) | primary |
| `EncodeError` | `type Error` of all encode trait impls (`At<EncodeError>`) | primary |
| `mux::MuxError` | `mux` demux/assemble API (`At<MuxError>`) | aggregating — delegates wrapped Encode/Decode |
| `ValidationError` | `Config::validate()` | whole type → `InvalidParameters` |
| `detect::ProbeError` | `detect::probe()` | |

The `At<E>` blanket impl forwards both category and codec name. Additive: opt-in trait on `#[non_exhaustive]` enums, no public-API break.

### Mappings

**DecodeError** — all bitstream/content variants (`RiffSignatureInvalid`, `WebpSignatureInvalid`, `ChunkMissing`, `ChunkHeaderInvalid`, `InvalidAlphaPreprocessing`, `InvalidCompressionMethod`, `AlphaChunkSizeMismatch`, `FrameOutsideImage`, `LosslessSignatureInvalid`, `VersionNumberInvalid`, `InvalidColorCacheBits`, `HuffmanError`, `BitStreamError`, `TransformError`, `Vp8MagicInvalid`, `ColorSpaceInvalid`, `Luma/Intra/ChromaPredictionModeInvalid`, `InconsistentImageSizes`, `InvalidChunkSize`) → `MalformedImage`; `NotEnoughInitData` + `NoMoreFrames` (animation-iteration end) → `UnexpectedEof`; `UnsupportedFeature` → `UnsupportedImageFeature`; `InvalidParameter` → `InvalidParameters`; `ImageTooLarge` → `LimitsExceeded(Pixels)`; `MemoryLimitExceeded` → `LimitsExceeded(Memory)`; `Cancelled(StopReason)` → delegate (Cancelled/TimedOut); `UnsupportedOperation(op)` → delegate; `IoError` (std) → `Io`.

**EncodeError** — `InvalidDimensions` + `TargetZensimUnsupportedLayout` → `InvalidParameters`; `InvalidBufferSize` → `InvalidBuffer`; `IccSynthesisUnavailable` → `CmsRequired`; `LimitExceeded(String)` → `LimitsExceeded(Memory)` (representative — see expansion); `Partition0Overflow` → `LimitsExceeded(OutputSize)`; `Cancelled` → delegate; `UnsupportedOperation` → delegate; `IoError` (std) → `Io`.

**MuxError** — `InvalidFormat` (demux parse) → `MalformedImage`; `InvalidDimensions`/`OddFrameOffset`/`FrameOutsideCanvas`/`FrameOutOfBounds` (assembly-side caller params) → `InvalidParameters`; `NoFrames` (assemble-before-add) → `InvalidState`; `EncodeError(e)`/`DecodeError(e)` → `e.category()`.

**ValidationError** — the entire type → `InvalidParameters` (every variant is a config range / cross-parameter invariant failure by construction).

**ProbeError** — `TooShort` + `Truncated` → `UnexpectedEof`; `NotWebP` → `UnsupportedImageType`; `InvalidVP8Magic` → `MalformedImage`.

`PickError` (the `picker` research-spike feature — not in any CI job, not in the campaign inventory) is intentionally **not** adopted: it would be untested code gated on `all(zencodec, picker)`.

### Expansion decision — `EncodeError::LimitExceeded`

The inventory flagged this stringly limit. Its 4 construction sites (`src/codec.rs`) stringify the typed `At<DecodeError>` limit error from `Limits::check_dimensions` / `check_memory` / `check_output_size` via `format!`, destroying the exact `LimitKind` at construction. Carrying it exactly would require changing the **public** `LimitExceeded(String)` tuple variant's shape — a breaking change. Per the public-API-stability rule I left the variant as-is, mapped it to a representative `LimitKind::Memory`, and **queued the exact-kind expansion as a breaking change in the CHANGELOG** (the construction sites already hold the typed error, so the rewire is mechanical once approved). Decode-side limits already map exactly (`ImageTooLarge`→Pixels, `MemoryLimitExceeded`→Memory — they're separate variants).

## Temporary dependency patch

```toml
[patch.crates-io]
zencodec = { git = "https://github.com/imazen/zencodec", branch = "cancellation-classification-99" }
```

PR #103 is unreleased. **Remove this patch and bump the `zencodec` dependency once `zencodec 0.1.26` ships.**

## Fix-forward commit (pre-existing CI breaks, unrelated to the taxonomy)

zenwebp's `main` CI has been **red since 2026-06-23** (run `28284349117`) for three independent reasons unrelated to this work. The first commit (`fix(build): …`) fixes them so this PR's CI can be green:

1. `predictor_avg_body_wide` (`src/decoder/lossless_transform_simd.rs`) was missing the `#[cfg(target_arch = "x86_64")]` gate its sibling `predictor_add_body_wide` carries → its x86_64-only `chunk32`/`chunk32_ref` helpers fell out of scope on **wasm32 / i686** (`E0425 cannot find function chunk32_ref`).
2. The `src/decoder/extended.rs` `#[cfg(test)]` module used the `vec!` macro without `use alloc::vec;` → `cargo test --no-default-features --lib` failed.
3. `AllocPreference::{Fallible, Infallible}` (`src/decoder/alloc_util.rs`) are only constructed via the `zencodec` adapter → default-feature clippy flagged them `dead_code` under `-D warnings`.

## Gate (local, all green)

- `cargo fmt --check` ✓
- `cargo clippy --all-targets -- -D warnings` (default) ✓
- `cargo clippy --all-targets --features zencodec,cms,imgref -- -D warnings` ✓
- `cargo test --features zencodec` ✓ — 320 lib tests + integration, incl. 7 new category-mapping tests
- `cargo test --no-default-features --lib` ✓ — 264
- `cargo check --target wasm32-wasip1 --no-default-features` ✓
- `cargo test` (default) ✓
- `cargo test --features "std,pixel-types,imgref,avx512,zencodec,cms"` ✓

i686 not run locally (needs cross/docker) — same root cause and identical error as the wasm32 break, which the same fix resolves; confirmed via CI.
