### PR TITLE
fix(decoder): wasm SIMD128 decodes every lossy WebP to solid green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,16 @@ jobs:
       - name: Check WASM (no_std)
         run: cargo check --target wasm32-wasip1 --no-default-features
 
+      # `cargo check` never executes a single wasm instruction, and without
+      # +simd128 it does not even compile the SIMD128 kernels. That is how the
+      # fused YUV->RGB kernel shipped a whole-image corruption from v0.4.2.
+      - uses: bytecodealliance/actions/wasmtime/setup@v1
+      - name: Test WASM SIMD128 (wasmtime)
+        env:
+          RUSTFLAGS: "-C target-feature=+simd128"
+          CARGO_TARGET_WASM32_WASIP1_RUNNER: wasmtime
+        run: cargo test --lib --release --target wasm32-wasip1 --no-default-features
+
   feature-permutations:
     name: Feature permutations
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -682,6 +682,21 @@ here has landed; see "Changed (BREAKING)" below.)
 
 ### Fixed
 
+- **wasm32 SIMD128 decoded every lossy WebP to solid green** (shipped since
+  v0.4.2, `0811747`). In `yuv_fused::wasm_fused::fused_row_2uv_wasm`, the Y/U/V
+  widening emulated libwebp's `_mm_unpacklo_epi8(zero, x)` with
+  `i8x16_shuffle::<8, 0, 9, 1, ...>(zero, x_half)` — every index is < 16, so all
+  sixteen lanes came from `zero` and the samples were discarded. With Y=U=V=0 the
+  transform yields R=`sat((0-14234)>>6)`=0, G=`8708>>6`=136, B=0: RGB (0, 136, 0)
+  for ~98% of pixels. Replaced with `u16x8_shl(u16x8_extend_low_u8x16(x), 8)`.
+  wasm+simd128 decode is now byte-identical to x86_64. Only the YUV→RGB stage was
+  affected — decoded YUV planes were always correct. Gated by
+  `fused_row_2uv_matches_scalar_reference` (`src/decoder/yuv_fused.rs`, the file's
+  first test), verified to fail against the reintroduced defect, plus a CI job
+  that runs the lib suite under wasmtime with `-C target-feature=+simd128`. The
+  previous `wasm` CI job was `cargo check` only: it never executed wasm and
+  `--no-default-features` without `+simd128` never even compiled the kernel.
+
 - **StrictLibwebpParity: ALL 14 of 14 method×segment cells now byte-identical
   to libwebp** (#38, 8256bec / 8b60a62 / c96f767 / 6b4fa0c). Four more
   parity-gated fixes (tuned default unchanged) closed the last three cells

--- a/src/decoder/vp8v2/yuv_exact.rs
+++ b/src/decoder/vp8v2/yuv_exact.rs
@@ -521,7 +521,7 @@ fn fill_2uv_row_scalar(
 
 /// Shared scalar implementation (used by all non-SIMD tiers and as tail handler).
 #[inline(always)]
-fn fill_2uv_row_generic(
+pub(crate) fn fill_2uv_row_generic(
     rgb: &mut [u8],
     y_row: &[u8],
     u_near: &[u8],
@@ -1497,6 +1497,8 @@ mod tests {
 
     /// Encode 64x64 Q75, decode with yuv_exact, compare against webpx::decode_rgb().
     /// Asserts zero diffs (bit-exact with libwebp).
+    // libwebp cross-check: `webpx` is a non-wasm dev-dependency.
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn bit_exact_vs_libwebp_64x64_q75() {
         let (w, h) = (64, 64);
@@ -1547,6 +1549,8 @@ mod tests {
     }
 
     /// Same test but for RGBA output.
+    // libwebp cross-check: `webpx` is a non-wasm dev-dependency.
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn bit_exact_vs_libwebp_64x64_q75_rgba() {
         let (w, h) = (64, 64);
@@ -1592,6 +1596,8 @@ mod tests {
     }
 
     /// Quick decode speed comparison: zenwebp (yuv_exact) vs libwebp.
+    // libwebp cross-check: `webpx` is a non-wasm dev-dependency.
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn bench_vs_libwebp_512() {
         let (w, h) = (512, 512);
@@ -1642,6 +1648,8 @@ mod tests {
     }
 
     /// Test odd dimensions to verify edge handling.
+    // libwebp cross-check: `webpx` is a non-wasm dev-dependency.
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn bit_exact_vs_libwebp_odd_dimensions() {
         for &(w, h) in &[(1, 1), (3, 3), (17, 9), (63, 63), (65, 33)] {

--- a/src/decoder/yuv_fused.rs
+++ b/src/decoder/yuv_fused.rs
@@ -881,7 +881,6 @@ mod wasm_fused {
         // Convert 16 YUV444 → 48 bytes RGB
         fn convert_and_store_rgb16(y: v128, u: v128, v: v128, rgb: &mut [u8; 48]) {
             fn process_half(y_half: v128, u_half: v128, v_half: v128) -> (v128, v128, v128) {
-                let zero = u16x8_splat(0);
                 let k19077 = u16x8_splat(19077);
                 let k26149 = u16x8_splat(26149);
                 let k14234 = u16x8_splat(14234);
@@ -891,61 +890,12 @@ mod wasm_fused {
                 let k13320 = u16x8_splat(13320);
                 let k8708 = u16x8_splat(8708);
 
-                // Widen to u16 in high byte position
-                let y16 = u16x8_extend_high_u8x16(i8x16_shuffle::<
-                    8,
-                    0,
-                    9,
-                    1,
-                    10,
-                    2,
-                    11,
-                    3,
-                    12,
-                    4,
-                    13,
-                    5,
-                    14,
-                    6,
-                    15,
-                    7,
-                >(zero, y_half));
-                let u16v = u16x8_extend_high_u8x16(i8x16_shuffle::<
-                    8,
-                    0,
-                    9,
-                    1,
-                    10,
-                    2,
-                    11,
-                    3,
-                    12,
-                    4,
-                    13,
-                    5,
-                    14,
-                    6,
-                    15,
-                    7,
-                >(zero, u_half));
-                let v16v = u16x8_extend_high_u8x16(i8x16_shuffle::<
-                    8,
-                    0,
-                    9,
-                    1,
-                    10,
-                    2,
-                    11,
-                    3,
-                    12,
-                    4,
-                    13,
-                    5,
-                    14,
-                    6,
-                    15,
-                    7,
-                >(zero, v_half));
+                // Widen to u16 with the value in the high byte (x << 8), matching
+                // libwebp's `_mm_unpacklo_epi8(zero, x)`. The 8 active samples sit
+                // in lanes 0..8 of each half.
+                let y16 = u16x8_shl(u16x8_extend_low_u8x16(y_half), 8);
+                let u16v = u16x8_shl(u16x8_extend_low_u8x16(u_half), 8);
+                let v16v = u16x8_shl(u16x8_extend_low_u8x16(v_half), 8);
 
                 // mulhi_epu16 emulation: multiply wide, take high 16 bits
                 fn mulhi_epu16(a: v128, b: v128) -> v128 {

--- a/src/decoder/yuv_fused.rs
+++ b/src/decoder/yuv_fused.rs
@@ -1258,3 +1258,55 @@ fn fused_row_2uv_dispatch_scalar(
         set_pixel(&mut rgb[yx * 3..yx * 3 + 3], y_row[yx], u_val, v_val);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[allow(unused_imports)]
+    use alloc::{vec, vec::Vec};
+
+    use crate::decoder::vp8v2::yuv_exact::fill_2uv_row_generic;
+
+    /// The fused SIMD kernel must be byte-identical to the scalar reference on
+    /// whatever tier the build selects: v3 on x86_64, NEON on aarch64, SIMD128
+    /// on wasm32. The wasm tier shipped a whole-image corruption for months
+    /// because CI only ever ran `cargo check` for wasm — never executed it.
+    #[test]
+    fn fused_row_2uv_matches_scalar_reference() {
+        // Two patterns: a ramp, and an LCG spread that pushes R/G/B into the
+        // saturating ends of the YUV->RGB transform.
+        for pattern in 0..2u32 {
+            let sample = |i: usize, salt: u32| -> u8 {
+                if pattern == 0 {
+                    (i * 7 + salt as usize * 37) as u8
+                } else {
+                    let x = (i as u32)
+                        .wrapping_mul(1_664_525)
+                        .wrapping_add(1_013_904_223 ^ salt);
+                    (x >> 24) as u8
+                }
+            };
+            // Widths straddling the 32-pixel SIMD block and its 16-pixel tail.
+            for width in [
+                1usize, 2, 3, 15, 16, 17, 31, 32, 33, 47, 63, 64, 65, 127, 550,
+            ] {
+                let chroma_width = width.div_ceil(2);
+                let y: Vec<u8> = (0..width).map(|i| sample(i, 0)).collect();
+                let u_near: Vec<u8> = (0..chroma_width).map(|i| sample(i, 1)).collect();
+                let u_far: Vec<u8> = (0..chroma_width).map(|i| sample(i, 2)).collect();
+                let v_near: Vec<u8> = (0..chroma_width).map(|i| sample(i, 3)).collect();
+                let v_far: Vec<u8> = (0..chroma_width).map(|i| sample(i, 4)).collect();
+
+                let mut fused = vec![0u8; width * 3];
+                super::fused_row_2uv(&mut fused, &y, &u_near, &u_far, &v_near, &v_far);
+
+                let mut reference = vec![0u8; width * 3];
+                fill_2uv_row_generic(&mut reference, &y, &u_near, &u_far, &v_near, &v_far, 3);
+
+                assert_eq!(
+                    fused, reference,
+                    "fused kernel differs from scalar: pattern={pattern} width={width}"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Every lossy WebP decoded on `wasm32` with `+simd128` comes out solid green — whole-image garbage from pixel (0,0). Shipped since **v0.4.2** (`0811747`, which wired the fused kernel into the `incant!` dispatch), so crates.io **0.4.4** has it. Unrelated to #72 (that one is the VP8L lossless *encoder*).

## Mechanism

`wasm_fused::fused_row_2uv_wasm` → `process_half` emulated libwebp's `_mm_unpacklo_epi8(zero, x)` — the sample into the **high** byte of each `u16` — with:

```rust
u16x8_extend_high_u8x16(i8x16_shuffle::<8, 0, 9, 1, ...>(zero, x_half))
```

`i8x16_shuffle` takes indices `0..15` from the **first** operand. Every index here is < 16, so all sixteen lanes came from `zero` and the samples were thrown away.

With Y = U = V = 0 the transform degenerates to a constant:

| | |
|---|---|
| R | `(0 - 14234) >> 6` = −223, saturated to **0** at the `u8` pack |
| G | `(0 + 8708) >> 6` = **136** |
| B | `0 -\| 17685` = **0** (unsigned saturating sub) |

RGB **(0, 136, 0)** — the green.

Fixed by `u16x8_shl(u16x8_extend_low_u8x16(x_half), 8)`, which is what `unpacklo(zero, x)` actually computes; the 8 active samples sit in lanes `0..8` of each half, per the `y_lo_half`/`y_hi_half` shuffles just above.

## Scope

Only the YUV→RGB stage was wrong. `decode_yuv420` planes were already bit-identical to x86_64 on both wasm tiers, so coefficient parsing, prediction and the loop filter are unaffected. The `wasm128` arm of the non-fused `fill_2uv_row` (`vp8v2/yuv_exact.rs`) is a scalar delegation and was never involved — only the `bpp=3` fused path reaches this kernel, and `decode_rgba` is corrupted downstream of it.

Measured against x86_64 as ground truth on `tests/images/gallery1/{1,2}.webp` (550x368 / 550x404 lossy VP8) under wasmtime 47 for `wasm32-wasip1`:

| build | `decode_rgb` hash | pixels exactly (0,136,0) |
|---|---|---|
| native x86_64 | `f569a1750c4854c7` | 0 / 202400 |
| wasm32, no `+simd128` | `f569a1750c4854c7` | 0 / 202400 |
| wasm32, `+simd128` (before) | `c82937b6f85608df` | **199104 / 202400** |
| wasm32, `+simd128` (after) | `f569a1750c4854c7` | 0 / 202400 |

## Why nothing caught it

`src/decoder/yuv_fused.rs` had **no tests at all**, and the wasm CI job was `cargo check --target wasm32-wasip1 --no-default-features` — which never executes a wasm instruction and, without `+simd128`, does not even compile the SIMD128 kernels. The NEON sibling of this same kernel had a bug of exactly this class (`c321c2b`), caught only because aarch64 CI runs tests.

## The gate

`fused_row_2uv_matches_scalar_reference` asserts the fused kernel is byte-identical to `fill_2uv_row_generic` (the independent scalar implementation) across 15 widths straddling the 32-pixel SIMD block and its 16-pixel tail, under two data patterns — a ramp, and an LCG spread that drives R/G/B into the saturating ends of the transform. Arch-generic by construction: the `incant!` dispatch picks v3 on x86_64, NEON on aarch64, SIMD128 on wasm32, so one test covers every tier the build can select.

**Verified to gate, not merely to pass:** with the widening defect deliberately reintroduced, the test aborts under wasmtime. CI keeps the existing `cargo check` step and adds one that runs the lib suite under wasmtime with `-C target-feature=+simd128`.

Locally: **332 passed** on x86_64, **288 passed** on `wasm32-wasip1 +simd128`. The delta is the four libwebp cross-checks in `vp8v2/yuv_exact.rs` — now `cfg`'d off for wasm32, since `webpx` is already declared under `[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]` and cannot link there — plus the tests behind default features.

`fill_2uv_row_generic` becomes `pub(crate)` so the reference is reachable from `yuv_fused`.

## Note on `cargo fmt`

`cargo fmt -- --check` already flags 5 files on `main` (`benches/kernel_tiers.rs`, `src/codec.rs`, `src/common/prediction.rs`, `src/common/transform.rs`, `src/decoder/lossless_transform.rs`) with rustfmt 1.9.0. Left untouched — the two files this PR edits are clean, and pre-existing drift elsewhere is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
