### PR TITLE
fix(encoder): tuned default stops escalating m6 alpha VP8L to quality 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,31 @@ here has landed; see "Changed (BREAKING)" below.)
   the rewire reads `e.kind()` at each call site. Resolves the item that was
   queued in `QUEUED BREAKING CHANGES` since the PR #103 taxonomy adoption.
 
+### Fixed
+- **Lossy RGBA at m6 was ~40x slower than m4 — the tuned default no longer
+  escalates the alpha plane's VP8L to quality 100.** Since `376b7b6` (tuned
+  default adopts the libwebp alpha pipeline) every lossy-alpha encode at
+  `method = 6` with the default `alpha_quality = 100` hit libwebp's
+  `EncodeLossless` escape branch (`use_quality_100 && effort == 6` →
+  VP8L quality 100), running the q100/m6 cruncher (predictor transform-bits
+  sweep, dual refs, TraceBackwards) once per filter trial. Found as the
+  debug-wedge "75x alpha slowdown" on a wasm32 CDN edge deployment; the
+  operating point is libwebp-faithful (native libwebp pays 223ms on the same
+  150x150 RGBA q80 m6 input) but wrong for the tuned default. Measured
+  (native, 150x150 logo-alpha, q80 m6): 558ms → 13.7ms; 570x570:
+  1890ms → 45ms; ALPH grows ~25% (a few % of total file). The tuned default
+  now always codes alpha at `quality = 8·effort`; `StrictLibwebpParity`
+  keeps the escalation (byte parity unchanged, suite green). Guarded by
+  `tests/lossy_alpha_effort.rs` (alpha stays bit-exact at
+  `alpha_quality = 100`).
+
+### Added
+- **`LossyConfig::with_alpha_effort(0..=6)`** — decouples the alpha plane's
+  effort from `method` (default `None` = follow `method`). The alpha plane
+  is coded with VP8L at `quality = 8·effort`; lowering it trades ALPH bytes
+  for encode time without touching the VP8 image plane. Threaded through
+  `EncoderParams` into both the still and animation (mux) alpha paths.
+
 ### Changed
 - **zencodec encode memory pre-flight now gates on the calibrated peak
   estimate (5b17fd84).** With `ResourceLimits::max_memory_bytes` set, the

--- a/src/encoder/api.rs
+++ b/src/encoder/api.rs
@@ -646,6 +646,8 @@ pub struct EncoderParams {
     pub(crate) sharp_yuv: Option<zenyuv::SharpYuvConfig>,
     /// Alpha channel quality (0-100). 100 = lossless alpha, <100 = quantize alpha levels.
     pub(crate) alpha_quality: u8,
+    /// Alpha plane effort (0-6). `None` = follow `method`.
+    pub(crate) alpha_effort: Option<u8>,
     /// Partition limit (0-100). Penalizes I4 mode to prevent partition 0 overflow.
     /// None = automatic retry on overflow.
     pub(crate) partition_limit: Option<u8>,
@@ -693,6 +695,7 @@ impl Default for EncoderParams {
             target_psnr: 0.0,
             sharp_yuv: None,
             alpha_quality: 100,
+            alpha_effort: None,
             partition_limit: None,
             exact: false,
             smooth_segment_map: false,
@@ -1141,6 +1144,7 @@ impl EncoderConfig {
             target_psnr: self.target_psnr,
             sharp_yuv: self.sharp_yuv,
             alpha_quality: self.alpha_quality,
+            alpha_effort: None, // legacy config predates the knob
             partition_limit: self.partition_limit,
             exact: self.exact,
             smooth_segment_map: self.smooth_segment_map,
@@ -2394,17 +2398,17 @@ pub(crate) fn alpha_is_opaque(
 /// Encodes the alpha part of the image data losslessly.
 /// Used for lossy images that include transparency.
 ///
-/// Under `StrictLibwebpParity` this runs libwebp's full `EncodeAlpha`
-/// pipeline (`alpha_enc.c`): `QuantizeLevels` preprocessing, the
-/// `GetFilterMap` filter-trial loop (none/horizontal/vertical/gradient at
-/// the default FAST filtering), a per-trial raw fallback when compression
-/// does not pay, and the winning payload coded with the VP8L encoder at
-/// libwebp's alpha operating point (`method = effort`, `quality =
-/// 8·effort`, alpha in the GREEN channel with R=B=0). The tuned default
-/// keeps zenwebp's historical single-shot path (no filters, gray-expanded
-/// plane, its own quantizer mapping) — its bytes are unchanged; switching
-/// it to the libwebp pipeline is a measurable-adoption candidate (filters
-/// usually shrink the ALPH payload).
+/// Both cost models run libwebp's full `EncodeAlpha` pipeline
+/// (`alpha_enc.c`): `QuantizeLevels` preprocessing (the tuned default keeps
+/// its historical uniform level mapping), the `GetFilterMap` filter-trial
+/// loop (none/horizontal/vertical/gradient at the default FAST filtering),
+/// a per-trial raw fallback when compression does not pay, and the winning
+/// payload coded with the VP8L encoder at libwebp's alpha operating point
+/// (`method = effort`, `quality = 8·effort`, alpha in the GREEN channel
+/// with R=B=0). Only `StrictLibwebpParity` keeps libwebp's escalation to
+/// VP8L quality 100 at `alpha_quality == 100 && effort == 6`; the tuned
+/// default caps alpha at `8·effort` — the escalation costs ~40x for the
+/// last ~25% of the ALPH chunk (see `alpha_vp8l_payload_inner`).
 ///
 /// # Panics
 ///
@@ -2553,6 +2557,14 @@ fn encode_alpha_libwebp_pipeline(
 /// and encodes that image with the full lossless coder at
 /// `method = effort_level`, `quality = (use_quality_100 && effort == 6)
 /// ? 100 : 8 * effort` (`EncodeLossless`, alpha_enc.c). (#38)
+///
+/// The quality-100 escalation is PARITY-ONLY: at m6 with the default
+/// `alpha_quality = 100` it kicks the per-trial VP8L into the q100/m6
+/// cruncher (predictor transform-bits sweep, dual refs), which costs
+/// ~40x the q48 point for the last ~25% of an ALPH chunk — measured
+/// 558ms -> 13.7ms on a 150x150 RGBA at q80 m6 (debug-wedge, 2026-08-20;
+/// native libwebp pays 223ms on the same input). The tuned default caps
+/// alpha at `quality = 8 * effort`.
 pub(crate) fn alpha_vp8l_payload_inner(
     plane: &[u8],
     width: u32,
@@ -2577,7 +2589,8 @@ pub(crate) fn alpha_vp8l_payload_inner(
     // compression before (#38).
     let vp8l_config = super::vp8l::Vp8lConfig {
         quality: super::vp8l::Vp8lQuality {
-            quality: super::alpha::vp8l_quality_for_effort(effort_level, use_quality_100) as u8,
+            quality: super::alpha::vp8l_quality_for_effort(effort_level, use_quality_100 && parity)
+                as u8,
             method: effort_level,
         },
         exact: true,
@@ -2688,7 +2701,7 @@ impl<'a> WebPEncoder<'a> {
         let lossy_with_alpha =
             use_lossy && color.has_alpha() && !alpha_is_opaque(data, width, height, stride, color);
         let alpha_quality = self.params.alpha_quality;
-        let alpha_effort = self.params.method;
+        let alpha_effort = self.params.alpha_effort.unwrap_or(self.params.method);
         let alpha_cost_model = self.params.cost_model;
 
         let mut stats = EncodeStats::default();
@@ -2852,7 +2865,7 @@ impl<'a> WebPEncoder<'a> {
         let lossy_with_alpha =
             use_lossy && color.has_alpha() && !alpha_is_opaque(data, width, height, stride, color);
         let alpha_quality = self.params.alpha_quality;
-        let alpha_effort = self.params.method;
+        let alpha_effort = self.params.alpha_effort.unwrap_or(self.params.method);
         let alpha_cost_model = self.params.cost_model;
         let mut stats;
         let diagnostics;

--- a/src/encoder/config.rs
+++ b/src/encoder/config.rs
@@ -254,6 +254,11 @@ pub struct LossyConfig {
     pub method: u8,
     /// Alpha channel quality (0-100, 100 = lossless alpha). Default: 100.
     pub alpha_quality: u8,
+    /// Alpha plane effort (0-6), decoupled from [`Self::method`].
+    /// `None` (default) = follow `method`. The alpha plane is re-encoded
+    /// with the VP8L coder at `quality = 8·effort`; lowering this trades
+    /// ALPH bytes for encode time without touching the VP8 image plane.
+    pub alpha_effort: Option<u8>,
     /// Target file size in bytes (0 = disabled). Default: 0.
     pub target_size: u32,
     /// Target PSNR in dB (0.0 = disabled). Default: 0.0.
@@ -329,6 +334,7 @@ impl LossyConfig {
             quality: 75.0,
             method: 4,
             alpha_quality: 100,
+            alpha_effort: None,
             target_size: 0,
             target_psnr: 0.0,
             target_zensim: None,
@@ -375,6 +381,14 @@ impl LossyConfig {
     #[must_use]
     pub fn with_alpha_quality(mut self, quality: u8) -> Self {
         self.alpha_quality = quality.min(100);
+        self
+    }
+
+    /// Set alpha plane effort (0-6), decoupled from the image `method`.
+    /// Default follows `method`.
+    #[must_use]
+    pub fn with_alpha_effort(mut self, effort: u8) -> Self {
+        self.alpha_effort = Some(effort.min(6));
         self
     }
 
@@ -1102,6 +1116,7 @@ impl core::fmt::Debug for LossyConfig {
             .field("quality", &self.quality)
             .field("method", &self.method)
             .field("alpha_quality", &self.alpha_quality)
+            .field("alpha_effort", &self.alpha_effort)
             .field("target_size", &self.target_size)
             .field("target_psnr", &self.target_psnr)
             .field("preset", &self.preset)
@@ -1170,6 +1185,7 @@ impl LossyConfig {
             target_psnr: self.target_psnr,
             sharp_yuv: self.sharp_yuv,
             alpha_quality: self.alpha_quality,
+            alpha_effort: self.alpha_effort,
             partition_limit: self.partition_limit,
             exact: false, // Not applicable to lossy (alpha plane is lossless separately)
             smooth_segment_map: self.smooth_segment_map,
@@ -1196,6 +1212,7 @@ impl LosslessConfig {
             target_psnr: 0.0,
             sharp_yuv: None,
             alpha_quality: self.alpha_quality,
+            alpha_effort: None,    // Lossy-only knob
             partition_limit: None, // Not applicable to lossless
             exact: self.exact,
             smooth_segment_map: false, // Not applicable to lossless

--- a/src/mux/anim.rs
+++ b/src/mux/anim.rs
@@ -503,7 +503,7 @@ fn encode_frame_data(
                 stride,
                 color,
                 params.alpha_quality,
-                params.method,
+                params.alpha_effort.unwrap_or(params.method),
                 params.cost_model,
                 &Unstoppable,
             )

--- a/tests/lossy_alpha_effort.rs
+++ b/tests/lossy_alpha_effort.rs
@@ -1,0 +1,85 @@
+//! Lossy-alpha operating point: the tuned default caps the alpha plane's
+//! VP8L at `quality = 8·effort` (no q100 escalation at m6 — that cruncher
+//! cost ~40x for ~25% of the ALPH chunk, debug-wedge 2026-08-20), and
+//! `LossyConfig::with_alpha_effort` decouples alpha effort from `method`.
+//! At `alpha_quality = 100` decoded alpha must stay bit-exact regardless.
+
+use zenwebp::{
+    DecodeConfig, DecodeRequest, EncodeRequest, EncoderConfig, LossyConfig, PixelLayout,
+};
+
+/// 96x96 logo-like RGBA: antialiased disc edge -> many distinct alpha levels.
+fn test_rgba(w: usize, h: usize) -> Vec<u8> {
+    let mut px = vec![0u8; w * h * 4];
+    let (cx, cy) = (w as f32 / 2.0, h as f32 / 2.0);
+    let r_out = w.min(h) as f32 * 0.45;
+    for y in 0..h {
+        for x in 0..w {
+            let d = ((x as f32 - cx).powi(2) + (y as f32 - cy).powi(2)).sqrt();
+            let a = ((r_out - d + 1.5) / 3.0).clamp(0.0, 1.0);
+            let i = (y * w + x) * 4;
+            px[i] = (x * 255 / w) as u8;
+            px[i + 1] = (y * 255 / h) as u8;
+            px[i + 2] = ((x ^ y) & 0xff) as u8;
+            px[i + 3] = (a * 255.0) as u8;
+        }
+    }
+    px
+}
+
+fn encode(cfg: &LossyConfig, rgba: &[u8], w: u32, h: u32) -> Vec<u8> {
+    EncodeRequest::new(
+        &EncoderConfig::Lossy(cfg.clone()),
+        rgba,
+        PixelLayout::Rgba8,
+        w,
+        h,
+    )
+    .encode()
+    .unwrap()
+}
+
+fn decoded_alpha(webp: &[u8]) -> Vec<u8> {
+    let config = DecodeConfig::default();
+    let (pixels, _, _, layout) = DecodeRequest::new(&config, webp).decode().unwrap();
+    assert_eq!(layout, PixelLayout::Rgba8);
+    pixels.chunks(4).map(|p| p[3]).collect()
+}
+
+#[test]
+fn tuned_m6_alpha_values_exact() {
+    let (w, h) = (96usize, 96usize);
+    let rgba = test_rgba(w, h);
+    let src_alpha: Vec<u8> = rgba.chunks(4).map(|p| p[3]).collect();
+    let cfg = LossyConfig::new().with_quality(80.0).with_method(6);
+    let out = encode(&cfg, &rgba, w as u32, h as u32);
+    assert_eq!(
+        decoded_alpha(&out),
+        src_alpha,
+        "alpha_quality=100 must keep decoded alpha bit-exact at m6"
+    );
+}
+
+#[test]
+fn alpha_effort_knob_honored() {
+    let (w, h) = (96usize, 96usize);
+    let rgba = test_rgba(w, h);
+    let src_alpha: Vec<u8> = rgba.chunks(4).map(|p| p[3]).collect();
+    let base = LossyConfig::new().with_quality(80.0).with_method(6);
+    let out_default = encode(&base, &rgba, w as u32, h as u32);
+    let out_e0 = encode(
+        &base.clone().with_alpha_effort(0),
+        &rgba,
+        w as u32,
+        h as u32,
+    );
+    // Same VP8 image plane, different alpha operating point -> the outputs
+    // must differ (the knob reached the ALPH coder)...
+    assert_ne!(
+        out_default, out_e0,
+        "alpha_effort must change the ALPH payload"
+    );
+    // ...and both stay bit-exact on decoded alpha values.
+    assert_eq!(decoded_alpha(&out_default), src_alpha);
+    assert_eq!(decoded_alpha(&out_e0), src_alpha);
+}


### PR DESCRIPTION
## Summary

Lossy RGBA at m6 was ~40x slower than m4: since 376b7b6 (tuned default adopts the libwebp alpha pipeline), every lossy-alpha encode at `method = 6` with the default `alpha_quality = 100` hit libwebp's `EncodeLossless` escape branch (`use_quality_100 && effort == 6`), running each filter trial's VP8L at **quality 100 / method 6** — the cruncher tier (predictor transform-bits sweep from #70, dual refs, TraceBackwards).

Found while debugging a wasm32 CDN edge deployment where RGBA thumbnails took 350ms–3.7s per encode and large alpha planes minutes (orphaned proxy-wasm encodes then pinned nginx workers at 100% CPU). The operating point is libwebp-faithful — native libwebp pays 223ms on the same 150x150 RGBA q80 m6 input — but wrong as a tuned default.

## Changes

- **Tuned default caps the alpha plane's VP8L at `quality = 8·effort`** — the q100 escalation is now parity-only (`use_quality_100 && parity` in `alpha_vp8l_payload_inner`). Only m6 tuned bytes change; m0–m5 are byte-identical.
- **New `LossyConfig::with_alpha_effort(0..=6)`** — decouples alpha-plane effort from `method` (default `None` = follow `method`), threaded through `EncoderParams` into the still and animation (mux) alpha paths.
- Guard test `tests/lossy_alpha_effort.rs`: decoded alpha stays bit-exact at `alpha_quality = 100`, and the knob reaches the ALPH coder.
- Changelog + stale doc comments on `encode_alpha_lossless` corrected (they still described the pre-376b7b6 literal-only path).

## Measurements

| input (q80 m6 RGBA) | before | after | output |
|---|---|---|---|
| 150x150 native | 558 ms | **13.7 ms** | 2108 → 2432 B |
| 570x570 native | 1890 ms | **45 ms** | 10674 → 11690 B |
| wasm32+simd128, 18 production combos | 350 ms – 3.7 s each | **2–18 ms each** | — |

ALPH grows ~25% (a few % of total file). Perf attribution matched the live capture: `combined_shannon_entropy` / `get_combined_cost_for_type` / `apply_predictor_transform` under the transform-bits sweep.

## Verification

- Full release suite green (53/53 test binaries on the source branch; targeted lib/mux/anim/alpha suites re-run green on this base)
- `libwebp_byte_parity` with `--features __expert`: 8/8 — **StrictLibwebpParity stays byte-exact** (it keeps the escalation)
- clippy/fmt clean for touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UuJWhfz8NAmHud6BoNLKtV